### PR TITLE
Fix memory issues by writing to temporary files instead

### DIFF
--- a/Engine/src/main/java/com/ing/engine/reporting/TestCaseReport.java
+++ b/Engine/src/main/java/com/ing/engine/reporting/TestCaseReport.java
@@ -66,10 +66,10 @@ public final class TestCaseReport implements Report {
         if (isRPEnabled()) {
             register(new RPTestCaseHandler(this), true);
         }
-        register(new HtmlTestCaseHandler(this), true);
         if (isAzureEnabled()) {
             register(new AzureTestCaseHandler(this), true);
         }
+        register(new HtmlTestCaseHandler(this), true);
     }
 
     public boolean isExtentEnabled() {

--- a/Engine/src/main/java/com/ing/engine/reporting/impl/azure/AzureSummaryHandler.java
+++ b/Engine/src/main/java/com/ing/engine/reporting/impl/azure/AzureSummaryHandler.java
@@ -1,17 +1,6 @@
-
 package com.ing.engine.reporting.impl.azure;
 
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-
-import java.text.SimpleDateFormat;
-
-import org.apache.http.client.ClientProtocolException;
-import org.json.simple.parser.ParseException;
-
-import org.xml.sax.SAXException;
-
+import java.io.*;
 import com.ing.engine.constants.FilePath;
 import com.ing.engine.core.Control;
 import com.ing.engine.core.RunManager;
@@ -20,8 +9,8 @@ import com.ing.engine.reporting.impl.azureNunit.AzureReport;
 import com.ing.engine.reporting.impl.handlers.PrimaryHandler;
 import com.ing.engine.reporting.impl.handlers.SummaryHandler;
 import com.ing.engine.support.Status;
-
-import java.util.Date;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.UUID;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -30,11 +19,7 @@ import org.apache.commons.io.FileUtils;
 public class AzureSummaryHandler extends SummaryHandler implements PrimaryHandler {
 
     private static final Logger LOGGER = Logger.getLogger(AzureSummaryHandler.class.getName());
-
-    int FailedTestCases = 0;
-    int PassedTestCases = 0;
-
-    String testcasename = "";
+    private String startTime;
 
     public AzureSummaryHandler(SummaryReport report) {
         super(report);
@@ -43,13 +28,10 @@ public class AzureSummaryHandler extends SummaryHandler implements PrimaryHandle
     @SuppressWarnings("unchecked")
     @Override
     public synchronized void createReport(String runTime, int size) {
-        if (!RunManager.getGlobalSettings().isTestRun()) {
-            try {
-                startReport(RunManager.getGlobalSettings().getTestSet());
-            } catch (Exception ex) {
-                LOGGER.log(Level.SEVERE, ex.getMessage(), ex);
-            }
-        }
+        if (RunManager.getGlobalSettings().isTestRun()) return;
+        if (!isAzureEnabled()) return;
+
+        startTime = getDateDetails("time");
     }
 
     public boolean isAzureEnabled() {
@@ -58,17 +40,6 @@ public class AzureSummaryHandler extends SummaryHandler implements PrimaryHandle
                     .getExecSettings(RunManager.getGlobalSettings().getRelease(), RunManager.getGlobalSettings().getTestSet()).getRunSettings().isAzureEnabled();
         }
         return false;
-    }
-
-    private void startReport(String testset) {
-        System.out.println("testset : " + testset);
-        if (isAzureEnabled()) {
-            try {
-                startReport();
-            } catch (IOException | ParseException e) {
-                LOGGER.log(Level.SEVERE, e.getMessage(), e);
-            }
-        }
     }
 
     @Override
@@ -85,7 +56,7 @@ public class AzureSummaryHandler extends SummaryHandler implements PrimaryHandle
 
     @Override
     public Status getCurrentStatus() {
-        if (FailedTestCases > 0 || PassedTestCases == 0) {
+        if (AzureReport.failed > 0 || AzureReport.passed == 0) {
             return Status.FAIL;
         } else {
             return Status.PASS;
@@ -94,63 +65,46 @@ public class AzureSummaryHandler extends SummaryHandler implements PrimaryHandle
 
     @Override
     public synchronized void finalizeReport() {
-        if (!RunManager.getGlobalSettings().isTestRun()) {
-            if (isAzureEnabled()) {
-                try {
-                    finishReport(FilePath.getCurrentAzureReportPath());
-                    FileUtils.copyFileToDirectory(new File(FilePath.getCurrentAzureReportPath()),
+        if (RunManager.getGlobalSettings().isTestRun()) return;
+        if (!isAzureEnabled()) return;
+
+        try {
+            finishReport(FilePath.getCurrentAzureReportPath());
+            FileUtils.copyFileToDirectory(new File(FilePath.getCurrentAzureReportPath()),
                     new File(FilePath.getLatestResultsLocation()),true);
-                } catch (Exception ex) {
-                    LOGGER.log(Level.SEVERE, ex.getMessage(), ex);
-                }
-            }
+        } catch (Exception ex) {
+            LOGGER.log(Level.SEVERE, ex.getMessage(), ex);
         }
-
     }
 
-    public String getUUID() {
-        UUID uuid = UUID.randomUUID();
-        return uuid.toString();
-    }
-
-    public String getDateDetails(String type) {
-        SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-        Date date = new Date();
-        String fulldate = formatter.format(date);
-        if (type.equalsIgnoreCase("date")) {
-            return (fulldate.split(" ")[0]);
+    private String getDateDetails(String type) {
+        LocalDateTime now = LocalDateTime.now();
+        if ("date".equalsIgnoreCase(type)) {
+            return now.format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
         } else {
-            return (fulldate.split(" ")[1]);
+            return now.format(DateTimeFormatter.ofPattern("HH:mm:ss"));
         }
     }
 
-    public void startReport()
-            throws ClientProtocolException, IOException, ParseException {
-        AzureReport.startTime = getDateDetails("time");
-    }
-
-    public void finishReport(String AzureReportPath) throws ClientProtocolException, IOException, ParseException, SAXException {
-
+    private void finishReport(String AzureReportPath) throws IOException {
         String total = String.valueOf(AzureReport.passed + AzureReport.failed);
         String passed = String.valueOf(AzureReport.passed);
         String failed = String.valueOf(AzureReport.failed);
-        String result = "Passed";
-        if (AzureReport.failed > 0) {
-            result = "Failed";
-        }
+        String result = (AzureReport.failed > 0) ? "Failed" : "Passed";
         String duration = AzureReport.totalDuration + ".000";
 
-        AzureReport.testrun = "<test-run id=\"" + getUUID() + "\" name=\"" + RunManager.getGlobalSettings().getTestSet()
+        String testRun = "<test-run id=\"" + UUID.randomUUID() + "\" name=\"" + RunManager.getGlobalSettings().getTestSet()
                 + "\" fullname=\"" + RunManager.getGlobalSettings().getTestSet() + "\" testcasecount=\"" + total
                 + "\" passed=\"" + passed
                 + "\" failed=\"" + failed
                 + "\" result=\"" + result
                 + "\" time=\"" + duration
                 + "\" run-date=\"" + getDateDetails("date")
-                + "\" start-time=\"" + AzureReport.startTime
+                + "\" start-time=\"" + startTime
                 + "\" end-time=\"" + getDateDetails("time")
                 + "\">" + "\n";
-        AzureReport.testsuite = "<test-suite id=\"" + getUUID() + "\" type=\"Assembly\" name=\""
+
+        String testSuite = "<test-suite id=\"" + UUID.randomUUID() + "\" type=\"Assembly\" name=\""
                 + RunManager.getGlobalSettings().getTestSet() + "\" fullname=\""
                 + RunManager.getGlobalSettings().getTestSet() + "\" testcasecount=\"" + total
                 + "\" passed=\"" + passed
@@ -159,40 +113,42 @@ public class AzureSummaryHandler extends SummaryHandler implements PrimaryHandle
                 + "\" time=\"" + duration
                 + "\">" + "\n";
 
-        AzureReport.xmlData = AzureReport.testrun
-                + AzureReport.testsuite
-                + AzureReport.testcase
-                + "</test-suite>"
-                + "</test-run>";
-        
-
         FileOutputStream out = new FileOutputStream(AzureReportPath);
 
-        out.write(AzureReport.xmlData.getBytes());
+        out.write(testRun.getBytes());
+        out.write(testSuite.getBytes());
+
+        try (FileInputStream in = new FileInputStream(AzureReport.testCasesFile)) {
+            byte[] buffer = new byte[8192];
+            int bytesRead;
+            while ((bytesRead = in.read(buffer)) != -1) {
+                out.write(buffer, 0, bytesRead);
+            }
+        }
+
+        out.write("</test-suite></test-run>".getBytes());
         out.close();
+
         System.out.println("\n-----------------------------------------------------");
+        System.out.println("Azure Report Path: " + AzureReportPath);
         System.out.println("Azure Report XML generated");
         System.out.println("-----------------------------------------------------\n");
-		resetAzureVars();
 
+        resetAzureVars();
     }
-    
     private void resetAzureVars() {
-    	AzureReport.totalDuration=0;
-    	AzureReport.failed=0;
-    	AzureReport.passed=0;
-    	AzureReport.message="";
-    	AzureReport.CDATA="";
-    	AzureReport.stacktraceData="";
-    	AzureReport.stacktrace="";
-    	AzureReport.xmlData="";
-    	AzureReport.testrun="";
-    	AzureReport.testsuite="";
-    	AzureReport.testcase="";
-    	AzureReport.failures="";
-    	AzureReport.attachments="";
-    	AzureReport.startTime="";
-    	AzureReport.endTime="";
-    }
+        AzureReport.totalDuration = 0;
+        AzureReport.failed = 0;
+        AzureReport.passed = 0;
 
+        try {
+            if (!AzureReport.testCasesFile.delete()) {
+                throw new RuntimeException("Cannot delete temporary file.");
+            }
+
+            AzureReport.testCasesFile = File.createTempFile("test-cases", ".xml");
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
 }

--- a/Engine/src/main/java/com/ing/engine/reporting/impl/azure/AzureTestCaseHandler.java
+++ b/Engine/src/main/java/com/ing/engine/reporting/impl/azure/AzureTestCaseHandler.java
@@ -1,86 +1,48 @@
 package com.ing.engine.reporting.impl.azure;
 
 import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Stack;
-import java.util.TimeZone;
-import java.util.UUID;
+import java.util.*;
+import java.util.stream.Collectors;
 
-import org.apache.http.client.ClientProtocolException;
-import org.apache.http.client.HttpClient;
-
-import org.apache.http.impl.client.HttpClientBuilder;
-import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
-import org.json.simple.parser.ParseException;
 
 import com.ing.engine.constants.AppResourcePath;
 import com.ing.engine.constants.FilePath;
 import com.ing.engine.core.Control;
 import com.ing.engine.core.RunContext;
 import com.ing.engine.core.RunManager;
-import com.ing.engine.drivers.PlaywrightDriverCreation;
-import com.ing.engine.drivers.WebDriverCreation;
 import com.ing.engine.reporting.TestCaseReport;
 import com.ing.engine.reporting.impl.azureNunit.AzureReport;
 import com.ing.engine.reporting.impl.handlers.PrimaryHandler;
 import com.ing.engine.reporting.impl.handlers.TestCaseHandler;
-import com.ing.engine.reporting.util.DateTimeUtils;
-import com.ing.engine.reporting.util.RDS;
 import com.ing.engine.reporting.util.RDS.TestCase;
 import com.ing.engine.reporting.util.ReportUtils;
 import com.ing.engine.support.Status;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 @SuppressWarnings({"unchecked"})
 public class AzureTestCaseHandler extends TestCaseHandler implements PrimaryHandler {
+    private final JSONObject testCaseData = new JSONObject();
 
-    private static final Logger LOGGER = Logger.getLogger(AzureTestCaseHandler.class.getName());
+    private String scenarioName;
+    private String testCaseName;
 
-    JSONObject testCaseData = new JSONObject();
-    JSONArray Steps = new JSONArray();
-    JSONObject iteration;
-    JSONObject reusable;
-    String DATAF = "[<DATA>]";
-    boolean isIteration = true;
-    Stack<JSONObject> reusableStack = new Stack<>();
+    private int FailedSteps = 0;
+    private int PassedSteps = 0;
+    private int DoneSteps = 0;
+    private final List<String> attachmentPaths = new ArrayList<>();
 
-    private StringBuffer SourceDoc;
-    public File ReportFile;
-    public HttpClient client = HttpClientBuilder.create().useSystemProperties().build();
-    public static Map<String, String> itemIds = new HashMap<String, String>();
-
-    String CurrentComponent = "";
-
-    int ComponentCounter = 0;
-    int iterCounter = 0;
-
-    int FailedSteps = 0;
-    int PassedSteps = 0;
-    int DoneSteps = 0;
-
-    String testcasename = "";
-    String description = "";
-    String platform = "";
-    String browserName = "";
-    String iterationValue = "";
-    String attachments = "";
-
-    String messageCDATA = "";
-    String stacktraceData = "";
+    private String messageCDATA = "";
+    private String stacktraceData = "";
 
     public AzureTestCaseHandler(TestCaseReport report) {
         super(report);
     }
 
-    public boolean isAzureEnabled() {
+    private boolean isAzureEnabled() {
         if (!RunManager.getGlobalSettings().isTestRun()) {
             return Control.getCurrentProject().getProjectSettings()
                     .getExecSettings(RunManager.getGlobalSettings().getRelease(), RunManager.getGlobalSettings().getTestSet()).getRunSettings().isAzureEnabled();
@@ -89,33 +51,14 @@ public class AzureTestCaseHandler extends TestCaseHandler implements PrimaryHand
     }
 
     @Override
-    public void setPlaywrightDriver(PlaywrightDriverCreation driver) {
-        testCaseData.put(TestCase.B_VERSION, getPlaywrightDriver().getBrowserVersion());
-        platform = System.getProperty("os.name") + " " + System.getProperty("os.version") + " " + System.getProperty("os.arch");
-        browserName = getPlaywrightDriver().getCurrentBrowser();
-    }
-
-    @Override
-    public void setWebDriver(WebDriverCreation driver) {
-        testCaseData.put(TestCase.B_VERSION, getWebDriver().getCurrentBrowserVersion());
-        platform = getWebDriver().getPlatform();
-        browserName = getWebDriver().getCurrentBrowser();
-    }
-
-    @Override
     public void createReport(RunContext runContext, String runTime) {
-        if (isAzureEnabled()) {
-            try {
-                testcasename = runContext.Scenario + ":" + runContext.TestCase;
-                description = runContext.Description;
-                iterationValue = runContext.Iteration;
-                addTestCase();
-            } catch (Exception e) {
-                e.printStackTrace();
-            }
-        }
-        testCaseData.put(TestCase.SCENARIO_NAME, runContext.Scenario);
-        testCaseData.put(TestCase.TESTCASE_NAME, runContext.TestCase);
+        if (isAzureEnabled()) messageCDATA = "";
+
+        scenarioName = runContext.Scenario;
+        testCaseName = runContext.TestCase;
+
+        testCaseData.put(TestCase.SCENARIO_NAME, scenarioName);
+        testCaseData.put(TestCase.TESTCASE_NAME, testCaseName);
         testCaseData.put(TestCase.DESCRIPTION, runContext.Description);
         testCaseData.put(TestCase.START_TIME, runTime);
         testCaseData.put(TestCase.ITERATION_TYPE, runContext.Iteration);
@@ -135,234 +78,68 @@ public class AzureTestCaseHandler extends TestCaseHandler implements PrimaryHand
 
     @Override
     public void updateTestLog(String stepName, String stepDescription, Status state, String link, List<String> links) {
+        if (!isAzureEnabled()) return;
 
-        String time = DateTimeUtils.DateTimeNow();
-        String stepData = "";
-        JSONObject step;
         try {
-
-            step = RDS.getNewStep(getStep().Description);
-            JSONObject data = (JSONObject) step.get(RDS.Step.DATA);
-            data.put(RDS.Step.Data.STEP_NO, getStepCount());
-            data.put(RDS.Step.Data.STEP_NAME, stepName);
-            data.put(RDS.Step.Data.ACTION, getStep().Action);
-            data.put(RDS.Step.Data.DESCRIPTION, ReportUtils.resolveDesc(stepDescription));
-            data.put(RDS.Step.Data.TIME_STAMP, time);
-            data.put(RDS.Step.Data.STATUS, state.toString());
-            stepData = String.format("[%s]   | %s", state, ReportUtils.resolveDesc(stepDescription));
+            String stepData = String.format("[%s]   | %s", state, ReportUtils.resolveDesc(stepDescription));
 
             stepData = stepData.replaceAll("\"", "--");
             stepData = stepData.replaceAll("\\r\\n|\\r|\\n", "");
             stepData = stepData.replaceAll("<br>", "");
             stepData = stepData.replaceAll("#CTAG", "");
 
-            if (link != null) {
-                data.put(RDS.Step.Data.LINK, link);
-            }
-            putStatus(state, links, link, data);
+            String screenshotSrc = putStatus(state);
             String filename = "";
 
-            if (data.get(RDS.Step.Data.LINK) != null) {
-                filename = AppResourcePath.getCurrentResultsPath() + data.get(RDS.Step.Data.LINK);
+            if (screenshotSrc != null) {
+                filename = AppResourcePath.getCurrentResultsPath() + screenshotSrc;
             }
 
-            String payloadfiles = testCaseData.get(TestCase.SCENARIO_NAME)
-                    + "_"
-                    + testCaseData.get(TestCase.TESTCASE_NAME)
-                    + "_Step-"
-                    + getStepCount()
-                    + "_";
-
-            String linkPath = AppResourcePath.getCurrentResultsPath() + link + File.separator + payloadfiles;
-
-            if (linkPath.contains("webservice")) {
-                data.put(RDS.Step.Data.LINK, linkPath);
-            }
-
-            if (isAzureEnabled()) {
-                try {
-
-                    createLogNodes(stepData, state.toString(), filename);
-                } catch (IOException | ParseException e) {
-                    LOGGER.log(Level.SEVERE, e.getMessage(), e);
-                }
-            }
-            if (isIteration) {
-                ((JSONArray) iteration.get(RDS.Step.DATA)).add(step);
-            } else {
-                ((JSONArray) reusable.get(RDS.Step.DATA)).add(step);
-            }
+            createLogNodes(stepData, state, filename);
         } catch (Exception ex) {
             ex.printStackTrace();
         }
     }
 
-    /**
-     * creates new iteration object
-     *
-     * @param iterationNo
-     */
-    @Override
-    public void startIteration(int iterationNo) {
-        reusableStack.clear();
-        ++iterCounter;
-        String Iterationid = "Iteration_" + iterationNo;
-        iteration = RDS.getNewIteration(Iterationid);
-        isIteration = true;
-    }
-
-    /**
-     * creates new reusable object
-     *
-     * @param component
-     * @param desc
-     */
-    @Override
-    public void startComponent(String component, String desc) {
-        reusable = RDS.getNewReusable(component, desc);
-        reusableStack.push(reusable);
-        isIteration = false;
-    }
-
-    @Override
-    public void endComponent(String string) {
-        reusable.put(RDS.Step.END_TIME, DateTimeUtils.DateTimeNow());
-        if (reusable.get(TestCase.STATUS).equals("")) {
-            /* status not is updated set it to PASS */
-            reusable.put(TestCase.STATUS, "PASS");
-        }
-
-        /*
-		 * remove the reusable from the stack then fall back to iteration if stack is
-		 * empty else update the outer reusable status.
-         */
-        reusableStack.pop();
-        if (reusableStack.empty()) {
-            ((JSONArray) iteration.get(RDS.Step.DATA)).add(reusable);
-            reusable = null;
-            isIteration = true;
-        } else {
-            ((JSONArray) reusableStack.peek().get(RDS.Step.DATA)).add(reusable);
-            reusableStack.peek().put(TestCase.STATUS, reusable.get(TestCase.STATUS));
-            reusable = reusableStack.peek();
-        }
-
-    }
-
-    @Override
-    public void endIteration(int CurrentTestCaseIteration) {
-        if (iteration.get(TestCase.STATUS).equals("")) {
-            iteration.put(TestCase.STATUS, "FAIL");
-        }
-        Steps.add(iteration);
-    }
-
-    private void onSetpDone() {
-        DoneSteps++;
-        if (reusable != null && reusable.get(TestCase.STATUS).equals("")) {
-            reusable.put(TestCase.STATUS, "PASS");
-        }
-        if (iteration != null && iteration.get(TestCase.STATUS).equals("")) {
-            iteration.put(TestCase.STATUS, "PASS");
-        }
-    }
-
-    private void onSetpPassed() {
-        PassedSteps++;
-        if (reusable != null && reusable.get(TestCase.STATUS).equals("")) {
-            reusable.put(TestCase.STATUS, "PASS");
-        }
-        if (iteration != null && iteration.get(TestCase.STATUS).equals("")) {
-            iteration.put(TestCase.STATUS, "PASS");
-        }
-    }
-
-    private void onSetpFailed() {
-        FailedSteps++;
-        if (iteration != null) {
-            iteration.put(TestCase.STATUS, "FAIL");
-        }
-        if (reusable != null) {
-            reusable.put(TestCase.STATUS, "FAIL");
-        }
-    }
-
-    private void putStatus(Status state, List<String> optional, String optionalLink, JSONObject data) {
+    private String putStatus(Status state) {
         switch (state) {
             case DONE:
             case PASSNS:
-                onSetpDone();
+                DoneSteps++;
                 break;
             case PASS:
             case FAIL:
-            case SCREENSHOT:
-                takeScreenShot(state, optional, optionalLink, data);
-                break;
             case DEBUG:
+            case SCREENSHOT:
+                if (state == Status.FAIL || state == Status.DEBUG) FailedSteps++;
+                if (state == Status.PASS) PassedSteps++;
+                if (!canTakeScreenShot(state)) break;
+
+                String imgSrc = getScreenShotName();
+                if (ReportUtils.takeScreenshot(getPlaywrightDriver(), getWebDriver(), imgSrc)) return imgSrc;
+
+                break;
             case WARNING:
             case FAILNS:
-                onSetpFailed();
-                break;
-
-        }
-    }
-
-    private void takeScreenShot(Status status, List<String> optional, String optionalLink, JSONObject data) {
-        String imgSrc = getScreenShotName();
-        switch (status) {
-            case PASS:
-            case FAIL:
-                if (!canTakeScreenShot(status)) {
-                    break;
-                }
-                if (optionalLink != null) {
-                    break;
-                }
-            case SCREENSHOT:
-                takeSSAndPutDetail(data, optional, imgSrc);
-                break;
-            default:
+                FailedSteps++;
                 break;
         }
+
+        return null;
     }
 
     private Boolean canTakeScreenShot(Status status) {
-        if (status.equals(Status.FAIL)) {
-            onSetpFailed();
+        if (status.equals(Status.FAIL) || status.equals(Status.DEBUG)) {
             return screenShotSettings().matches("(Fail|Both)");
         }
         if (status.equals(Status.PASS)) {
-            onSetpPassed();
             return screenShotSettings().matches("(Pass|Both)");
-
         }
         return false;
     }
 
-    private static String screenShotSettings() {
+    private String screenShotSettings() {
         return Control.exe.getExecSettings().getRunSettings().getScreenShotFor();
-    }
-
-    /**
-     * takes new screen shot and updates the the json object for that step
-     *
-     * @param data
-     * @param imgSrc
-     */
-    private void takeSSAndPutDetail(JSONObject data, List<String> optional, String imgSrc) {
-        if (optional != null && optional.size() == 3) {
-            data.put(RDS.Step.Data.EXPECTED, optional.get(0));
-            data.put(RDS.Step.Data.ACTUAL, optional.get(1));
-            data.put(RDS.Step.Data.COMPARISION, optional.get(2));
-        } else {
-            if (optional != null) {
-                data.put(RDS.Step.Data.OBJECTS, optional.get(0));
-            }
-            if (ReportUtils.takeScreenshot(getPlaywrightDriver(), getWebDriver(), imgSrc)) {
-                data.put(RDS.Step.Data.LINK, imgSrc);
-            }
-        }
-
     }
 
     /**
@@ -373,77 +150,68 @@ public class AzureTestCaseHandler extends TestCaseHandler implements PrimaryHand
      */
     @Override
     public Status finalizeReport() {
-        updateResults();
-        String prefix = testCaseData.get(TestCase.SCENARIO_NAME) + "_" + testCaseData.get(TestCase.TESTCASE_NAME);
+        testCaseData.put(TestCase.NO_OF_TESTS, getStepCount());
+        testCaseData.put(TestCase.NO_OF_FAIL_TESTS, String.valueOf(this.FailedSteps));
+        testCaseData.put(TestCase.NO_OF_PASS_TESTS, String.valueOf(this.DoneSteps + this.PassedSteps));
+        testCaseData.put(TestCase.EXE_TIME, report.startTime.timeRun());
+
+        String prefix = scenarioName + "_" + testCaseName;
         File logsFolder = new File(FilePath.getCurrentTestCaseLogsLocation());
         String logPath = logsFolder.getAbsolutePath() + File.separator + prefix + ".txt";
-        attachments += "<attachment><filePath>" + logPath + "</filePath></attachment>" + "\n";
+        attachmentPaths.add(logPath);
 
         File videoFolder = new File(FilePath.getCurrentTestCaseVideosLocation());
         if (videoFolder.exists()) {
             File testCaseVideo = new File(FilePath.getCurrentTestCaseVideosLocation() + File.separator + prefix);
             for (File fileEntry : testCaseVideo.listFiles()) {
-                this.attachments += "<attachment><filePath>" + fileEntry.getAbsolutePath() + "</filePath></attachment>" + "\n";
+                attachmentPaths.add(fileEntry.getAbsolutePath());
             }
         }
 
-        String status = "";
+        String result, message;
+        String stacktrace = "";
         String noError = "This Test Case has no error. For details see the steps below:" + "\n";
         if (this.stacktraceData.isEmpty()) {
-            AzureReport.message = "<message><![CDATA[" + noError + this.messageCDATA + "]]></message>";
+            message = "<message><![CDATA[" + noError + this.messageCDATA + "]]></message>";
         } else {
-            AzureReport.message = "<message><![CDATA[" + this.messageCDATA + "]]></message>";
-            AzureReport.stacktrace = "<stack-trace><![CDATA[" + this.stacktraceData + "]]></stack-trace>";
+            message = "<message><![CDATA[" + this.messageCDATA + "]]></message>";
+            stacktrace = "<stack-trace><![CDATA[" + this.stacktraceData + "]]></stack-trace>";
         }
-        AzureReport.failures = "<failure>" + AzureReport.message + AzureReport.stacktrace + "</failure>";
-        AzureReport.attachments = "<attachments>" + attachments + "</attachments>";
-        if (testCaseData.get(TestCase.STATUS).equals("PASS") || testCaseData.get(TestCase.STATUS).equals("DONE")
-                || testCaseData.get(TestCase.STATUS).equals("COMPLETE")) {
-            status = "Passed";
+
+        Status status = getCurrentStatus();
+        if (status == Status.PASS || status == Status.DONE || status == Status.COMPLETE) {
+            result = "Passed";
             AzureReport.passed++;
         } else {
-            status = "Failed";
+            result = "Failed";
             AzureReport.failed++;
         }
 
-        AzureReport.testcase += "<test-case id=\"" + getUUID() + "\" name=\"" + testCaseData.get(TestCase.TESTCASE_NAME)
-                + "\" fullname=\"" + testCaseData.get(TestCase.TESTCASE_NAME) + "\" result=\"" + status + "\" time=\""
-                + duration(testCaseData.get(TestCase.EXE_TIME).toString()) + "\">" + AzureReport.failures + AzureReport.attachments
-                + "</test-case>";
-        AzureReport.testsuite += AzureReport.testcase;
+        try (FileOutputStream out = new FileOutputStream(AzureReport.testCasesFile, true)) {
+            String attachments = attachmentPaths
+                    .stream().map(p -> "<attachment><filePath>" + p + "</filePath></attachment>")
+                    .collect(Collectors.joining("\n"));
+
+            String testCase = "<test-case "
+                    + "id=\"" + UUID.randomUUID() + "\" "
+                    + "name=\"" + testCaseName + "\" "
+                    + "fullname=\"" + testCaseName + "\" "
+                    + "result=\"" + result + "\" "
+                    + "time=\"" + duration(testCaseData.get(TestCase.EXE_TIME).toString()) + "\" "
+                    + ">"
+                    + "<failure>" + message + stacktrace + "</failure>"
+                    + "<attachments>" + attachments + "</attachments>"
+                    + "</test-case>\n";
+
+            out.write(testCase.getBytes());
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
         return report.getCurrentStatus();
-
     }
 
-    public String getUUID() {
-        UUID uuid = UUID.randomUUID();
-        return uuid.toString();
-    }
-
-    /**
-     * update the test case execution details to the json DATA file
-     *
-     * @return
-     */
-    private void updateResults() {
-        String endTime = DateTimeUtils.DateTimeNow();
-        String exeTime = startTime().timeRun();
-        testCaseData.put(TestCase.STEPS, Steps);
-        testCaseData.put(TestCase.END_TIME, endTime);
-        testCaseData.put(TestCase.EXE_TIME, exeTime);
-        testCaseData.put(TestCase.ITERATIONS, iterCounter);
-        testCaseData.put(TestCase.NO_OF_TESTS, getStepCount());
-        testCaseData.put(TestCase.NO_OF_FAIL_TESTS, String.valueOf(this.FailedSteps));
-        testCaseData.put(TestCase.NO_OF_PASS_TESTS, String.valueOf(this.DoneSteps + this.PassedSteps));
-        testCaseData.put(TestCase.STATUS, getCurrentStatus().toString());
-
-    }
-
-    private DateTimeUtils startTime() {
-        return report.startTime;
-    }
-
-    public String duration(String executionTime) {
+    private String duration(String executionTime) {
         long seconds = 0;
         try {
             DateFormat dateFormat = new SimpleDateFormat("HH:mm:ss");
@@ -467,41 +235,26 @@ public class AzureTestCaseHandler extends TestCaseHandler implements PrimaryHand
         }
     }
 
-    public void addTestCase() throws ClientProtocolException, IOException, ParseException {
-        this.messageCDATA = AzureReport.CDATA;
-        this.stacktraceData = AzureReport.stacktraceData;
-    }
+    private void createLogNodes(String stepdata, Status status, String filepath) throws IOException {
+        messageCDATA += "Step " + getStepCount() + ":   " + stepdata + "\n";
 
-    public void createLogNodes(String stepdata, String status, String filepath) throws IOException, ParseException {
-        String prefix = testCaseData.get(TestCase.SCENARIO_NAME) + "_" + testCaseData.get(TestCase.TESTCASE_NAME);
-        this.messageCDATA += "Step " + getStepCount() + ":   " + stepdata + "\n";
-        if (filepath.equalsIgnoreCase("")) {
-
-            if (status.contains("PASS") || status.contains("DONE") || status.contains("COMPLETE")) {
-
-            } else {
-                this.stacktraceData += "Step " + getStepCount() + ":   " + stepdata + "\n";
-            }
-
-        } else {
-            File attachment = new File(new File(filepath).getCanonicalPath());
-            if (attachment.isDirectory()) {
-                for (File fileEntry : attachment.listFiles()) {
-                    if (fileEntry.getName().contains(prefix)) {
-                        this.attachments += "<attachment><filePath>" + fileEntry.getAbsolutePath() + "</filePath></attachment>" + "\n";
-                    }
-                }
-            } else {
-                filepath = attachment.getAbsolutePath();
-                this.attachments += "<attachment><filePath>" + filepath + "</filePath></attachment>" + "\n";
-            }
-
-            if (status.contains("PASS") || status.contains("DONE") || status.contains("COMPLETE")) {
-
-            } else {
-                this.stacktraceData += "Step " + getStepCount() + ":   " + stepdata + "\n";
-            }
+        if (status != Status.PASS && status != Status.DONE && status != Status.COMPLETE) {
+            stacktraceData += "Step " + getStepCount() + ":   " + stepdata + "\n";
         }
 
+        if (filepath.isEmpty()) return;
+
+        File attachment = new File(new File(filepath).getCanonicalPath());
+        if (attachment.isDirectory()) {
+            String prefix = scenarioName + "_" + testCaseName;
+
+            for (File fileEntry : attachment.listFiles()) {
+                if (fileEntry.getName().contains(prefix)) {
+                    attachmentPaths.add(fileEntry.getAbsolutePath());
+                }
+            }
+        } else {
+            attachmentPaths.add(attachment.getAbsolutePath());
+        }
     }
 }

--- a/Engine/src/main/java/com/ing/engine/reporting/impl/azureNunit/AzureReport.java
+++ b/Engine/src/main/java/com/ing/engine/reporting/impl/azureNunit/AzureReport.java
@@ -2,21 +2,22 @@
 package com.ing.engine.reporting.impl.azureNunit;
 
 
+import java.io.File;
+import java.io.IOException;
+
 public class AzureReport {
-		
-    public static long totalDuration=0;
-    public static int failed=0;
-    public static int passed=0;
-    public static String message="";
-    public static String CDATA="";
-    public static String stacktraceData="";
-    public static String stacktrace="";
-    public static String xmlData="";
-    public static String testrun="";
-    public static String testsuite="";
-    public static String testcase="";
-    public static String failures="";
-    public static String attachments="";
-    public static String startTime="";
-    public static String endTime="";
+
+    public static long totalDuration = 0;
+    public static int failed = 0;
+    public static int passed = 0;
+
+    public static File testCasesFile;
+
+    static {
+        try {
+            testCasesFile = File.createTempFile("test-cases", ".xml");
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
 }

--- a/IDE/src/main/java/com/ing/ide/main/utils/MessageConsole.java
+++ b/IDE/src/main/java/com/ing/ide/main/utils/MessageConsole.java
@@ -4,6 +4,7 @@ package com.ing.ide.main.utils;
 import java.awt.Color;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Objects;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -128,6 +129,8 @@ public class MessageConsole {
      */
     class ConsoleOutputStream extends ByteArrayOutputStream {
 
+        static final int MAX_CONSOLE_LENGTH = 16_384;
+
         private final String EOL = System.getProperty("line.separator");
         private SimpleAttributeSet attributes, attr_PASS, attr_FAIL;
         private PrintStream printStream;
@@ -164,57 +167,16 @@ public class MessageConsole {
          */
         @Override
         public void flush() {
-            String message = toString();
+            if (count == 0) return;
 
-            if (message.length() == 0) {
-                return;
-            }
+            String message = new String(buf, 0, count, StandardCharsets.UTF_8);
+            buffer.append(message);
 
-            if (isAppend) {
-                handleAppend(message);
-            } else {
-                handleInsert(message);
+            if (message.contains(EOL)) {
+                clearBuffer();
             }
 
             reset();
-        }
-
-        /*
-         *	We don't want to have blank lines in the Document. The first line
-         *  added will simply be the message. For additional lines it will be:
-         *
-         *  newLine + message
-         */
-        private void handleAppend(String message) {
-            //  This check is needed in case the text in the Document has been
-            //	cleared. The buffer may contain the EOL string from the previous
-            //  message.
-
-            if (document.getLength() == 0) {
-                buffer.setLength(0);
-            }
-
-            if (EOL.equals(message)) {
-                buffer.append(message);
-            } else {
-                buffer.append(message);
-                clearBuffer();
-            }
-
-        }
-
-        /*
-         *  We don't want to merge the new message with the existing message
-         *  so the line will be inserted as:
-         *
-         *  message + newLine
-         */
-        private void handleInsert(String message) {
-            buffer.append(message);
-
-            if (EOL.equals(message)) {
-                clearBuffer();
-            }
         }
 
         /*
@@ -235,8 +197,9 @@ public class MessageConsole {
 
             try {
                 if (isAppend) {
-                    int offset = document.getLength();
-                    document.insertString(offset, line, withDynamicColor(line));
+                    document.insertString(document.getLength(), line, withDynamicColor(line));
+                    document.remove(0, Math.max(document.getLength(), MAX_CONSOLE_LENGTH));
+
                     textComponent.setCaretPosition(document.getLength());
                 } else {
                     document.insertString(0, line, withDynamicColor(line));


### PR DESCRIPTION
This PR solves some issues we ran into when working with INGenious where a significantly large set of tests is ran (250+ tests with each ~1000 steps), INGenious runs out of heap space. The issue was found to be regarding the in-memory storage of several test-related logs.

As a solution, these logs have been written to temporary files and copied whenever needed.

Additionally, I refactored the `AzureSummaryHandler` and the `AzureTestCaseHandler` since they also contained memory issues, but it was difficult to find exactly what the issues were without refactoring (and deleting a lot of unused code.)