### PR TITLE
devops: add flakiness.io dashboard

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -10,6 +10,9 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write  # needed for Flakiness.io OIDC
 
     steps:
       - uses: actions/checkout@v4
@@ -21,6 +24,15 @@ jobs:
           cache: maven
       - name: Build with Maven
         run: mvn clean install --file pom.xml
+      - name: Upload to Flakiness.io
+        if: always()
+        env:
+          FLAKINESS_PROJECT: ing-bank/INGenious
+        run: |
+          curl -LsSf https://cli.flakiness.io/install.sh | sh
+          flakiness convert-junit Engine/target/surefire-reports/junitreports --env-name engine --output-dir flakiness-engine
+          flakiness convert-junit Datalib/target/surefire-reports/junitreports --env-name datalib --output-dir flakiness-datalib
+          flakiness upload flakiness-*
       - name: Upload INGenious release
         uses: actions/upload-artifact@v4.3.6
         with:


### PR DESCRIPTION
Hey folks,

As discussed with @ghoshasish99, this PR adds a pilot Flakiness.io integration to the repository. 

> [!tip]
> Dashboard demo: https://flakiness.io/flakiness/flakiness

Steps to enable integration:
1. Install the [Flakiness.io Github App](https://github.com/apps/flakiness-io) to this repository
2. Goto https://flakiness.io, create an `ing-bank` organization and a `INGenious` project. (You can choose any name for your org and project, but I'd recommend to mirror github names.)
3. Merge this PR: the code is configured to upload to `ing-bank/INGenious` flakiness.io project.

After the PR is merged, you get:
- all test runs will be uploaded to the dashboard
- PRs will get an additional check that flags **new regressions**
  A regression is reported only if a test was consistently passing on the target branch but fails in the PR (based on commit history) - [docs](https://docs.flakiness.io/platform/pull-requests/)
- You can optionally add a badge to README.md to show the main branch test status - [docs](https://docs.flakiness.io/platform/project-badges/)

> [!NOTE]
> There are no secrets needed for this to work since Flakiness.io supports Github OIDC for secretless auth.


Demo of the dashboard: https://flakiness.io/flakiness/flakiness
