### PR TITLE
Migration feature to convert OR.object to YAML

### DIFF
--- a/Datalib/src/main/java/com/ing/datalib/component/Project.java
+++ b/Datalib/src/main/java/com/ing/datalib/component/Project.java
@@ -11,6 +11,8 @@ import com.ing.datalib.settings.ProjectSettings;
 import com.ing.datalib.util.data.FileScanner;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ing.datalib.or.mobile.MobileOR;
+import com.ing.datalib.or.web.WebOR;
 import com.ing.datalib.or.web.WebOR.ORScope;
 import java.io.File;
 import java.nio.file.Files;
@@ -567,6 +569,26 @@ public class Project {
     public void refactorObjectName(ORScope scope, String pageName, String oldName, String newName) {
         for (Scenario scenario : scenarios) {
             scenario.refactorObjectName(scope, pageName, oldName, newName);
+        }
+    }
+    
+    /**
+     * Refactors Mobile OR object references in TestSteps.
+     * Mobile scope is mapped to Web scope because Scenarios/TestSteps
+     * are tool-agnostic and only care about PROJECT vs SHARED.
+     */
+    public void refactorMobileObjectName(MobileOR.ORScope scope, String pageName, String oldName, String newName) {
+        for (Scenario scenario : scenarios) {
+            WebOR.ORScope webScope =
+            (scope == MobileOR.ORScope.SHARED)
+                ? WebOR.ORScope.SHARED
+                : WebOR.ORScope.PROJECT;
+            scenario.refactorObjectName(
+                webScope,
+                pageName,
+                oldName,
+                newName
+            );
         }
     }
 

--- a/Datalib/src/main/java/com/ing/datalib/component/TestCase.java
+++ b/Datalib/src/main/java/com/ing/datalib/component/TestCase.java
@@ -4,6 +4,7 @@ package com.ing.datalib.component;
 import com.ing.datalib.component.TestStep.HEADERS;
 import com.ing.datalib.component.utils.FileUtils;
 import com.ing.datalib.component.utils.SaveListener;
+import com.ing.datalib.or.web.ResolvedWebObject;
 import com.ing.datalib.or.web.WebOR.ORScope;
 import java.io.File;
 import java.io.FileWriter;
@@ -213,6 +214,11 @@ public class TestCase extends DataModel {
 
     public void addObjectStep(int index, String objectName, String pageName) {
         TestStep step = new TestStep(this).asObjectStep(objectName, pageName);
+        addStep(index, step);
+    }
+
+    public void addObjectStep(int index, ResolvedWebObject rwo) {
+        TestStep step = new TestStep(this).asObjectStep(rwo);
         addStep(index, step);
     }
 

--- a/Datalib/src/main/java/com/ing/datalib/component/TestStep.java
+++ b/Datalib/src/main/java/com/ing/datalib/component/TestStep.java
@@ -1,6 +1,7 @@
 
 package com.ing.datalib.component;
 
+import com.ing.datalib.or.web.ResolvedWebObject;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -203,6 +204,17 @@ public class TestStep {
     public TestStep asObjectStep(String objectName, String pageName) {
         setObject(objectName);
         setReference(pageName);
+        return this;
+    }
+
+    public TestStep asObjectStep(ResolvedWebObject rwo) {
+        setObject(rwo.getObjectName());
+        setReference(
+            new ResolvedWebObject.PageRef(
+                rwo.getPageName(),
+                rwo.getScope()
+            ).qualified()
+        );
         return this;
     }
 

--- a/Datalib/src/main/java/com/ing/datalib/component/TestStep.java
+++ b/Datalib/src/main/java/com/ing/datalib/component/TestStep.java
@@ -1,6 +1,7 @@
 
 package com.ing.datalib.component;
 
+import com.ing.datalib.or.mobile.ResolvedMobileObject;
 import com.ing.datalib.or.web.ResolvedWebObject;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -213,6 +214,17 @@ public class TestStep {
             new ResolvedWebObject.PageRef(
                 rwo.getPageName(),
                 rwo.getScope()
+            ).qualified()
+        );
+        return this;
+    }
+
+    public TestStep asObjectStep(ResolvedMobileObject rmo) {
+        setObject(rmo.getObjectName());
+        setReference(
+            new ResolvedMobileObject.PageRef(
+                rmo.getPageName(),
+                rmo.getScope()
             ).qualified()
         );
         return this;

--- a/Datalib/src/main/java/com/ing/datalib/or/ObjectRepository.java
+++ b/Datalib/src/main/java/com/ing/datalib/or/ObjectRepository.java
@@ -105,14 +105,21 @@ public class ObjectRepository {
             webProjectOR = new WebOR();
             webProjectOR.setScope(WebOR.ORScope.PROJECT);
             webProjectOR.setObjectRepository(this);
+            webProjectOR.setName(sProject.getName());
+            
             mobileProjectOR = new MobileOR();
             mobileProjectOR.setScope(MobileOR.ORScope.PROJECT);
             mobileProjectOR.setObjectRepository(this);
+            mobileProjectOR.setName(sProject.getName());
+            
             apiProjectOR = new APIOR();
             apiProjectOR.setObjectRepository(this);
+            apiProjectOR.setName(sProject.getName());
             useYamlFormat = true;
+            
+            ensureSharedORsExist();
             }
-
+                
         } catch (Exception e) {
             LOG.log(Level.SEVERE, "Failed to initialize ObjectRepository", e);
         }
@@ -127,9 +134,6 @@ public class ObjectRepository {
     public String getMORLocation() {
         return sProject.getLocation() + File.separator + "MOR.object";
     }
-    public String getAPIORLocation() {
-        return sProject.getLocation() + File.separator + "APIOR.object";
-    }
     public String getSharedORLocation() {
         return "Shared" + File.separator + "SharedWebObjects" + File.separator + "SharedOR.object";
     }
@@ -142,24 +146,11 @@ public class ObjectRepository {
     public String getIORRepLocation() {
         return sProject.getLocation() + File.separator + "ImageObjectRepository";
     }
-    public String getMORRepLocation() {
-        return sProject.getLocation() + File.separator + "MobileObjectRepository";
-    }
-    public String getAPIORRepLocation() {
-        return sProject.getLocation() + File.separator + "APIObjectRepository";
-    }
     public String getSharedORRepLocation() {
         File projectDir = new File(sProject.getLocation());   
         File projectsRoot = projectDir.getParentFile();       
         File ingeniousRoot = projectsRoot.getParentFile();    
         File sharedOR = new File(ingeniousRoot,"Shared" + File.separator + "SharedObjectRepository");
-        return sharedOR.getAbsolutePath();
-    }
-    public String getSharedMORRepLocation() {
-        File projectDir = new File(sProject.getLocation());   
-        File projectsRoot = projectDir.getParentFile();       
-        File ingeniousRoot = projectsRoot.getParentFile();    
-        File sharedOR = new File(ingeniousRoot,"Shared" + File.separator + "SharedMobileObjectRepository");
         return sharedOR.getAbsolutePath();
     }
     public Project getsProject() {
@@ -191,7 +182,6 @@ public class ObjectRepository {
             LinkedHashSet<String> mergedProjects = new LinkedHashSet<>();
             if (existingProjects != null) mergedProjects.addAll(existingProjects);
             mergedProjects.addAll(sharedUsageProjects);
-
             boolean projectsChanged = false;
             if (webSharedOR != null) {
                 List<String> current = webSharedOR.getSharedProjects();
@@ -201,12 +191,10 @@ public class ObjectRepository {
                     webSharedOR.setSharedProjects(new ArrayList<>(mergedProjects));
                 }
             }
-
             List<String> mExisting = (mobileSharedOR != null) ? mobileSharedOR.getSharedProjects() : List.of();
             LinkedHashSet<String> mMerged = new LinkedHashSet<>();
             if (mExisting != null) mMerged.addAll(mExisting);
             mMerged.addAll(sharedUsageProjects);
-
             boolean mProjectsChanged = false;
             if (mobileSharedOR != null) {
                 List<String> mCurrent = mobileSharedOR.getSharedProjects();
@@ -216,7 +204,6 @@ public class ObjectRepository {
                     mobileSharedOR.setSharedProjects(new ArrayList<>(mMerged));
                 }
             }
-            
             if (useYamlFormat) {
                 if (webSharedOR != null && (!webSharedOR.isSaved() || projectsChanged)) {
                     yamlWriter.writeWebOR(webSharedOR,new File(getSharedORRepLocation()) );
@@ -229,50 +216,26 @@ public class ObjectRepository {
                 saveAsYaml();
                 LOG.info("Saved Shared and Project ORs in YAML format");
                 return;
-
             }
-
-            if (webSharedOR != null && (!webSharedOR.isSaved() || projectsChanged)) {
-                File sharedORFile = new File(getSharedORLocation());
-                sharedORFile.getParentFile().mkdirs();
-                XML_MAPPER.writerWithDefaultPrettyPrinter().writeValue(sharedORFile, webSharedOR);
-                webSharedOR.setSaved(true);
-            }
-            if (mobileSharedOR != null && (!mobileSharedOR.isSaved() || mProjectsChanged)) {
-                File sharedMORFile = new File(getSharedMORLocation());
-                sharedMORFile.getParentFile().mkdirs();
-                XML_MAPPER.writerWithDefaultPrettyPrinter().writeValue(sharedMORFile, mobileSharedOR);
-                mobileSharedOR.setSaved(true);
-            }
-
-            if (webProjectOR != null && !webProjectOR.isSaved()) {
-                File orFile = new File(getORLocation());
-                orFile.getParentFile().mkdirs();
-                XML_MAPPER.writerWithDefaultPrettyPrinter().writeValue(orFile, webProjectOR);
-                webProjectOR.setSaved(true);
-            }
-
-            if (mobileProjectOR != null && !mobileProjectOR.isSaved()) {
-                File morFile = new File(getMORLocation());
-                morFile.getParentFile().mkdirs();
-                XML_MAPPER.writerWithDefaultPrettyPrinter().writeValue(morFile, mobileProjectOR);
-                mobileProjectOR.setSaved(true);
-            }
-
-            if (apiProjectOR != null && !apiProjectOR.isSaved()) {
-                File apiFile = new File(getAPIORLocation());
-                apiFile.getParentFile().mkdirs();
-                XML_MAPPER.writerWithDefaultPrettyPrinter().writeValue(apiFile, apiProjectOR);
-                apiProjectOR.setSaved(true);
-            }
-            LOG.info("Saved ORs in legacy XML format");
-
         } catch (IOException ex) {
-            Logger.getLogger(ObjectRepository.class.getName())
-                    .log(Level.SEVERE, "Failed to save Object Repository", ex);
+            Logger.getLogger(ObjectRepository.class.getName()).log(Level.SEVERE, "Failed to save Object Repository", ex);
         }
     }
-    
+
+    private void ensureSharedORsExist() {
+        if (webSharedOR == null) {
+            webSharedOR = new WebOR("Shared Web Objects");
+            webSharedOR.setScope(WebOR.ORScope.SHARED);
+            webSharedOR.setObjectRepository(this);
+            webSharedOR.setSaved(true);
+        }
+        if (mobileSharedOR == null) {
+            mobileSharedOR = new MobileOR("Shared Mobile Objects");
+            mobileSharedOR.setScope(MobileOR.ORScope.SHARED);
+            mobileSharedOR.setObjectRepository(this);
+            mobileSharedOR.setSaved(true);
+        }
+    }
     /**
      * Save Object Repository in YAML format.
      * Creates page-per-file structure under ObjectRepository/Web/, ObjectRepository/Mobile/, and ObjectRepository/API/
@@ -284,6 +247,8 @@ public class ObjectRepository {
             yamlWriter.writeMobileOR(mobileProjectOR, orRepLocation);
             yamlWriter.writeAPIOR(apiProjectOR, orRepLocation);
             webProjectOR.setSaved(true);
+            mobileProjectOR.setSaved(true);
+            apiProjectOR.setSaved(true);
             useYamlFormat = true;
             LOG.info("Saved Object Repository in YAML format");
         } catch (IOException ex) {
@@ -392,10 +357,15 @@ public class ObjectRepository {
         File orRepRoot = new File(getORRepLocation());
         webProjectOR = yamlReader.readWebOR(orRepRoot);
         webProjectOR.setObjectRepository(this);
+        webProjectOR.setName(sProject.getName());
+        
         mobileProjectOR = yamlReader.readMobileOR(orRepRoot);
         mobileProjectOR.setObjectRepository(this);
+        mobileProjectOR.setName(sProject.getName());
+        
         apiProjectOR = yamlReader.readAPIOR(orRepRoot);
         apiProjectOR.setObjectRepository(this);
+        apiProjectOR.setName(sProject.getName());
 
         normalizeWebOR(webProjectOR);
         normalizeMobileOR(mobileProjectOR);
@@ -405,8 +375,11 @@ public class ObjectRepository {
         File sharedRoot = new File(getSharedORRepLocation());
         webSharedOR = yamlReader.readWebOR(sharedRoot);
         webSharedOR.setObjectRepository(this);
+        webSharedOR.setName("Shared Web Objects");
+        
         mobileSharedOR = yamlReader.readMobileOR(sharedRoot);
         mobileSharedOR.setObjectRepository(this);
+        mobileSharedOR.setName("Shared Mobile Objects");
         
         normalizeWebOR(webSharedOR);
         normalizeMobileOR(mobileSharedOR);
@@ -1086,8 +1059,8 @@ public class ObjectRepository {
         try {
             File repoRoot =
                 (page.getRoot().getScope() == MobileOR.ORScope.SHARED)
-                    ? new File(getSharedMORRepLocation())
-                    : new File(getMORRepLocation());
+                    ? new File(getSharedORRepLocation())
+                    : new File(getORRepLocation());
             File mobilePagesDir = new File(repoRoot, "Mobile");
             if (!mobilePagesDir.exists()) {
                 mobilePagesDir.mkdirs();

--- a/Datalib/src/main/java/com/ing/datalib/or/ObjectRepository.java
+++ b/Datalib/src/main/java/com/ing/datalib/or/ObjectRepository.java
@@ -15,11 +15,15 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
+import com.ing.datalib.component.TestCase;
+import com.ing.datalib.component.TestStep;
 import com.ing.datalib.or.api.APIORObject;
 import com.ing.datalib.or.api.APIORPage;
 import com.ing.datalib.or.mobile.ResolvedMobileObject;
 import com.ing.datalib.or.web.ResolvedWebObject;
 import com.ing.datalib.or.web.WebOR.ORScope;
+import static com.ing.datalib.or.web.WebOR.ORScope.PROJECT;
+import static com.ing.datalib.or.web.WebOR.ORScope.SHARED;
 import com.ing.datalib.or.web.WebORObject;
 import com.ing.datalib.or.web.WebORPage;
 import java.io.File;
@@ -40,7 +44,6 @@ import java.util.logging.Logger;
  */
 public class ObjectRepository {
     private static final XmlMapper XML_MAPPER = new XmlMapper();
-    private static final ObjectMapper YAML_MAPPER = createYamlMapper();
     private static final Logger LOG = Logger.getLogger(ObjectRepository.class.getName());
     private final Project sProject;
     private WebOR webSharedOR;
@@ -57,7 +60,7 @@ public class ObjectRepository {
     private YamlORWriter yamlWriter;
     
     // Migration / conversion
-    private boolean xmlConvertedThisSession = false;
+    private final boolean xmlConvertedThisSession = false;
     
     private static ObjectMapper createYamlMapper() {
         YAMLFactory factory = new YAMLFactory();
@@ -131,7 +134,7 @@ public class ObjectRepository {
             }
             }
                 
-        } catch (Exception e) {
+        } catch (IOException e) {
             LOG.log(Level.SEVERE, "Failed to initialize ObjectRepository", e);
         }
     }
@@ -226,7 +229,6 @@ public class ObjectRepository {
                 }
                 saveAsYaml();
                 LOG.info("Saved Shared and Project ORs in YAML format");
-                return;
             }
         } catch (IOException ex) {
             Logger.getLogger(ObjectRepository.class.getName()).log(Level.SEVERE, "Failed to save Object Repository", ex);
@@ -351,37 +353,51 @@ public class ObjectRepository {
     }
 
     private void loadYamlObjectRepositories() throws IOException {
-        File orRepRoot = new File(getORRepLocation());
-        webProjectOR = yamlReader.readWebOR(orRepRoot);
-        webProjectOR.setObjectRepository(this);
-        webProjectOR.setName(sProject.getName());
+        File projectRoot = new File(getORRepLocation());
         
-        mobileProjectOR = yamlReader.readMobileOR(orRepRoot);
-        mobileProjectOR.setObjectRepository(this);
-        mobileProjectOR.setName(sProject.getName());
-        
-        apiProjectOR = yamlReader.readAPIOR(orRepRoot);
-        apiProjectOR.setObjectRepository(this);
-        apiProjectOR.setName(sProject.getName());
+        webProjectOR = yamlReader.readWebOR(projectRoot);
+        if (webProjectOR != null) {
+            webProjectOR.setObjectRepository(this);
+            webProjectOR.setScope(WebOR.ORScope.PROJECT);
+            webProjectOR.setName(sProject.getName());
+            normalizeWebOR(webProjectOR);
+        }
 
-        normalizeWebOR(webProjectOR);
-        normalizeMobileOR(mobileProjectOR);
-        normalizeAPIOR(apiProjectOR);
+        mobileProjectOR = yamlReader.readMobileOR(projectRoot);
+        if (mobileProjectOR != null) {
+            mobileProjectOR.setObjectRepository(this);
+            mobileProjectOR.setScope(MobileOR.ORScope.PROJECT);
+            mobileProjectOR.setName(sProject.getName());
+            normalizeMobileOR(mobileProjectOR);
+        }
 
-        // Shared
+        apiProjectOR = yamlReader.readAPIOR(projectRoot);
+        if (apiProjectOR != null) {
+            apiProjectOR.setObjectRepository(this);
+            apiProjectOR.setName(sProject.getName());
+            normalizeAPIOR(apiProjectOR);
+        }
+
         File sharedRoot = new File(getSharedORRepLocation());
-        webSharedOR = yamlReader.readWebOR(sharedRoot);
-        webSharedOR.setObjectRepository(this);
-        webSharedOR.setName("Shared Web Objects");
-        webSharedOR.setScope(WebOR.ORScope.SHARED);
         
-        mobileSharedOR = yamlReader.readMobileOR(sharedRoot);
-        mobileSharedOR.setObjectRepository(this);
-        mobileSharedOR.setName("Shared Mobile Objects");
-        mobileSharedOR.setScope(MobileOR.ORScope.SHARED);
-        
-        normalizeWebOR(webSharedOR);
-        normalizeMobileOR(mobileSharedOR);
+        if (sharedRoot.exists() && sharedRoot.isDirectory()) {
+
+            webSharedOR = yamlReader.readWebOR(sharedRoot);
+            if (webSharedOR != null) {
+                webSharedOR.setObjectRepository(this);
+                webSharedOR.setScope(WebOR.ORScope.SHARED);
+                webSharedOR.setName("Shared Web Objects");
+                normalizeWebOR(webSharedOR);
+            }
+
+            mobileSharedOR = yamlReader.readMobileOR(sharedRoot);
+            if (mobileSharedOR != null) {
+                mobileSharedOR.setObjectRepository(this);
+                mobileSharedOR.setScope(MobileOR.ORScope.SHARED);
+                mobileSharedOR.setName("Shared Mobile Objects");
+                normalizeMobileOR(mobileSharedOR);
+            }
+        }
     }
 
     /**
@@ -696,27 +712,27 @@ public class ObjectRepository {
         return null;
     }
 
-    public ResolvedMobileObject resolveMobileObject(ResolvedMobileObject.PageRef pageRef, String objectName) {
-        if (pageRef == null || objectName == null) return null;
-        if (pageRef.scope == ORScope.PROJECT) {
-            var g = getFrom(mobileProjectOR, pageRef.name, objectName);
-            if (g != null) {
-                String actualPageName = g.getParent() != null ? g.getParent().getName() : pageRef.name;
-                return new ResolvedMobileObject(ORScope.PROJECT, actualPageName, objectName, g);
-            }
-            return null;
-        }
-        if (pageRef.scope == ORScope.SHARED) {
-            var g = getFrom(mobileSharedOR, pageRef.name, objectName);
-            if (g != null) {
-                markSharedUsage();
-                String actualPageName = g.getParent() != null ? g.getParent().getName() : pageRef.name;
-                return new ResolvedMobileObject(ORScope.SHARED, actualPageName, objectName, g);
-            }
-            return null;
-        }
-        return resolveMobileObjectWithScope(pageRef.name, objectName);
-    }
+   public ResolvedMobileObject resolveMobileObject(ResolvedMobileObject.PageRef pageRef, String objectName) {
+       if (pageRef == null || objectName == null) return null;
+       if (pageRef.scope == ORScope.PROJECT) {
+           var g = getFrom(mobileProjectOR, pageRef.name, objectName);
+           if (g != null) {
+               String actualPageName = g.getParent() != null ? g.getParent().getName() : pageRef.name;
+               return new ResolvedMobileObject(ORScope.PROJECT, actualPageName, objectName, g);
+           }
+           return null;
+       }
+       if (pageRef.scope == ORScope.SHARED) {
+           var g = getFrom(mobileSharedOR, pageRef.name, objectName);
+           if (g != null) {
+               markSharedUsage();
+               String actualPageName = g.getParent() != null ? g.getParent().getName() : pageRef.name;
+               return new ResolvedMobileObject(ORScope.SHARED, actualPageName, objectName, g);
+           }
+           return null;
+       }
+       return resolveMobileObjectWithScope(pageRef.name, objectName);
+   }
 
     /**
      * Resolves a WebOR object by searching project scope first, then shared scope.
@@ -736,6 +752,27 @@ public class ObjectRepository {
             markSharedUsage();
             String actualPageName = shared.getParent() != null ? shared.getParent().getName() : pageName;
             return new ResolvedWebObject(ORScope.SHARED, actualPageName, objectName, shared);
+        }
+        return null;
+    }
+
+    public ResolvedWebObject resolveWebObjectWithScope(String pageName, String objectName,TestStep step) {
+        var proj = getFrom(webProjectOR, pageName, objectName);
+        if (proj != null) {
+            return new ResolvedWebObject(PROJECT, pageName, objectName, proj);
+        }
+
+        var shared = getFrom(webSharedOR, pageName, objectName);
+        if (shared != null) {
+
+            if (step != null &&
+                step.getReference().startsWith("[Project] ")) {
+
+                step.setReference("[Shared] " + pageName);
+                step.getTestCase().setSaved(false);
+            }
+
+            return new ResolvedWebObject(SHARED, pageName, objectName, shared);
         }
         return null;
     }

--- a/Datalib/src/main/java/com/ing/datalib/or/ObjectRepository.java
+++ b/Datalib/src/main/java/com/ing/datalib/or/ObjectRepository.java
@@ -15,6 +15,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
+import com.ing.datalib.or.api.APIORObject;
+import com.ing.datalib.or.api.APIORPage;
 import com.ing.datalib.or.mobile.ResolvedMobileObject;
 import com.ing.datalib.or.web.ResolvedWebObject;
 import com.ing.datalib.or.web.WebOR.ORScope;
@@ -81,7 +83,7 @@ public class ObjectRepository {
      */
     private void init() {
         try {
-            yamlReader = new YamlORReader();
+            yamlReader = new YamlORReader(this);
             yamlWriter = new YamlORWriter();
 
             boolean yamlExists = hasYamlOR();
@@ -389,13 +391,25 @@ public class ObjectRepository {
     private void loadYamlObjectRepositories() throws IOException {
         File orRepRoot = new File(getORRepLocation());
         webProjectOR = yamlReader.readWebOR(orRepRoot);
+        webProjectOR.setObjectRepository(this);
         mobileProjectOR = yamlReader.readMobileOR(orRepRoot);
+        mobileProjectOR.setObjectRepository(this);
         apiProjectOR = yamlReader.readAPIOR(orRepRoot);
+        apiProjectOR.setObjectRepository(this);
+
+        normalizeWebOR(webProjectOR);
+        normalizeMobileOR(mobileProjectOR);
+        normalizeAPIOR(apiProjectOR);
 
         // Shared
         File sharedRoot = new File(getSharedORRepLocation());
         webSharedOR = yamlReader.readWebOR(sharedRoot);
+        webSharedOR.setObjectRepository(this);
         mobileSharedOR = yamlReader.readMobileOR(sharedRoot);
+        mobileSharedOR.setObjectRepository(this);
+        
+        normalizeWebOR(webSharedOR);
+        normalizeMobileOR(mobileSharedOR);
     }
 
     /**
@@ -436,6 +450,57 @@ public class ObjectRepository {
            LOG.info("Loaded SHARED Mobile XML OR");
        }
    }
+
+   private void normalizeWebOR(WebOR webOR) {
+        if (webOR == null) return;
+
+        for (WebORPage page : webOR.getPages()) {
+            page.setRoot(webOR);
+
+            for (ObjectGroup<WebORObject> group : page.getObjectGroups()) {
+                group.setParent(page);
+
+                for (WebORObject obj : group.getObjects()) {
+                    obj.setParent(group);
+                }
+            }
+        }
+        webOR.setSaved(true);
+    }
+   
+   private void normalizeMobileOR(MobileOR mobileOR) {
+        if (mobileOR == null) return;
+
+        for (MobileORPage page : mobileOR.getPages()) {
+            page.setRoot(mobileOR);
+
+            for (ObjectGroup<MobileORObject> group : page.getObjectGroups()) {
+                group.setParent(page);
+
+                for (MobileORObject obj : group.getObjects()) {
+                    obj.setParent(group);
+                }
+            }
+        }
+        mobileOR.setSaved(true);
+    }
+   
+   private void normalizeAPIOR(APIOR apiOR) {
+        if (apiOR == null) return;
+
+        for (APIORPage page : apiOR.getPages()) {
+            page.setRoot(apiOR);
+
+            for (ObjectGroup<APIORObject> group : page.getObjectGroups()) {
+                group.setParent(page);
+
+                for (APIORObject obj : group.getObjects()) {
+                    obj.setParent(group);
+                }
+            }
+        }
+        apiOR.setSaved(true);
+    }
 
     /**
      * Checks whether the given object exists in either PROJECT or SHARED scope.
@@ -977,7 +1042,7 @@ public class ObjectRepository {
     public void setUseYamlFormat(boolean useYaml) {
         this.useYamlFormat = useYaml;
         if (useYaml && yamlReader == null) {
-            yamlReader = new YamlORReader();
+            yamlReader = new YamlORReader(this);
             yamlWriter = new YamlORWriter();
         }
     }

--- a/Datalib/src/main/java/com/ing/datalib/or/ObjectRepository.java
+++ b/Datalib/src/main/java/com/ing/datalib/or/ObjectRepository.java
@@ -15,7 +15,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
-import com.ing.datalib.component.TestCase;
 import com.ing.datalib.component.TestStep;
 import com.ing.datalib.or.api.APIORObject;
 import com.ing.datalib.or.api.APIORPage;
@@ -52,23 +51,16 @@ public class ObjectRepository {
     private MobileOR mobileSharedOR;
     private APIOR apiProjectOR;
     
-    private final Set<String> sharedUsageProjects = new HashSet<>();
-    
+    private final Set<String> webSharedUsageProjects = new HashSet<>();
+    private final Set<String> mobileSharedUsageProjects = new HashSet<>();
+    private List<String> webSharedProjectsFromXml = List.of();
+    private List<String> mobileSharedProjectsFromXml = List.of();
+
     // YAML support
     private boolean useYamlFormat = true; // Default to YAML for new projects
     private YamlORReader yamlReader;
     private YamlORWriter yamlWriter;
     
-    // Migration / conversion
-    private final boolean xmlConvertedThisSession = false;
-    
-    private static ObjectMapper createYamlMapper() {
-        YAMLFactory factory = new YAMLFactory();
-        factory.disable(YAMLGenerator.Feature.WRITE_DOC_START_MARKER);
-        factory.enable(YAMLGenerator.Feature.MINIMIZE_QUOTES);
-        return new ObjectMapper(factory);
-    }
-
     /**
      * Creates an ObjectRepository for the given project and loads all OR files
      * (project WebOR, shared WebOR, and MobileOR), initializing defaults when missing.
@@ -191,46 +183,65 @@ public class ObjectRepository {
      */
     public void save() {
         try {
-            List<String> existingProjects = (webSharedOR != null) ? webSharedOR.getSharedProjects() : List.of();
-            LinkedHashSet<String> mergedProjects = new LinkedHashSet<>();
-            if (existingProjects != null) mergedProjects.addAll(existingProjects);
-            mergedProjects.addAll(sharedUsageProjects);
-            boolean projectsChanged = false;
+            boolean webProjectsChanged = false;
             if (webSharedOR != null) {
+                LinkedHashSet<String> webMerged = new LinkedHashSet<>();
+                webMerged.addAll(webSharedProjectsFromXml);
+                webMerged.addAll(webSharedUsageProjects);
+                File sharedRoot = new File(getSharedORRepLocation());
+                File webMetaFile = new File(sharedRoot, "webor-projectsdata.yaml");
+                webMerged.addAll(yamlWriter.readExistingProjects(webMetaFile));
                 List<String> current = webSharedOR.getSharedProjects();
-                projectsChanged = current == null
-                        || !new LinkedHashSet<>(current).equals(mergedProjects);
-                if (projectsChanged) {
-                    webSharedOR.setSharedProjects(new ArrayList<>(mergedProjects));
+                webProjectsChanged = current == null || !new LinkedHashSet<>(current).equals(webMerged);
+                if (webProjectsChanged) {
+                    webSharedOR.setSharedProjects(
+                        new ArrayList<>(webMerged)
+                    );
                 }
             }
-            List<String> mExisting = (mobileSharedOR != null) ? mobileSharedOR.getSharedProjects() : List.of();
-            LinkedHashSet<String> mMerged = new LinkedHashSet<>();
-            if (mExisting != null) mMerged.addAll(mExisting);
-            mMerged.addAll(sharedUsageProjects);
-            boolean mProjectsChanged = false;
+            
+            boolean mobileProjectsChanged = false;
             if (mobileSharedOR != null) {
-                List<String> mCurrent = mobileSharedOR.getSharedProjects();
-                mProjectsChanged = mCurrent == null
-                        || !new LinkedHashSet<>(mCurrent).equals(mMerged);
-                if (mProjectsChanged) {
-                    mobileSharedOR.setSharedProjects(new ArrayList<>(mMerged));
+                LinkedHashSet<String> mobileMerged = new LinkedHashSet<>();
+                mobileMerged.addAll(mobileSharedProjectsFromXml);
+                mobileMerged.addAll(mobileSharedUsageProjects);
+                File sharedRoot = new File(getSharedORRepLocation());
+                File mobileMetaFile = new File(sharedRoot, "mobileor-projectsdata.yaml");
+                mobileMerged.addAll(yamlWriter.readExistingProjects(mobileMetaFile));
+                List<String> current = mobileSharedOR.getSharedProjects();
+                mobileProjectsChanged = current == null || !new LinkedHashSet<>(current).equals(mobileMerged);
+                if (mobileProjectsChanged) {
+                    mobileSharedOR.setSharedProjects(
+                        new ArrayList<>(mobileMerged)
+                    );
                 }
             }
+
             if (useYamlFormat) {
-                if (webSharedOR != null && (!webSharedOR.isSaved() || projectsChanged)) {
-                    yamlWriter.writeWebOR(webSharedOR,new File(getSharedORRepLocation()) );
+                File sharedRoot = new File(getSharedORRepLocation());
+                if (webSharedOR != null && (!webSharedOR.isSaved() || webProjectsChanged)) {
+                    yamlWriter.writeWebOR(webSharedOR, sharedRoot);
+                    if (webSharedOR.getSharedProjects() != null &&
+                        !webSharedOR.getSharedProjects().isEmpty()) {
+                        yamlWriter.writeSharedMetadata(webSharedOR,sharedRoot);
+                    }
                     webSharedOR.setSaved(true);
                 }
-                if (mobileSharedOR != null && (!mobileSharedOR.isSaved() || mProjectsChanged)) {
-                    yamlWriter.writeMobileOR(mobileSharedOR,new File(getSharedORRepLocation()));
+
+                if (mobileSharedOR != null && (!mobileSharedOR.isSaved() || mobileProjectsChanged)) {
+                    yamlWriter.writeMobileOR(mobileSharedOR, sharedRoot);
+                    if (mobileSharedOR.getSharedProjects() != null &&
+                        !mobileSharedOR.getSharedProjects().isEmpty()) {
+                        yamlWriter.writeSharedMetadata(mobileSharedOR,sharedRoot);
+                    }
                     mobileSharedOR.setSaved(true);
                 }
                 saveAsYaml();
                 LOG.info("Saved Shared and Project ORs in YAML format");
             }
         } catch (IOException ex) {
-            Logger.getLogger(ObjectRepository.class.getName()).log(Level.SEVERE, "Failed to save Object Repository", ex);
+            Logger.getLogger(ObjectRepository.class.getName())
+                  .log(Level.SEVERE, "Failed to save Object Repository", ex);
         }
     }
 
@@ -442,6 +453,14 @@ public class ObjectRepository {
            mobileSharedOR.setScope(MobileOR.ORScope.SHARED);
            LOG.info("Loaded SHARED Mobile XML OR");
        }
+
+       if (webSharedOR != null && webSharedOR.getSharedProjects() != null) {
+            webSharedProjectsFromXml = new ArrayList<>(webSharedOR.getSharedProjects());
+        }
+
+        if (mobileSharedOR != null && mobileSharedOR.getSharedProjects() != null) {
+            mobileSharedProjectsFromXml = new ArrayList<>(mobileSharedOR.getSharedProjects());
+        }
    }
 
    private void normalizeWebOR(WebOR webOR) {
@@ -541,7 +560,7 @@ public class ObjectRepository {
 
         } else if (inShared && webSharedOR != null) {
             webSharedOR.setSaved(false);
-            markSharedUsage();
+            markSharedUsage("WebOR");
             sProject.refactorObjectName(
                 WebOR.ORScope.SHARED,
                 parentPage.getName(),
@@ -697,7 +716,7 @@ public class ObjectRepository {
         if (pageRef.scope == WebOR.ORScope.SHARED) {
             var g = getFrom(webSharedOR, pageRef.name, objectName);
             if (g != null) {
-                markSharedUsage();
+                markSharedUsage("WebOR");
                 String actualPageName = g.getParent() != null ? g.getParent().getName() : pageRef.name;
                 return new ResolvedWebObject(WebOR.ORScope.SHARED, actualPageName, objectName, g);
             }
@@ -710,7 +729,7 @@ public class ObjectRepository {
         }
         var shared = getFrom(webSharedOR, pageRef.name, objectName);
         if (shared != null) {
-            markSharedUsage();
+            markSharedUsage("WebOR");
             String actualPageName = shared.getParent() != null ? shared.getParent().getName() : pageRef.name;
             return new ResolvedWebObject(WebOR.ORScope.SHARED, actualPageName, objectName, shared);
         }
@@ -730,7 +749,7 @@ public class ObjectRepository {
        if (pageRef.scope == ORScope.SHARED) {
            var g = getFrom(mobileSharedOR, pageRef.name, objectName);
            if (g != null) {
-               markSharedUsage();
+               markSharedUsage("MobileOR");
                String actualPageName = g.getParent() != null ? g.getParent().getName() : pageRef.name;
                return new ResolvedMobileObject(ORScope.SHARED, actualPageName, objectName, g);
            }
@@ -754,7 +773,7 @@ public class ObjectRepository {
         }
         var shared = getFrom(webSharedOR, pageName, objectName);
         if (shared != null) {
-            markSharedUsage();
+            markSharedUsage("MobileOR");
             String actualPageName = shared.getParent() != null ? shared.getParent().getName() : pageName;
             return new ResolvedWebObject(ORScope.SHARED, actualPageName, objectName, shared);
         }
@@ -797,7 +816,7 @@ public class ObjectRepository {
        }
        var shared = getFrom(mobileSharedOR, pageName, objectName);
        if (shared != null) {
-           markSharedUsage();
+           markSharedUsage("MobileOR");
            String actualPageName = shared.getParent() != null ? shared.getParent().getName() : pageName;
            return new ResolvedMobileObject(ORScope.SHARED, actualPageName, objectName, shared);
        }
@@ -1035,9 +1054,15 @@ public class ObjectRepository {
      * Marks that the current project has used a shared object,
      * updating shared OR metadata.
      */
-    private void markSharedUsage() {
-        if (sProject != null && sProject.getName() != null && !sProject.getName().isBlank()) {
-            sharedUsageProjects.add(sProject.getName());
+    private void markSharedUsage(String orType) {
+        if (sProject == null || sProject.getName() == null) {
+            return;
+        }
+
+        if ("WebOR".equals(orType)) {
+            webSharedUsageProjects.add(sProject.getName());
+        } else if ("MobileOR".equals(orType)) {
+            mobileSharedUsageProjects.add(sProject.getName());
         }
     }
 

--- a/Datalib/src/main/java/com/ing/datalib/or/ObjectRepository.java
+++ b/Datalib/src/main/java/com/ing/datalib/or/ObjectRepository.java
@@ -83,22 +83,32 @@ public class ObjectRepository {
         try {
             yamlReader = new YamlORReader();
             yamlWriter = new YamlORWriter();
-            boolean xmlExists  = hasAnyXmlOR();
+
             boolean yamlExists = hasYamlOR();
-            LOG.info("OR init: xmlExists=" + xmlExists + ", yamlExists=" + yamlExists);
-            
-            if (xmlExists && !yamlExists) {
-                LOG.info("Legacy XML detected. Loading XML for migration...");
+            boolean xmlExists = hasAnyXmlOR();
+
+            LOG.info(() -> "OR init: xmlExists=" + xmlExists + ", yamlExists=" + yamlExists);
+
+            if (yamlExists) {
+                loadYamlObjectRepositories();
+                useYamlFormat = true;
+
+            } else if (xmlExists) {
                 loadXmlObjectRepositories();
                 convertXmlOrsToYamlAndArchive();
-                LOG.info("Loading YAML after migration");
                 loadYamlObjectRepositories();
                 useYamlFormat = true;
-            }
-            else {
-                LOG.info("YAML detected. Loading YAML only...");
-                loadYamlObjectRepositories();
-                useYamlFormat = true;
+
+            } else {
+            webProjectOR = new WebOR();
+            webProjectOR.setScope(WebOR.ORScope.PROJECT);
+            webProjectOR.setObjectRepository(this);
+            mobileProjectOR = new MobileOR();
+            mobileProjectOR.setScope(MobileOR.ORScope.PROJECT);
+            mobileProjectOR.setObjectRepository(this);
+            apiProjectOR = new APIOR();
+            apiProjectOR.setObjectRepository(this);
+            useYamlFormat = true;
             }
 
         } catch (Exception e) {
@@ -175,101 +185,95 @@ public class ObjectRepository {
      */
     public void save() {
         try {
-            List<String> existingProjects = (webSharedOR != null) ? webSharedOR.getSharedProjects() : java.util.List.of();
+            List<String> existingProjects = (webSharedOR != null) ? webSharedOR.getSharedProjects() : List.of();
             LinkedHashSet<String> mergedProjects = new LinkedHashSet<>();
             if (existingProjects != null) mergedProjects.addAll(existingProjects);
             mergedProjects.addAll(sharedUsageProjects);
+
             boolean projectsChanged = false;
             if (webSharedOR != null) {
-                ArrayList<String> mergedList = new ArrayList<>(mergedProjects);
                 List<String> current = webSharedOR.getSharedProjects();
-                projectsChanged = (current == null) || !new LinkedHashSet<>(current).equals(mergedProjects);
+                projectsChanged = current == null
+                        || !new LinkedHashSet<>(current).equals(mergedProjects);
                 if (projectsChanged) {
-                    webSharedOR.setSharedProjects(mergedList);
+                    webSharedOR.setSharedProjects(new ArrayList<>(mergedProjects));
                 }
             }
-            List<String> mExisting = (mobileSharedOR != null) ? mobileSharedOR.getSharedProjects() : java.util.List.of();
+
+            List<String> mExisting = (mobileSharedOR != null) ? mobileSharedOR.getSharedProjects() : List.of();
             LinkedHashSet<String> mMerged = new LinkedHashSet<>();
             if (mExisting != null) mMerged.addAll(mExisting);
             mMerged.addAll(sharedUsageProjects);
+
             boolean mProjectsChanged = false;
             if (mobileSharedOR != null) {
-                ArrayList<String> mList = new ArrayList<>(mMerged);
                 List<String> mCurrent = mobileSharedOR.getSharedProjects();
-                mProjectsChanged = (mCurrent == null) || !new LinkedHashSet<>(mCurrent).equals(mMerged);
+                mProjectsChanged = mCurrent == null
+                        || !new LinkedHashSet<>(mCurrent).equals(mMerged);
                 if (mProjectsChanged) {
-                    mobileSharedOR.setSharedProjects(mList);
+                    mobileSharedOR.setSharedProjects(new ArrayList<>(mMerged));
                 }
             }
             
-            // === SHARED ORs (always XML) ===
+            if (useYamlFormat) {
+                if (webSharedOR != null && (!webSharedOR.isSaved() || projectsChanged)) {
+                    yamlWriter.writeWebOR(webSharedOR,new File(getSharedORRepLocation()) );
+                    webSharedOR.setSaved(true);
+                }
+                if (mobileSharedOR != null && (!mobileSharedOR.isSaved() || mProjectsChanged)) {
+                    yamlWriter.writeMobileOR(mobileSharedOR,new File(getSharedORRepLocation()));
+                    mobileSharedOR.setSaved(true);
+                }
+                saveAsYaml();
+                LOG.info("Saved Shared and Project ORs in YAML format");
+                return;
+
+            }
+
             if (webSharedOR != null && (!webSharedOR.isSaved() || projectsChanged)) {
                 File sharedORFile = new File(getSharedORLocation());
                 sharedORFile.getParentFile().mkdirs();
-                XML_MAPPER.writerWithDefaultPrettyPrinter()
-                    .writeValue(sharedORFile, webSharedOR);
+                XML_MAPPER.writerWithDefaultPrettyPrinter().writeValue(sharedORFile, webSharedOR);
                 webSharedOR.setSaved(true);
             }
             if (mobileSharedOR != null && (!mobileSharedOR.isSaved() || mProjectsChanged)) {
                 File sharedMORFile = new File(getSharedMORLocation());
                 sharedMORFile.getParentFile().mkdirs();
-                XML_MAPPER.writerWithDefaultPrettyPrinter()
-                        .writeValue(sharedMORFile, mobileSharedOR);
+                XML_MAPPER.writerWithDefaultPrettyPrinter().writeValue(sharedMORFile, mobileSharedOR);
                 mobileSharedOR.setSaved(true);
             }
-            
-            // === PROJECT ORs (YAML or XML based on format) ===
-            if (useYamlFormat) {
-                // Save in YAML format
-                if (webProjectOR != null && !webProjectOR.isSaved()) {
-                    File orRepLocation = new File(getORRepLocation());
-                    yamlWriter.writeWebOR(webProjectOR, orRepLocation);
-                    webProjectOR.setSaved(true);
-                }
-                if (mobileProjectOR != null && !mobileProjectOR.isSaved()) {
-                    File morRepLocation = new File(getMORRepLocation());
-                    yamlWriter.writeMobileOR(mobileProjectOR, morRepLocation);
-                    mobileProjectOR.setSaved(true);
-                }
-                if (apiProjectOR != null && !apiProjectOR.isSaved()) {
-                    File apiorRepLocation = new File(getAPIORRepLocation());
-                    yamlWriter.writeAPIOR(apiProjectOR, apiorRepLocation);
-                    apiProjectOR.setSaved(true);
-                }
-                LOG.info("Saved project ORs in YAML format");
-            } else {
-                // Save in XML format (legacy)
-                if (webProjectOR != null && !webProjectOR.isSaved()) {
-                    File orFile = new File(getORLocation());
-                    orFile.getParentFile().mkdirs();
-                    XML_MAPPER.writerWithDefaultPrettyPrinter()
-                        .writeValue(orFile, webProjectOR);
-                    webProjectOR.setSaved(true);
-                }
-                if (mobileProjectOR != null && !mobileProjectOR.isSaved()) {
-                    File morFile = new File(getMORLocation());
-                    morFile.getParentFile().mkdirs();
-                    XML_MAPPER.writerWithDefaultPrettyPrinter()
-                            .writeValue(morFile, mobileProjectOR);
-                    mobileProjectOR.setSaved(true);
-                }
-                if (apiProjectOR != null && !apiProjectOR.isSaved()) {
-                    File apiorFile = new File(getAPIORLocation());
-                    apiorFile.getParentFile().mkdirs();
-                    XML_MAPPER.writerWithDefaultPrettyPrinter()
-                            .writeValue(apiorFile, apiProjectOR);
-                    apiProjectOR.setSaved(true);
-                }
-                LOG.info("Saved project ORs in XML format");
+
+            if (webProjectOR != null && !webProjectOR.isSaved()) {
+                File orFile = new File(getORLocation());
+                orFile.getParentFile().mkdirs();
+                XML_MAPPER.writerWithDefaultPrettyPrinter().writeValue(orFile, webProjectOR);
+                webProjectOR.setSaved(true);
             }
+
+            if (mobileProjectOR != null && !mobileProjectOR.isSaved()) {
+                File morFile = new File(getMORLocation());
+                morFile.getParentFile().mkdirs();
+                XML_MAPPER.writerWithDefaultPrettyPrinter().writeValue(morFile, mobileProjectOR);
+                mobileProjectOR.setSaved(true);
+            }
+
+            if (apiProjectOR != null && !apiProjectOR.isSaved()) {
+                File apiFile = new File(getAPIORLocation());
+                apiFile.getParentFile().mkdirs();
+                XML_MAPPER.writerWithDefaultPrettyPrinter().writeValue(apiFile, apiProjectOR);
+                apiProjectOR.setSaved(true);
+            }
+            LOG.info("Saved ORs in legacy XML format");
+
         } catch (IOException ex) {
-            Logger.getLogger(ObjectRepository.class.getName()).log(Level.SEVERE, null, ex);
+            Logger.getLogger(ObjectRepository.class.getName())
+                    .log(Level.SEVERE, "Failed to save Object Repository", ex);
         }
     }
     
     /**
      * Save Object Repository in YAML format.
-     * Creates page-per-file structure under ObjectRepository/Web/pages/, ObjectRepository/Mobile/pages/, and ObjectRepository/API/pages/
+     * Creates page-per-file structure under ObjectRepository/Web/, ObjectRepository/Mobile/, and ObjectRepository/API/
      */
     public void saveAsYaml() {
         try {
@@ -298,8 +302,8 @@ public class ObjectRepository {
     }
 
     private boolean hasYamlOR() {
-        File webPages = new File(getORRepLocation(), "Web/pages");
-        File mobilePages = new File(getORRepLocation(), "Mobile/pages");
+        File webPages = new File(getORRepLocation(), "Web");
+        File mobilePages = new File(getORRepLocation(), "Mobile");
         return (webPages.exists() && webPages.isDirectory()) || (mobilePages.exists() && mobilePages.isDirectory());
     }
     
@@ -310,7 +314,6 @@ public class ObjectRepository {
         File projectYamlRoot = new File(getORRepLocation());
         File sharedYamlRoot  = new File(getSharedORRepLocation());
 
-        // Convert Web + Mobile only
         converter.convertAll(
             webProjectOR,
             webSharedOR,
@@ -320,7 +323,6 @@ public class ObjectRepository {
             sharedYamlRoot
         );
 
-        // Archive XML files
         archiveProjectXmlORs();
         archiveSharedXmlORs();
         cleanupLegacySharedXmlFolders();
@@ -349,9 +351,9 @@ public class ObjectRepository {
         if (!xmlFile.exists()) return;
         File bakFile = new File(targetDir, xmlFile.getName() + ".bak");
         if (xmlFile.renameTo(bakFile)) {
-            LOG.info("Archived XML OR: " + bakFile.getAbsolutePath());
+            LOG.info(() -> "Archived XML OR: " + bakFile.getAbsolutePath());
         } else {
-            LOG.warning("Failed to archive XML OR: " + xmlFile.getAbsolutePath());
+            LOG.warning(() -> "Failed to archive XML OR: " + xmlFile.getAbsolutePath());
         }
     }
 
@@ -371,9 +373,9 @@ public class ObjectRepository {
         }
         boolean deleted = dir.delete();
         if (deleted) {
-            LOG.info("Deleted legacy XML directory: " + dir.getAbsolutePath());
+            LOG.info(() -> "Deleted legacy XML directory: " + dir.getAbsolutePath());
         } else {
-            LOG.warning("Failed to delete legacy XML directory: " + dir.getAbsolutePath());
+            LOG.warning(() -> "Failed to delete legacy XML directory: " + dir.getAbsolutePath());
         }
     }
 
@@ -403,10 +405,7 @@ public class ObjectRepository {
     * It must NOT be called once YAML ORs exist.
     */
    private void loadXmlObjectRepositories() throws IOException {
-
        LOG.info("Loading legacy XML Object Repositories for migration...");
-
-       // PROJECT XML ORs
        File projectWebXml = new File(getORLocation());
        if (projectWebXml.exists()) {
            webProjectOR = XML_MAPPER.readValue(projectWebXml, WebOR.class);
@@ -421,7 +420,6 @@ public class ObjectRepository {
            LOG.info("Loaded PROJECT Mobile XML OR");
        }
 
-       // SHARED XML ORs
        File sharedWebXml = new File(getSharedORLocation());
        if (sharedWebXml.exists()) {
            webSharedOR = XML_MAPPER.readValue(sharedWebXml, WebOR.class);
@@ -438,7 +436,6 @@ public class ObjectRepository {
            LOG.info("Loaded SHARED Mobile XML OR");
        }
    }
-
 
     /**
      * Checks whether the given object exists in either PROJECT or SHARED scope.
@@ -468,19 +465,46 @@ public class ObjectRepository {
         if (parentPage == null) return;
         String oldName = group.getName();
         if (oldName.equals(newName)) return;
-        boolean inProject = (webProjectOR != null) &&
-            (webProjectOR.getPageByName(parentPage.getName()) == parentPage);
-        boolean inShared  = !inProject && (webSharedOR != null) &&
-            (webSharedOR.getPageByName(parentPage.getName()) == parentPage);
+        boolean inProject = (webProjectOR != null) && (webProjectOR.getPageByName(parentPage.getName()) == parentPage);
+        boolean inShared = !inProject && (webSharedOR != null) && (webSharedOR.getPageByName(parentPage.getName()) == parentPage);
+
         if (inProject && webProjectOR != null) {
             webProjectOR.setSaved(false);
-            sProject.refactorObjectName(WebOR.ORScope.PROJECT, parentPage.getName(), oldName, newName);
+            sProject.refactorObjectName(
+                WebOR.ORScope.PROJECT,
+                parentPage.getName(),
+                oldName,
+                newName
+            );
+
+            if (useYamlFormat) {
+                saveWebPageNow((WebORPage) parentPage);
+            }
+
         } else if (inShared && webSharedOR != null) {
             webSharedOR.setSaved(false);
             markSharedUsage();
-            sProject.refactorObjectName(WebOR.ORScope.SHARED, parentPage.getName(), oldName, newName);
+            sProject.refactorObjectName(
+                WebOR.ORScope.SHARED,
+                parentPage.getName(),
+                oldName,
+                newName
+            );
+
+            if (useYamlFormat) {
+                saveWebPageNow((WebORPage) parentPage);
+            }
+
         } else {
-            sProject.refactorObjectName(parentPage.getName(), oldName, newName);
+            sProject.refactorObjectName(
+                parentPage.getName(),
+                oldName,
+                newName
+            );
+
+            if (useYamlFormat) {
+                saveWebPageNow((WebORPage) parentPage);
+            }
         }
     }
     
@@ -493,10 +517,13 @@ public class ObjectRepository {
      */
     public void renamePage(ORPageInf page, String newName) {
         if (page == null || newName == null || newName.isBlank()) return;
+
         String oldName = page.getName();
         if (oldName.equals(newName)) return;
+
         boolean renamed = false;
         ORScope scopeRenamed = null;
+
         if (webProjectOR != null) {
             var p = webProjectOR.getPageByName(oldName);
             if (p == page) {
@@ -508,8 +535,13 @@ public class ObjectRepository {
                 webProjectOR.setSaved(false);
                 renamed = true;
                 scopeRenamed = ORScope.PROJECT;
+
+                if (useYamlFormat) {
+                    renameWebPageYaml(oldName, newName, scopeRenamed);
+                }
             }
         }
+
         if (!renamed && webSharedOR != null) {
             var s = webSharedOR.getPageByName(oldName);
             if (s == page) {
@@ -521,8 +553,13 @@ public class ObjectRepository {
                 webSharedOR.setSaved(false);
                 renamed = true;
                 scopeRenamed = ORScope.SHARED;
+
+                if (useYamlFormat) {
+                    renameWebPageYaml(oldName, newName, scopeRenamed);
+                }
             }
         }
+
         if (renamed) {
             sProject.refactorPageName(scopeRenamed, oldName, newName);
         } else {
@@ -530,38 +567,55 @@ public class ObjectRepository {
         }
     }
 
-    public void renamePage(com.ing.datalib.or.mobile.MobileORPage page, String newName) {
+    public void renamePage(MobileORPage page, String newName) {
         if (page == null || newName == null || newName.isBlank()) return;
+
         String oldName = page.getName();
         if (oldName.equals(newName)) return;
+
         boolean renamed = false;
-        com.ing.datalib.or.mobile.MobileOR.ORScope mScope = null;
+        MobileOR.ORScope mScope = null;
+
         if (mobileProjectOR != null) {
             var p = mobileProjectOR.getPageByName(oldName);
             if (p == page) {
                 var existsSameScope = mobileProjectOR.getPageByName(newName);
                 if (existsSameScope != null && existsSameScope != page) return;
+
                 p.setName(newName);
                 mobileProjectOR.setSaved(false);
                 renamed = true;
-                mScope = com.ing.datalib.or.mobile.MobileOR.ORScope.PROJECT;
+                mScope = MobileOR.ORScope.PROJECT;
+
+                if (useYamlFormat) {
+                    renameMobilePageYaml(oldName, newName, mScope);
+                }
             }
         }
+
         if (!renamed && mobileSharedOR != null) {
             var s = mobileSharedOR.getPageByName(oldName);
             if (s == page) {
                 var existsSameScope = mobileSharedOR.getPageByName(newName);
                 if (existsSameScope != null && existsSameScope != page) return;
+
                 s.setName(newName);
                 mobileSharedOR.setSaved(false);
                 renamed = true;
-                mScope = com.ing.datalib.or.mobile.MobileOR.ORScope.SHARED;
+                mScope = MobileOR.ORScope.SHARED;
+
+                if (useYamlFormat) {
+                    renameMobilePageYaml(oldName, newName, mScope);
+                }
             }
         }
+
         if (renamed) {
-            var webLikeScope = (mScope == com.ing.datalib.or.mobile.MobileOR.ORScope.PROJECT)
-                    ? com.ing.datalib.or.web.WebOR.ORScope.PROJECT
-                    : com.ing.datalib.or.web.WebOR.ORScope.SHARED;
+            var webLikeScope =
+                (mScope == MobileOR.ORScope.PROJECT)
+                    ? WebOR.ORScope.PROJECT
+                    : WebOR.ORScope.SHARED;
+
             sProject.refactorPageName(webLikeScope, oldName, newName);
         } else {
             sProject.refactorPageName(oldName, newName);
@@ -776,6 +830,9 @@ public class ObjectRepository {
         WebORPage targetPage = getOrCreatePage(sharedOR, uniqueTargetName);
         copyAllGroups(sourcePage, targetPage);
         sharedOR.setSaved(false);
+        if (useYamlFormat) {
+            saveWebPageNow(targetPage);
+        }
         LOG.info(() -> "Copied Web Page '" + sourcePageName + "' to SHARED page '" + uniqueTargetName + "' successfully.");
         return uniqueTargetName;
     }
@@ -801,6 +858,9 @@ public class ObjectRepository {
         ObjectGroup<WebORObject> newGroup = cloneGroupIntoPage(originalGroup, targetPage, uniqueName);
         targetPage.getObjectGroups().add(newGroup);
         sharedOR.setSaved(false);
+        if (useYamlFormat) {
+            saveWebPageNow(targetPage);
+        }
         LOG.info(() -> "Copied Web Object '" + baseName + "' to SHARED as '" + uniqueName + "'");
         return uniqueName;
     }
@@ -821,8 +881,10 @@ public class ObjectRepository {
         MobileORPage targetPage = getOrCreateMobilePage(sharedMOR, uniqueTargetName);
         copyAllMobileGroups(sourcePage, targetPage);
         sharedMOR.setSaved(false);
-        LOG.info(() -> "Copied Mobile Page '" + sourcePageName
-                + "' to SHARED page '" + uniqueTargetName + "' successfully.");
+        if (useYamlFormat) {
+            saveMobilePageNow(targetPage);
+        }
+        LOG.info(() -> "Copied Mobile Page '" + sourcePageName + "' to SHARED page '" + uniqueTargetName + "' successfully.");
         return uniqueTargetName;
     }
 
@@ -846,6 +908,9 @@ public class ObjectRepository {
         ObjectGroup<MobileORObject> newGroup = cloneMobileGroupIntoPage(originalGroup, targetPage, uniqueName);
         targetPage.getObjectGroups().add(newGroup);
         sharedMOR.setSaved(false);
+        if (useYamlFormat) {
+            saveMobilePageNow(targetPage);
+        }
         LOG.info(() -> "Copied Mobile Object '" + baseName + "' to SHARED as '" + uniqueName + "'");
         return uniqueName;
     }
@@ -896,9 +961,6 @@ public class ObjectRepository {
             sharedUsageProjects.add(sProject.getName());
         }
     }
-    
-    // ============ YAML-related stub methods for backward compatibility ============
-    // These methods are placeholders for future YAML OR support integration
 
     /**
      * Check if using YAML format.
@@ -927,19 +989,22 @@ public class ObjectRepository {
      * @param page the page to save
      */
     public void saveWebPageNow(WebORPage page) {
-        if (useYamlFormat && yamlWriter != null) {
-            try {
-                File orRepLocation = new File(getORRepLocation());
-                File webPagesDir = new File(orRepLocation, "Web/pages");
-                if (!webPagesDir.exists()) {
-                    webPagesDir.mkdirs();
-                }
-                yamlWriter.writeWebPage(page, webPagesDir);
-            } catch (IOException e) {
-                LOG.log(Level.SEVERE, "Failed to save Web page: " + page.getName(), e);
+        if (!useYamlFormat || yamlWriter == null || page == null) return;
+        try {
+            File orRepLocation = new File(getORRepLocation());
+            File webPagesDir = new File(orRepLocation, "Web");
+            webPagesDir.mkdirs();
+            yamlWriter.writeWebPage(page, webPagesDir);
+            if (page.getRoot() != null) {
+                page.getRoot().setSaved(true);
             }
+
+        } catch (IOException e) {
+            LOG.log(Level.SEVERE,
+                "Failed to save Web page: " + page.getName(),
+                e
+            );
         }
-        // XML format doesn't need per-page saves
     }
     
     /**
@@ -949,17 +1014,23 @@ public class ObjectRepository {
      * @param page the page to save
      */
     public void saveMobilePageNow(MobileORPage page) {
-        if (useYamlFormat && yamlWriter != null) {
-            try {
-                File morRepLocation = new File(getMORRepLocation());
-                File mobilePagesDir = new File(morRepLocation, "Mobile/pages");
-                if (!mobilePagesDir.exists()) {
-                    mobilePagesDir.mkdirs();
-                }
-                yamlWriter.writeMobilePage(page, mobilePagesDir);
-            } catch (IOException e) {
-                LOG.log(Level.SEVERE, "Failed to save Mobile page: " + page.getName(), e);
+        if (!useYamlFormat || yamlWriter == null || page == null) return;
+        try {
+            File morRepLocation = new File(getORRepLocation());
+            File mobilePagesDir = new File(morRepLocation, "Mobile");
+            if (!mobilePagesDir.exists()) {
+                mobilePagesDir.mkdirs();
             }
+            yamlWriter.writeMobilePage(page, mobilePagesDir);
+            if (page.getRoot() != null) {
+                page.getRoot().setSaved(true);
+            }
+
+        } catch (IOException e) {
+            LOG.log(Level.SEVERE,
+                "Failed to save Mobile page: " + page.getName(),
+                e
+            );
         }
         // XML format doesn't need per-page saves
     }
@@ -973,12 +1044,15 @@ public class ObjectRepository {
     public void saveAPIPageNow(com.ing.datalib.or.api.APIORPage page) {
         if (useYamlFormat && yamlWriter != null) {
             try {
-                File apiorRepLocation = new File(getAPIORRepLocation());
-                File apiPagesDir = new File(apiorRepLocation, "API/pages");
+                File apiorRepLocation = new File(getORRepLocation());
+                File apiPagesDir = new File(apiorRepLocation, "API");
                 if (!apiPagesDir.exists()) {
                     apiPagesDir.mkdirs();
                 }
                 yamlWriter.writeAPIPage(page, apiPagesDir);
+                if (page.getRoot() != null) {
+                    page.getRoot().setSaved(true);
+                }
             } catch (IOException e) {
                 LOG.log(Level.SEVERE, "Failed to save API page: " + page.getName(), e);
             }
@@ -993,15 +1067,24 @@ public class ObjectRepository {
      * @param newName new page name
      * @return true if renamed successfully, false otherwise
      */
-    public boolean renameWebPageYaml(String oldName, String newName) {
+    public boolean renameWebPageYaml(String oldName, String newName, WebOR.ORScope scope) {
         if (!useYamlFormat || yamlWriter == null) {
-            return true; // XML mode - no-op
+            return true;
+        }
+        if (oldName == null || newName == null || oldName.equals(newName)) {
+            return true;
         }
         try {
-            File orRepLocation = new File(getORRepLocation());
-            return yamlWriter.renameWebPage(oldName, newName, orRepLocation);
+            File repoRoot =
+                (scope == WebOR.ORScope.SHARED)
+                    ? new File(getSharedORRepLocation())
+                    : new File(getORRepLocation());
+            return yamlWriter.renameWebPage(oldName, newName, repoRoot);
+
         } catch (Exception e) {
-            LOG.log(Level.SEVERE, "Failed to rename Web page from " + oldName + " to " + newName, e);
+            LOG.log(Level.SEVERE,
+                "Failed to rename Web page [" + scope + "] from " +
+                oldName + " to " + newName, e);
             return false;
         }
     }
@@ -1013,12 +1096,18 @@ public class ObjectRepository {
      * @param newName new page name
      * @return true if renamed successfully, false otherwise
      */
-    public boolean renameMobilePageYaml(String oldName, String newName) {
+    public boolean renameMobilePageYaml(String oldName, String newName, MobileOR.ORScope scope) {
         if (!useYamlFormat || yamlWriter == null) {
             return true; // XML mode - no-op
         }
+        if (oldName == null || newName == null || oldName.equals(newName)) {
+            return true;
+        }
         try {
-            File morRepLocation = new File(getMORRepLocation());
+            File morRepLocation =
+                (scope == MobileOR.ORScope.SHARED)
+                    ? new File(getSharedORRepLocation())
+                    : new File(getORRepLocation());
             return yamlWriter.renameMobilePage(oldName, newName, morRepLocation);
         } catch (Exception e) {
             LOG.log(Level.SEVERE, "Failed to rename Mobile page from " + oldName + " to " + newName, e);
@@ -1037,11 +1126,62 @@ public class ObjectRepository {
         if (!useYamlFormat || yamlWriter == null) {
             return true; // XML mode - no-op
         }
+        if (oldName == null || newName == null || oldName.equals(newName)) {
+            return true;
+        }
         try {
-            File apiorRepLocation = new File(getAPIORRepLocation());
+            File apiorRepLocation = new File(getORRepLocation());
             return yamlWriter.renameAPIPage(oldName, newName, apiorRepLocation);
         } catch (Exception e) {
             LOG.log(Level.SEVERE, "Failed to rename API page from " + oldName + " to " + newName, e);
+            return false;
+        }
+    }
+    
+    public boolean deleteWebPageYaml(String pageName) {
+        if (!useYamlFormat || yamlWriter == null) {
+            return true; // XML mode - no-op
+        }
+        if (pageName == null || pageName.isBlank()) {
+            return true;
+        }
+        try {
+            File orRepLocation = new File(getORRepLocation());
+            return yamlWriter.deleteWebPage(pageName, orRepLocation);
+        } catch (Exception e) {
+            LOG.log(Level.SEVERE, "Failed to delete Web page YAML: " + pageName, e);
+            return false;
+        }
+    }
+    
+    public boolean deleteMobilePageYaml(String pageName) {
+        if (!useYamlFormat || yamlWriter == null) {
+            return true; // XML mode - no-op
+        }
+        if (pageName == null || pageName.isBlank()) {
+            return true;
+        }
+        try {
+            File morRepLocation = new File(getORRepLocation());
+            return yamlWriter.deleteMobilePage(pageName, morRepLocation);
+        } catch (Exception e) {
+            LOG.log(Level.SEVERE, "Failed to delete Mobile page YAML: " + pageName, e);
+            return false;
+        }
+    }
+    
+    public boolean deleteAPIPageYaml(String pageName) {
+        if (!useYamlFormat || yamlWriter == null) {
+            return true; // XML mode - no-op
+        }
+        if (pageName == null || pageName.isBlank()) {
+            return true;
+        }
+        try {
+            File apiorRepLocation = new File(getORRepLocation());
+            return yamlWriter.deleteAPIPage(pageName, apiorRepLocation);
+        } catch (Exception e) {
+            LOG.log(Level.SEVERE, "Failed to delete API page YAML: " + pageName, e);
             return false;
         }
     }

--- a/Datalib/src/main/java/com/ing/datalib/or/ObjectRepository.java
+++ b/Datalib/src/main/java/com/ing/datalib/or/ObjectRepository.java
@@ -117,7 +117,18 @@ public class ObjectRepository {
             apiProjectOR.setName(sProject.getName());
             useYamlFormat = true;
             
-            ensureSharedORsExist();
+            if (webSharedOR == null) {
+                webSharedOR = new WebOR("Shared Web Objects");
+                webSharedOR.setScope(WebOR.ORScope.SHARED);
+                webSharedOR.setObjectRepository(this);
+                webSharedOR.setSaved(true);
+            }
+            if (mobileSharedOR == null) {
+                mobileSharedOR = new MobileOR("Shared Mobile Objects");
+                mobileSharedOR.setScope(MobileOR.ORScope.SHARED);
+                mobileSharedOR.setObjectRepository(this);
+                mobileSharedOR.setSaved(true);
+            }
             }
                 
         } catch (Exception e) {
@@ -222,20 +233,6 @@ public class ObjectRepository {
         }
     }
 
-    private void ensureSharedORsExist() {
-        if (webSharedOR == null) {
-            webSharedOR = new WebOR("Shared Web Objects");
-            webSharedOR.setScope(WebOR.ORScope.SHARED);
-            webSharedOR.setObjectRepository(this);
-            webSharedOR.setSaved(true);
-        }
-        if (mobileSharedOR == null) {
-            mobileSharedOR = new MobileOR("Shared Mobile Objects");
-            mobileSharedOR.setScope(MobileOR.ORScope.SHARED);
-            mobileSharedOR.setObjectRepository(this);
-            mobileSharedOR.setSaved(true);
-        }
-    }
     /**
      * Save Object Repository in YAML format.
      * Creates page-per-file structure under ObjectRepository/Web/, ObjectRepository/Mobile/, and ObjectRepository/API/
@@ -376,10 +373,12 @@ public class ObjectRepository {
         webSharedOR = yamlReader.readWebOR(sharedRoot);
         webSharedOR.setObjectRepository(this);
         webSharedOR.setName("Shared Web Objects");
+        webSharedOR.setScope(WebOR.ORScope.SHARED);
         
         mobileSharedOR = yamlReader.readMobileOR(sharedRoot);
         mobileSharedOR.setObjectRepository(this);
         mobileSharedOR.setName("Shared Mobile Objects");
+        mobileSharedOR.setScope(MobileOR.ORScope.SHARED);
         
         normalizeWebOR(webSharedOR);
         normalizeMobileOR(mobileSharedOR);

--- a/Datalib/src/main/java/com/ing/datalib/or/ObjectRepository.java
+++ b/Datalib/src/main/java/com/ing/datalib/or/ObjectRepository.java
@@ -54,6 +54,9 @@ public class ObjectRepository {
     private YamlORReader yamlReader;
     private YamlORWriter yamlWriter;
     
+    // Migration / conversion
+    private boolean xmlConvertedThisSession = false;
+    
     private static ObjectMapper createYamlMapper() {
         YAMLFactory factory = new YAMLFactory();
         factory.disable(YAMLGenerator.Feature.WRITE_DOC_START_MARKER);
@@ -76,198 +79,234 @@ public class ObjectRepository {
      * Loads OR files from disk (shared, project, mobile), updates names, sets scopes,
      * and links them to this repository.
      */
+//    private void init() {
+//        try {
+//            // Initialize YAML support
+//            yamlReader = new YamlORReader();
+//            yamlWriter = new YamlORWriter();
+//            
+//            File orRepLocation = new File(getORRepLocation());
+//            
+//            // Determine format once for PROJECT ORs only
+//            // Check if YAML or XML files exist for project ORs
+//            boolean hasYamlFiles = yamlReader.webORExists(orRepLocation) 
+//                                || yamlReader.mobileORExists(orRepLocation) 
+//                                || yamlReader.apiORExists(orRepLocation);
+//            boolean hasXmlFiles = new File(getORLocation()).exists() 
+//                               || new File(getMORLocation()).exists() 
+//                               || new File(getAPIORLocation()).exists();
+//            
+//            // Set format once for entire project
+//            if (hasYamlFiles) {
+//                useYamlFormat = true;
+//                LOG.info("Using YAML format for project Object Repositories");
+//            } else if (hasXmlFiles) {
+//                useYamlFormat = false;
+//                LOG.info("Using XML format for project Object Repositories (legacy)");
+//            } else {
+//                // New project - default to YAML
+//                useYamlFormat = true;
+//                LOG.info("New project - using YAML format for Object Repositories");
+//            }
+//            
+//            // === SHARED ORs (always XML) ===
+//            File sharedFile = new File(getSharedORLocation());
+//            if (sharedFile.exists()) {
+//                webSharedOR = XML_MAPPER.readValue(sharedFile, WebOR.class);
+//                webSharedOR.setName("Shared Web Objects");
+//            } else {
+//                webSharedOR = new WebOR("Shared Web Objects");
+//            }
+//            
+//            File sharedmorFile = new File(getSharedMORLocation());
+//            if (sharedmorFile.exists()) {
+//                mobileSharedOR = XML_MAPPER.readValue(sharedmorFile, MobileOR.class);
+//                mobileSharedOR.setName("Shared Mobile Objects");
+//            } else {
+//                mobileSharedOR = new MobileOR("Shared Mobile Objects");
+//            }
+//            
+//            // === PROJECT ORs (YAML or XML based on detection) ===
+//            // Load Web Project OR
+//            if (useYamlFormat && yamlReader.webORExists(orRepLocation)) {
+//                webProjectOR = yamlReader.readWebOR(orRepLocation);
+//                webProjectOR.setName(sProject.getName());
+//            } else if (!useYamlFormat && new File(getORLocation()).exists()) {
+//                webProjectOR = XML_MAPPER.readValue(new File(getORLocation()), WebOR.class);
+//                webProjectOR.setName(sProject.getName());
+//            } else {
+//                webProjectOR = new WebOR(sProject.getName());
+//            }
+//            // Set ObjectRepository reference immediately to prevent directory creation
+//            if (webProjectOR != null) {
+//                webProjectOR.setObjectRepository(this);
+//                webProjectOR.setScope(ORScope.PROJECT);
+//            }
+//            
+//            // Load Mobile Project OR
+//            if (useYamlFormat && yamlReader.mobileORExists(orRepLocation)) {
+//                mobileProjectOR = yamlReader.readMobileOR(orRepLocation);
+//                mobileProjectOR.setName(sProject.getName());
+//            } else if (!useYamlFormat && new File(getMORLocation()).exists()) {
+//                mobileProjectOR = XML_MAPPER.readValue(new File(getMORLocation()), MobileOR.class);
+//                mobileProjectOR.setName(sProject.getName());
+//            } else {
+//                mobileProjectOR = new MobileOR(sProject.getName());
+//            }
+//            // Set ObjectRepository reference immediately
+//            if (mobileProjectOR != null) {
+//                mobileProjectOR.setObjectRepository(this);
+//                mobileProjectOR.setScope(MobileOR.ORScope.PROJECT);
+//            }
+//            
+//            // Load API Project OR
+//            if (useYamlFormat && yamlReader.apiORExists(orRepLocation)) {
+//                apiProjectOR = yamlReader.readAPIOR(orRepLocation);
+//                apiProjectOR.setName(sProject.getName());
+//            } else if (!useYamlFormat && new File(getAPIORLocation()).exists()) {
+//                apiProjectOR = XML_MAPPER.readValue(new File(getAPIORLocation()), APIOR.class);
+//                apiProjectOR.setName(sProject.getName());
+//            } else {
+//                apiProjectOR = new APIOR(sProject.getName());
+//            }
+//
+//            // Set ObjectRepository reference immediately
+//            if (apiProjectOR != null) {
+//                apiProjectOR.setObjectRepository(this);
+//            }
+//
+//            // Set remaining properties for shared and project ORs
+//            if (webSharedOR != null) {
+//                webSharedOR.setObjectRepository(this);
+//                webSharedOR.setSaved(true);
+//                webSharedOR.setRepLocationOverride(getSharedORRepLocation());
+//                webSharedOR.setScope(ORScope.SHARED);
+//            }
+//            if (webProjectOR != null) {
+//                webProjectOR.setSaved(true);
+//            }
+//            if (mobileSharedOR != null) {
+//                mobileSharedOR.setObjectRepository(this);
+//                mobileSharedOR.setSaved(true);
+//                mobileSharedOR.setRepLocationOverride(getSharedMORRepLocation());
+//                mobileSharedOR.setScope(MobileOR.ORScope.SHARED);
+//                
+//            }
+//            if (mobileProjectOR != null) {
+//                mobileProjectOR.setSaved(true);
+//            }
+//            if (apiProjectOR != null) {
+//                apiProjectOR.setObjectRepository(this);
+//                apiProjectOR.setSaved(true);
+//            }
+//
+//            LOG.log(Level.INFO, "Shared WebOR loaded: {0}", (webSharedOR != null));
+//            LOG.log(Level.INFO, "Project WebOR loaded: {0}", (webProjectOR != null));
+//            LOG.log(Level.INFO, "Shared MobileOR loaded: {0}", (mobileSharedOR != null));
+//            LOG.log(Level.INFO, "Project MobileOR loaded: {0}", (mobileProjectOR != null));
+//            
+//            // Try YAML format first (modern format)
+//            if (yamlReader.webORExists(orRepLocation)) {
+//                LOG.info("Loading Web OR from YAML format");
+//                webProjectOR = yamlReader.readWebOR(orRepLocation);
+//                webProjectOR.setName(sProject.getName());
+//                useYamlFormat = true;
+//            } else if (new File(getORLocation()).exists()) {
+//                // Fall back to XML format (legacy)
+//                LOG.info("Loading Web OR from XML format");
+//                webProjectOR = XML_MAPPER.readValue(new File(getORLocation()), WebOR.class);
+//                webProjectOR.setName(sProject.getName());
+//                useYamlFormat = false; // Use XML format for legacy projects
+//            } else {
+//                webProjectOR = new WebOR(sProject.getName());
+//                // useYamlFormat stays true for new projects
+//            }
+//            
+//            // Try YAML format first for Mobile OR
+//            if (yamlReader.mobileORExists(orRepLocation)) {
+//                LOG.info("Loading Mobile OR from YAML format");
+//                mobileProjectOR = yamlReader.readMobileOR(orRepLocation);
+//                mobileProjectOR.setName(sProject.getName());
+//                useYamlFormat = true;
+//            } else if (new File(getMORLocation()).exists()) {
+//                // Fall back to XML format (legacy)
+//                LOG.info("Loading Mobile OR from XML format");
+//                mobileProjectOR = XML_MAPPER.readValue(new File(getMORLocation()), MobileOR.class);
+//                mobileProjectOR.setName(sProject.getName());
+//                useYamlFormat = false; // Use XML format for legacy projects
+//            } else {
+//                mobileProjectOR = new MobileOR(sProject.getName());
+//                // useYamlFormat stays true for new projects
+//            }
+//
+//            // Try YAML format first for API OR
+//            if (yamlReader.apiORExists(orRepLocation)) {
+//                LOG.info("Loading API OR from YAML format");
+//                apiProjectOR = yamlReader.readAPIOR(orRepLocation);
+//                apiProjectOR.setName(sProject.getName());
+//                useYamlFormat = true;
+//            } else if (new File(getAPIORLocation()).exists()) {
+//                // Fall back to XML format (legacy)
+//                LOG.info("Loading API OR from XML format");
+//                apiProjectOR = XML_MAPPER.readValue(new File(getAPIORLocation()), APIOR.class);
+//                apiProjectOR.setName(sProject.getName());
+//                useYamlFormat = false; // Use XML format for legacy projects
+//            } else {
+//                apiProjectOR = new APIOR(sProject.getName());
+//                // useYamlFormat stays true for new projects
+//            }
+//
+//            webProjectOR.setObjectRepository(this);
+//            webProjectOR.setSaved(true);
+//            mobileProjectOR.setObjectRepository(this);
+//            apiProjectOR.setObjectRepository(this);
+//        
+//        } catch (IOException ex) {
+//            Logger.getLogger(ObjectRepository.class.getName()).log(Level.SEVERE, null, ex);
+//        }
+//    }
     private void init() {
         try {
-            // Initialize YAML support
             yamlReader = new YamlORReader();
             yamlWriter = new YamlORWriter();
-            
-            File orRepLocation = new File(getORRepLocation());
-            
-            // Determine format once for PROJECT ORs only
-            // Check if YAML or XML files exist for project ORs
-            boolean hasYamlFiles = yamlReader.webORExists(orRepLocation) 
-                                || yamlReader.mobileORExists(orRepLocation) 
-                                || yamlReader.apiORExists(orRepLocation);
-            boolean hasXmlFiles = new File(getORLocation()).exists() 
-                               || new File(getMORLocation()).exists() 
-                               || new File(getAPIORLocation()).exists();
-            
-            // Set format once for entire project
-            if (hasYamlFiles) {
+
+            boolean xmlExists  = hasAnyXmlOR();
+            boolean yamlExists = hasYamlOR();
+
+            LOG.info("OR init: xmlExists=" + xmlExists + ", yamlExists=" + yamlExists);
+
+            // ======================================================
+            // CASE 1: Legacy project → migrate
+            // ======================================================
+            if (xmlExists && !yamlExists) {
+
+                LOG.info("Legacy XML detected. Loading XML for migration...");
+
+                loadXmlObjectRepositories();
+
+                convertXmlOrsToYamlAndArchive();
+
+                LOG.info("Loading YAML after migration");
+                loadYamlObjectRepositories();
+
                 useYamlFormat = true;
-                LOG.info("Using YAML format for project Object Repositories");
-            } else if (hasXmlFiles) {
-                useYamlFormat = false;
-                LOG.info("Using XML format for project Object Repositories (legacy)");
-            } else {
-                // New project - default to YAML
+            }
+            // ======================================================
+            // CASE 2: YAML-first project
+            // ======================================================
+            else {
+                LOG.info("YAML detected. Loading YAML only...");
+                loadYamlObjectRepositories();
                 useYamlFormat = true;
-                LOG.info("New project - using YAML format for Object Repositories");
-            }
-            
-            // === SHARED ORs (always XML) ===
-            File sharedFile = new File(getSharedORLocation());
-            if (sharedFile.exists()) {
-                webSharedOR = XML_MAPPER.readValue(sharedFile, WebOR.class);
-                webSharedOR.setName("Shared Web Objects");
-            } else {
-                webSharedOR = new WebOR("Shared Web Objects");
-            }
-            
-            File sharedmorFile = new File(getSharedMORLocation());
-            if (sharedmorFile.exists()) {
-                mobileSharedOR = XML_MAPPER.readValue(sharedmorFile, MobileOR.class);
-                mobileSharedOR.setName("Shared Mobile Objects");
-            } else {
-                mobileSharedOR = new MobileOR("Shared Mobile Objects");
-            }
-            
-            // === PROJECT ORs (YAML or XML based on detection) ===
-            // Load Web Project OR
-            if (useYamlFormat && yamlReader.webORExists(orRepLocation)) {
-                webProjectOR = yamlReader.readWebOR(orRepLocation);
-                webProjectOR.setName(sProject.getName());
-            } else if (!useYamlFormat && new File(getORLocation()).exists()) {
-                webProjectOR = XML_MAPPER.readValue(new File(getORLocation()), WebOR.class);
-                webProjectOR.setName(sProject.getName());
-            } else {
-                webProjectOR = new WebOR(sProject.getName());
-            }
-            // Set ObjectRepository reference immediately to prevent directory creation
-            if (webProjectOR != null) {
-                webProjectOR.setObjectRepository(this);
-                webProjectOR.setScope(ORScope.PROJECT);
-            }
-            
-            // Load Mobile Project OR
-            if (useYamlFormat && yamlReader.mobileORExists(orRepLocation)) {
-                mobileProjectOR = yamlReader.readMobileOR(orRepLocation);
-                mobileProjectOR.setName(sProject.getName());
-            } else if (!useYamlFormat && new File(getMORLocation()).exists()) {
-                mobileProjectOR = XML_MAPPER.readValue(new File(getMORLocation()), MobileOR.class);
-                mobileProjectOR.setName(sProject.getName());
-            } else {
-                mobileProjectOR = new MobileOR(sProject.getName());
-            }
-            // Set ObjectRepository reference immediately
-            if (mobileProjectOR != null) {
-                mobileProjectOR.setObjectRepository(this);
-                mobileProjectOR.setScope(MobileOR.ORScope.PROJECT);
-            }
-            
-            // Load API Project OR
-            if (useYamlFormat && yamlReader.apiORExists(orRepLocation)) {
-                apiProjectOR = yamlReader.readAPIOR(orRepLocation);
-                apiProjectOR.setName(sProject.getName());
-            } else if (!useYamlFormat && new File(getAPIORLocation()).exists()) {
-                apiProjectOR = XML_MAPPER.readValue(new File(getAPIORLocation()), APIOR.class);
-                apiProjectOR.setName(sProject.getName());
-            } else {
-                apiProjectOR = new APIOR(sProject.getName());
             }
 
-            // Set ObjectRepository reference immediately
-            if (apiProjectOR != null) {
-                apiProjectOR.setObjectRepository(this);
-            }
-
-            // Set remaining properties for shared and project ORs
-            if (webSharedOR != null) {
-                webSharedOR.setObjectRepository(this);
-                webSharedOR.setSaved(true);
-                webSharedOR.setRepLocationOverride(getSharedORRepLocation());
-                webSharedOR.setScope(ORScope.SHARED);
-            }
-            if (webProjectOR != null) {
-                webProjectOR.setSaved(true);
-            }
-            if (mobileSharedOR != null) {
-                mobileSharedOR.setObjectRepository(this);
-                mobileSharedOR.setSaved(true);
-                mobileSharedOR.setRepLocationOverride(getSharedMORRepLocation());
-                mobileSharedOR.setScope(MobileOR.ORScope.SHARED);
-                
-            }
-            if (mobileProjectOR != null) {
-                mobileProjectOR.setSaved(true);
-            }
-            if (apiProjectOR != null) {
-                apiProjectOR.setObjectRepository(this);
-                apiProjectOR.setSaved(true);
-            }
-
-            LOG.log(Level.INFO, "Shared WebOR loaded: {0}", (webSharedOR != null));
-            LOG.log(Level.INFO, "Project WebOR loaded: {0}", (webProjectOR != null));
-            LOG.log(Level.INFO, "Shared MobileOR loaded: {0}", (mobileSharedOR != null));
-            LOG.log(Level.INFO, "Project MobileOR loaded: {0}", (mobileProjectOR != null));
-            
-            // Try YAML format first (modern format)
-            if (yamlReader.webORExists(orRepLocation)) {
-                LOG.info("Loading Web OR from YAML format");
-                webProjectOR = yamlReader.readWebOR(orRepLocation);
-                webProjectOR.setName(sProject.getName());
-                useYamlFormat = true;
-            } else if (new File(getORLocation()).exists()) {
-                // Fall back to XML format (legacy)
-                LOG.info("Loading Web OR from XML format");
-                webProjectOR = XML_MAPPER.readValue(new File(getORLocation()), WebOR.class);
-                webProjectOR.setName(sProject.getName());
-                useYamlFormat = false; // Use XML format for legacy projects
-            } else {
-                webProjectOR = new WebOR(sProject.getName());
-                // useYamlFormat stays true for new projects
-            }
-            
-            // Try YAML format first for Mobile OR
-            if (yamlReader.mobileORExists(orRepLocation)) {
-                LOG.info("Loading Mobile OR from YAML format");
-                mobileProjectOR = yamlReader.readMobileOR(orRepLocation);
-                mobileProjectOR.setName(sProject.getName());
-                useYamlFormat = true;
-            } else if (new File(getMORLocation()).exists()) {
-                // Fall back to XML format (legacy)
-                LOG.info("Loading Mobile OR from XML format");
-                mobileProjectOR = XML_MAPPER.readValue(new File(getMORLocation()), MobileOR.class);
-                mobileProjectOR.setName(sProject.getName());
-                useYamlFormat = false; // Use XML format for legacy projects
-            } else {
-                mobileProjectOR = new MobileOR(sProject.getName());
-                // useYamlFormat stays true for new projects
-            }
-
-            // Try YAML format first for API OR
-            if (yamlReader.apiORExists(orRepLocation)) {
-                LOG.info("Loading API OR from YAML format");
-                apiProjectOR = yamlReader.readAPIOR(orRepLocation);
-                apiProjectOR.setName(sProject.getName());
-                useYamlFormat = true;
-            } else if (new File(getAPIORLocation()).exists()) {
-                // Fall back to XML format (legacy)
-                LOG.info("Loading API OR from XML format");
-                apiProjectOR = XML_MAPPER.readValue(new File(getAPIORLocation()), APIOR.class);
-                apiProjectOR.setName(sProject.getName());
-                useYamlFormat = false; // Use XML format for legacy projects
-            } else {
-                apiProjectOR = new APIOR(sProject.getName());
-                // useYamlFormat stays true for new projects
-            }
-
-            webProjectOR.setObjectRepository(this);
-            webProjectOR.setSaved(true);
-            mobileProjectOR.setObjectRepository(this);
-            apiProjectOR.setObjectRepository(this);
-        
-        } catch (IOException ex) {
-            Logger.getLogger(ObjectRepository.class.getName()).log(Level.SEVERE, null, ex);
+        } catch (Exception e) {
+            LOG.log(Level.SEVERE, "Failed to initialize ObjectRepository", e);
         }
     }
 
     public String getORLocation() {
         return sProject.getLocation() + File.separator + "OR.object";
-    }
-    public String getSharedORLocation() {
-        return "Shared" + File.separator + "SharedWebObjects" + File.separator + "SharedOR.object";
     }
     public String getIORLocation() {
         return sProject.getLocation() + File.separator + "IOR.object";
@@ -278,14 +317,8 @@ public class ObjectRepository {
     public String getAPIORLocation() {
         return sProject.getLocation() + File.separator + "APIOR.object";
     }
-    public String getSharedMORLocation() {
-        return "Shared" + File.separator + "SharedMobileObjects" + File.separator + "SharedMOR.object";
-    }
     public String getORRepLocation() {
         return sProject.getLocation() + File.separator + "ObjectRepository";
-    }
-    public String getSharedORRepLocation() {
-        return "Shared" + File.separator + "SharedWebObjects" + File.separator + "SharedObjectRepository";
     }
     public String getIORRepLocation() {
         return sProject.getLocation() + File.separator + "ImageObjectRepository";
@@ -296,8 +329,17 @@ public class ObjectRepository {
     public String getAPIORRepLocation() {
         return sProject.getLocation() + File.separator + "APIObjectRepository";
     }
+    public String getSharedORLocation() {
+        return "Shared" + File.separator + "SharedWebObjects" + File.separator + "SharedOR.object";
+    }
+    public String getSharedMORLocation() {
+        return "Shared" + File.separator + "SharedMobileObjects" + File.separator + "SharedMOR.object";
+    }
+    public String getSharedORRepLocation() {
+        return "Shared" + File.separator + "SharedObjectRepository";
+    }
     public String getSharedMORRepLocation() {
-        return "Shared" + File.separator + "SharedMobileObjects" + File.separator + "MobileObjectRepository";
+        return "Shared" + File.separator + "SharedMobileObjectRepository";
     }
     public Project getsProject() {
         return sProject;
@@ -455,6 +497,175 @@ public class ObjectRepository {
     public void setUsingYamlFormat(boolean useYaml) {
         this.useYamlFormat = useYaml;
     }
+
+    private boolean hasProjectXmlOR() {
+        return new File(getORLocation()).exists() || new File(getMORLocation()).exists();
+    }
+
+    private boolean hasSharedXmlOR() {
+        return new File(getSharedORLocation()).exists() || new File(getSharedMORLocation()).exists();
+    }
+
+    private boolean hasAnyXmlOR() {
+        return hasProjectXmlOR() || hasSharedXmlOR();
+    }
+
+    private boolean hasYamlOR() {
+        File webPages = new File(getORRepLocation(), "Web/pages");
+        File mobilePages = new File(getORRepLocation(), "Mobile/pages");
+        return (webPages.exists() && webPages.isDirectory()) || (mobilePages.exists() && mobilePages.isDirectory());
+    }
+    
+    private void convertXmlOrsToYamlAndArchive() throws IOException {
+
+        LOG.info("Legacy XML ORs detected. Converting to YAML...");
+
+        XmlToYamlORConverter converter = new XmlToYamlORConverter(yamlWriter);
+
+        File projectYamlRoot = new File(getORRepLocation());
+        File sharedYamlRoot  = new File(getSharedORRepLocation());
+
+        // Convert Web + Mobile only
+        converter.convertAll(
+            webProjectOR,
+            webSharedOR,
+            mobileProjectOR,
+            mobileSharedOR,
+            projectYamlRoot,
+            sharedYamlRoot
+        );
+
+        // Archive XML files
+        archiveProjectXmlORs();
+        archiveSharedXmlORs();
+        cleanupLegacySharedXmlFolders();
+        useYamlFormat = true;
+
+        LOG.info("XML OR migration complete. YAML is now active.");
+    }
+
+    private void archiveProjectXmlORs() {
+        File archiveDir = new File(sProject.getLocation(), "ProjectXMLOR");
+        archiveDir.mkdirs();
+        moveXmlToBak(getORLocation(), archiveDir);
+        moveXmlToBak(getMORLocation(), archiveDir);
+    }
+    
+    private void archiveSharedXmlORs() {
+        File archiveDir = new File("Shared" + File.separator + "SharedXMLOR");
+        archiveDir.mkdirs();
+        moveXmlToBak(getSharedORLocation(), archiveDir);
+        moveXmlToBak(getSharedMORLocation(), archiveDir);
+    }
+    
+    private void moveXmlToBak(String xmlPath, File targetDir) {
+        if (xmlPath == null) return;
+        File xmlFile = new File(xmlPath);
+        if (!xmlFile.exists()) return;
+        File bakFile = new File(targetDir, xmlFile.getName() + ".bak");
+        if (xmlFile.renameTo(bakFile)) {
+            LOG.info("Archived XML OR: " + bakFile.getAbsolutePath());
+        } else {
+            LOG.warning("Failed to archive XML OR: " + xmlFile.getAbsolutePath());
+        }
+    }
+
+    private void deleteDirectoryRecursively(File dir) {
+        if (dir == null || !dir.exists()) {
+            return;
+        }
+
+        File[] contents = dir.listFiles();
+        if (contents != null) {
+            for (File file : contents) {
+                if (file.isDirectory()) {
+                    deleteDirectoryRecursively(file);
+                } else {
+                    file.delete();
+                }
+            }
+        }
+
+        boolean deleted = dir.delete();
+        if (deleted) {
+            LOG.info("Deleted legacy XML directory: " + dir.getAbsolutePath());
+        } else {
+            LOG.warning("Failed to delete legacy XML directory: " + dir.getAbsolutePath());
+        }
+    }
+
+    private void cleanupLegacySharedXmlFolders() {
+
+        File sharedWebXmlDir = new File("Shared" + File.separator + "SharedWebObjects");
+
+        File sharedMobileXmlDir = new File("Shared" + File.separator + "SharedMobileObjects");
+
+        deleteDirectoryRecursively(sharedWebXmlDir);
+        deleteDirectoryRecursively(sharedMobileXmlDir);
+    }
+
+    private void loadYamlObjectRepositories() throws IOException {
+        File orRepRoot = new File(getORRepLocation());
+
+        webProjectOR = yamlReader.readWebOR(orRepRoot);
+        mobileProjectOR = yamlReader.readMobileOR(orRepRoot);
+        apiProjectOR = yamlReader.readAPIOR(orRepRoot);
+
+        // Shared
+        File sharedRoot = new File(getSharedORRepLocation());
+        webSharedOR = yamlReader.readWebOR(sharedRoot);
+        mobileSharedOR = yamlReader.readMobileOR(sharedRoot);
+    }
+
+    /**
+    * Loads legacy XML-based Object Repositories into memory.
+    *
+    * This method is ONLY used during XML → YAML migration.
+    * It must NOT be called once YAML ORs exist.
+    */
+   private void loadXmlObjectRepositories() throws IOException {
+
+       LOG.info("Loading legacy XML Object Repositories for migration...");
+
+       // ========================
+       // PROJECT XML ORs
+       // ========================
+
+       File projectWebXml = new File(getORLocation());
+       if (projectWebXml.exists()) {
+           webProjectOR = XML_MAPPER.readValue(projectWebXml, WebOR.class);
+           webProjectOR.setObjectRepository(this);
+           LOG.info("Loaded PROJECT Web XML OR");
+       }
+
+       File projectMobileXml = new File(getMORLocation());
+       if (projectMobileXml.exists()) {
+           mobileProjectOR = XML_MAPPER.readValue(projectMobileXml, MobileOR.class);
+           mobileProjectOR.setObjectRepository(this);
+           LOG.info("Loaded PROJECT Mobile XML OR");
+       }
+
+       // ========================
+       // SHARED XML ORs
+       // ========================
+
+       File sharedWebXml = new File(getSharedORLocation());
+       if (sharedWebXml.exists()) {
+           webSharedOR = XML_MAPPER.readValue(sharedWebXml, WebOR.class);
+           webSharedOR.setObjectRepository(this);
+           webSharedOR.setScope(WebOR.ORScope.SHARED);
+           LOG.info("Loaded SHARED Web XML OR");
+       }
+
+       File sharedMobileXml = new File(getSharedMORLocation());
+       if (sharedMobileXml.exists()) {
+           mobileSharedOR = XML_MAPPER.readValue(sharedMobileXml, MobileOR.class);
+           mobileSharedOR.setObjectRepository(this);
+           mobileSharedOR.setScope(MobileOR.ORScope.SHARED);
+           LOG.info("Loaded SHARED Mobile XML OR");
+       }
+   }
+
 
     /**
      * Checks whether the given object exists in either PROJECT or SHARED scope.

--- a/Datalib/src/main/java/com/ing/datalib/or/ObjectRepository.java
+++ b/Datalib/src/main/java/com/ing/datalib/or/ObjectRepository.java
@@ -89,16 +89,15 @@ public class ObjectRepository {
             yamlReader = new YamlORReader(this);
             yamlWriter = new YamlORWriter();
 
-            boolean yamlExists = hasYamlOR();
+            boolean projectYamlExists = hasYamlOR();
+            boolean sharedYamlExists  = hasSharedYamlOR();
             boolean xmlExists = hasAnyXmlOR();
 
-            LOG.info(() -> "OR init: xmlExists=" + xmlExists + ", yamlExists=" + yamlExists);
-
-            if (yamlExists) {
+            if (projectYamlExists || sharedYamlExists) {
                 loadYamlObjectRepositories();
                 useYamlFormat = true;
-
-            } else if (xmlExists) {
+            }
+             else if (xmlExists) {
                 loadXmlObjectRepositories();
                 convertXmlOrsToYamlAndArchive();
                 loadYamlObjectRepositories();
@@ -120,13 +119,13 @@ public class ObjectRepository {
             apiProjectOR.setName(sProject.getName());
             useYamlFormat = true;
             
-            if (webSharedOR == null) {
+            if (webSharedOR == null && !sharedYamlExists) {
                 webSharedOR = new WebOR("Shared Web Objects");
                 webSharedOR.setScope(WebOR.ORScope.SHARED);
                 webSharedOR.setObjectRepository(this);
                 webSharedOR.setSaved(true);
             }
-            if (mobileSharedOR == null) {
+            if (mobileSharedOR == null && !sharedYamlExists) {
                 mobileSharedOR = new MobileOR("Shared Mobile Objects");
                 mobileSharedOR.setScope(MobileOR.ORScope.SHARED);
                 mobileSharedOR.setObjectRepository(this);
@@ -271,6 +270,12 @@ public class ObjectRepository {
         File webPages = new File(getORRepLocation(), "Web");
         File mobilePages = new File(getORRepLocation(), "Mobile");
         return (webPages.exists() && webPages.isDirectory()) || (mobilePages.exists() && mobilePages.isDirectory());
+    }
+
+    private boolean hasSharedYamlOR() {
+        File sharedWeb = new File(getSharedORRepLocation(), "Web");
+        File sharedMobile = new File(getSharedORRepLocation(), "Mobile");
+        return (sharedWeb.exists() && sharedWeb.isDirectory()) || (sharedMobile.exists() && sharedMobile.isDirectory());
     }
     
     private void convertXmlOrsToYamlAndArchive() throws IOException {

--- a/Datalib/src/main/java/com/ing/datalib/or/ObjectRepository.java
+++ b/Datalib/src/main/java/com/ing/datalib/or/ObjectRepository.java
@@ -536,16 +536,24 @@ public class ObjectRepository {
      * @param group   object group containing the object
      * @param newName new object name
      */
-    public void renameObject(ObjectGroup<WebORObject> group, String newName) {
+    public void renameObject(ObjectGroup group, String newName) {
         if (group == null || newName == null || newName.isBlank()) return;
+
         var parentPage = group.getParent();
         if (parentPage == null) return;
+
         String oldName = group.getName();
         if (oldName.equals(newName)) return;
-        boolean inProject = (webProjectOR != null) && (webProjectOR.getPageByName(parentPage.getName()) == parentPage);
-        boolean inShared = !inProject && (webSharedOR != null) && (webSharedOR.getPageByName(parentPage.getName()) == parentPage);
 
-        if (inProject && webProjectOR != null) {
+        boolean webProject =
+            webProjectOR != null &&
+            webProjectOR.getPageByName(parentPage.getName()) == parentPage;
+
+        boolean webShared =
+            webSharedOR != null &&
+            webSharedOR.getPageByName(parentPage.getName()) == parentPage;
+
+        if (webProject) {
             webProjectOR.setSaved(false);
             sProject.refactorObjectName(
                 WebOR.ORScope.PROJECT,
@@ -553,12 +561,10 @@ public class ObjectRepository {
                 oldName,
                 newName
             );
+            return;
+        }
 
-            if (useYamlFormat) {
-                saveWebPageNow((WebORPage) parentPage);
-            }
-
-        } else if (inShared && webSharedOR != null) {
+        if (webShared) {
             webSharedOR.setSaved(false);
             markSharedUsage("WebOR");
             sProject.refactorObjectName(
@@ -567,21 +573,37 @@ public class ObjectRepository {
                 oldName,
                 newName
             );
+            return;
+        }
 
-            if (useYamlFormat) {
-                saveWebPageNow((WebORPage) parentPage);
-            }
+        boolean mobileProject =
+            mobileProjectOR != null &&
+            mobileProjectOR.getPageByName(parentPage.getName()) == parentPage;
 
-        } else {
-            sProject.refactorObjectName(
+        boolean mobileShared =
+            mobileSharedOR != null &&
+            mobileSharedOR.getPageByName(parentPage.getName()) == parentPage;
+
+        if (mobileProject) {
+            mobileProjectOR.setSaved(false);
+            sProject.refactorMobileObjectName(
+                MobileOR.ORScope.PROJECT,
                 parentPage.getName(),
                 oldName,
                 newName
             );
+            return;
+        }
 
-            if (useYamlFormat) {
-                saveWebPageNow((WebORPage) parentPage);
-            }
+        if (mobileShared) {
+            mobileSharedOR.setSaved(false);
+            markSharedUsage("MobileOR");
+            sProject.refactorMobileObjectName(
+                MobileOR.ORScope.SHARED,
+                parentPage.getName(),
+                oldName,
+                newName
+            );
         }
     }
     
@@ -703,60 +725,47 @@ public class ObjectRepository {
      * Resolves a WebOR object from a scoped PageRef and object name, returning a
      * ResolvedWebObject containing scope, page, object name, and object group.
      */
-    public ResolvedWebObject resolveWebObject(ResolvedWebObject.PageRef pageRef, String objectName) {
+    public ResolvedWebObject resolveWebObject(ResolvedWebObject.PageRef pageRef,String objectName) {
         if (pageRef == null || objectName == null) return null;
-        if (pageRef.scope == WebOR.ORScope.PROJECT) {
-            var g = getFrom(webProjectOR, pageRef.name, objectName);
-            if (g != null) {
-                String actualPageName = g.getParent() != null ? g.getParent().getName() : pageRef.name;
-                return new ResolvedWebObject(WebOR.ORScope.PROJECT, actualPageName, objectName, g);
-            }
-            return null;
+        if (pageRef.scope != null) {
+            return resolveWebObjectInScope(pageRef.scope,pageRef.name,objectName);
         }
-        if (pageRef.scope == WebOR.ORScope.SHARED) {
-            var g = getFrom(webSharedOR, pageRef.name, objectName);
-            if (g != null) {
-                markSharedUsage("WebOR");
-                String actualPageName = g.getParent() != null ? g.getParent().getName() : pageRef.name;
-                return new ResolvedWebObject(WebOR.ORScope.SHARED, actualPageName, objectName, g);
-            }
-            return null;
-        }
-        var proj = getFrom(webProjectOR, pageRef.name, objectName);
-        if (proj != null) {
-            String actualPageName = proj.getParent() != null ? proj.getParent().getName() : pageRef.name;
-            return new ResolvedWebObject(WebOR.ORScope.PROJECT, actualPageName, objectName, proj);
-        }
-        var shared = getFrom(webSharedOR, pageRef.name, objectName);
-        if (shared != null) {
+        return resolveWebObjectWithScope(pageRef.name, objectName);
+    }
+    
+    private ResolvedWebObject resolveWebObjectInScope(ORScope scope,String pageName,String objectName) {
+        WebOR or = (scope == ORScope.PROJECT) ? webProjectOR : webSharedOR;
+        ObjectGroup g = getFrom(or, pageName, objectName);
+        if (g == null) return null;
+        if (scope == ORScope.SHARED) {
             markSharedUsage("WebOR");
-            String actualPageName = shared.getParent() != null ? shared.getParent().getName() : pageRef.name;
-            return new ResolvedWebObject(WebOR.ORScope.SHARED, actualPageName, objectName, shared);
         }
-        return null;
+        String actualPage = g.getParent() != null ? g.getParent().getName() : pageName;
+        return new ResolvedWebObject(scope, actualPage, objectName, g);
     }
 
-   public ResolvedMobileObject resolveMobileObject(ResolvedMobileObject.PageRef pageRef, String objectName) {
-       if (pageRef == null || objectName == null) return null;
-       if (pageRef.scope == ORScope.PROJECT) {
-           var g = getFrom(mobileProjectOR, pageRef.name, objectName);
-           if (g != null) {
-               String actualPageName = g.getParent() != null ? g.getParent().getName() : pageRef.name;
-               return new ResolvedMobileObject(ORScope.PROJECT, actualPageName, objectName, g);
-           }
-           return null;
-       }
-       if (pageRef.scope == ORScope.SHARED) {
-           var g = getFrom(mobileSharedOR, pageRef.name, objectName);
-           if (g != null) {
-               markSharedUsage("MobileOR");
-               String actualPageName = g.getParent() != null ? g.getParent().getName() : pageRef.name;
-               return new ResolvedMobileObject(ORScope.SHARED, actualPageName, objectName, g);
-           }
-           return null;
-       }
-       return resolveMobileObjectWithScope(pageRef.name, objectName);
-   }
+    public ResolvedMobileObject resolveMobileObject(ResolvedMobileObject.PageRef pageRef,String objectName) {
+        if (pageRef == null || objectName == null) return null;
+        if (pageRef.scope != null) {
+            return resolveMobileObjectInScope(
+                    pageRef.scope,
+                    pageRef.name,
+                    objectName
+            );
+        }
+        return resolveMobileObjectWithScope(pageRef.name, objectName);
+    }
+
+    private ResolvedMobileObject resolveMobileObjectInScope(ORScope scope,String pageName,String objectName) {
+        MobileOR or = (scope == ORScope.PROJECT) ? mobileProjectOR : mobileSharedOR;
+        ObjectGroup g = getFrom(or, pageName, objectName);
+        if (g == null) return null;
+        if (scope == ORScope.SHARED) {
+            markSharedUsage("MobileOR");
+        }
+        String actualPage = g.getParent() != null ? g.getParent().getName() : pageName;
+        return new ResolvedMobileObject(scope, actualPage, objectName, g);
+    }
 
     /**
      * Resolves a WebOR object by searching project scope first, then shared scope.
@@ -765,19 +774,10 @@ public class ObjectRepository {
      * @param objectName object group name
      * @return resolved WebOR object with scope metadata
      */
-    public ResolvedWebObject resolveWebObjectWithScope(String pageName, String objectName) {
-        var proj = getFrom(webProjectOR, pageName, objectName);
-        if (proj != null) {
-            String actualPageName = proj.getParent() != null ? proj.getParent().getName() : pageName;
-            return new ResolvedWebObject(ORScope.PROJECT, actualPageName, objectName, proj);
-        }
-        var shared = getFrom(webSharedOR, pageName, objectName);
-        if (shared != null) {
-            markSharedUsage("MobileOR");
-            String actualPageName = shared.getParent() != null ? shared.getParent().getName() : pageName;
-            return new ResolvedWebObject(ORScope.SHARED, actualPageName, objectName, shared);
-        }
-        return null;
+    public ResolvedWebObject resolveWebObjectWithScope(String pageName,String objectName) {
+        ResolvedWebObject proj = resolveWebObjectInScope(ORScope.PROJECT, pageName, objectName);
+        if (proj != null) return proj;
+        return resolveWebObjectInScope(ORScope.SHARED, pageName, objectName);
     }
 
     public ResolvedWebObject resolveWebObjectWithScope(String pageName, String objectName,TestStep step) {
@@ -785,17 +785,13 @@ public class ObjectRepository {
         if (proj != null) {
             return new ResolvedWebObject(PROJECT, pageName, objectName, proj);
         }
-
         var shared = getFrom(webSharedOR, pageName, objectName);
         if (shared != null) {
-
             if (step != null &&
                 step.getReference().startsWith("[Project] ")) {
-
                 step.setReference("[Shared] " + pageName);
                 step.getTestCase().setSaved(false);
             }
-
             return new ResolvedWebObject(SHARED, pageName, objectName, shared);
         }
         return null;
@@ -808,20 +804,11 @@ public class ObjectRepository {
     * @param objectName object group name
     * @return resolved MobileOR object with scope metadata
     */
-   public ResolvedMobileObject resolveMobileObjectWithScope(String pageName, String objectName) {
-       var proj = getFrom(mobileProjectOR, pageName, objectName);
-       if (proj != null) {
-           String actualPageName = proj.getParent() != null ? proj.getParent().getName() : pageName;
-           return new ResolvedMobileObject(ORScope.PROJECT, actualPageName, objectName, proj);
-       }
-       var shared = getFrom(mobileSharedOR, pageName, objectName);
-       if (shared != null) {
-           markSharedUsage("MobileOR");
-           String actualPageName = shared.getParent() != null ? shared.getParent().getName() : pageName;
-           return new ResolvedMobileObject(ORScope.SHARED, actualPageName, objectName, shared);
-       }
-       return null;
-   }
+    public ResolvedMobileObject resolveMobileObjectWithScope(String pageName, String objectName) {
+        ResolvedMobileObject proj = resolveMobileObjectInScope(ORScope.PROJECT, pageName, objectName);
+        if (proj != null) return proj;
+        return resolveMobileObjectInScope(ORScope.SHARED, pageName, objectName);
+    }
 
     private ObjectGroup<WebORObject> getFrom(WebOR or, String page, String obj) {
         if (or == null) return null;

--- a/Datalib/src/main/java/com/ing/datalib/or/ObjectRepository.java
+++ b/Datalib/src/main/java/com/ing/datalib/or/ObjectRepository.java
@@ -1056,16 +1056,19 @@ public class ObjectRepository {
     public void saveWebPageNow(WebORPage page) {
         if (!useYamlFormat || yamlWriter == null || page == null) return;
         try {
-            File orRepLocation = new File(getORRepLocation());
-            File webPagesDir = new File(orRepLocation, "Web");
-            webPagesDir.mkdirs();
-            yamlWriter.writeWebPage(page, webPagesDir);
-            if (page.getRoot() != null) {
-                page.getRoot().setSaved(true);
+            File repoRoot =
+                (page.getRoot().getScope() == WebOR.ORScope.SHARED)
+                    ? new File(getSharedORRepLocation())
+                    : new File(getORRepLocation());
+            File webPagesDir = new File(repoRoot, "Web");
+            if (!webPagesDir.exists()) {
+                webPagesDir.mkdirs();
             }
-
+            yamlWriter.writeWebPage(page, webPagesDir);
+            page.getRoot().setSaved(true);
         } catch (IOException e) {
-            LOG.log(Level.SEVERE,
+            LOG.log(
+                Level.SEVERE,
                 "Failed to save Web page: " + page.getName(),
                 e
             );
@@ -1081,23 +1084,23 @@ public class ObjectRepository {
     public void saveMobilePageNow(MobileORPage page) {
         if (!useYamlFormat || yamlWriter == null || page == null) return;
         try {
-            File morRepLocation = new File(getORRepLocation());
-            File mobilePagesDir = new File(morRepLocation, "Mobile");
+            File repoRoot =
+                (page.getRoot().getScope() == MobileOR.ORScope.SHARED)
+                    ? new File(getSharedMORRepLocation())
+                    : new File(getMORRepLocation());
+            File mobilePagesDir = new File(repoRoot, "Mobile");
             if (!mobilePagesDir.exists()) {
                 mobilePagesDir.mkdirs();
             }
             yamlWriter.writeMobilePage(page, mobilePagesDir);
-            if (page.getRoot() != null) {
-                page.getRoot().setSaved(true);
-            }
-
+            page.getRoot().setSaved(true);
         } catch (IOException e) {
-            LOG.log(Level.SEVERE,
+            LOG.log(
+                Level.SEVERE,
                 "Failed to save Mobile page: " + page.getName(),
                 e
             );
         }
-        // XML format doesn't need per-page saves
     }
     
     /**

--- a/Datalib/src/main/java/com/ing/datalib/or/ObjectRepository.java
+++ b/Datalib/src/main/java/com/ing/datalib/or/ObjectRepository.java
@@ -79,221 +79,22 @@ public class ObjectRepository {
      * Loads OR files from disk (shared, project, mobile), updates names, sets scopes,
      * and links them to this repository.
      */
-//    private void init() {
-//        try {
-//            // Initialize YAML support
-//            yamlReader = new YamlORReader();
-//            yamlWriter = new YamlORWriter();
-//            
-//            File orRepLocation = new File(getORRepLocation());
-//            
-//            // Determine format once for PROJECT ORs only
-//            // Check if YAML or XML files exist for project ORs
-//            boolean hasYamlFiles = yamlReader.webORExists(orRepLocation) 
-//                                || yamlReader.mobileORExists(orRepLocation) 
-//                                || yamlReader.apiORExists(orRepLocation);
-//            boolean hasXmlFiles = new File(getORLocation()).exists() 
-//                               || new File(getMORLocation()).exists() 
-//                               || new File(getAPIORLocation()).exists();
-//            
-//            // Set format once for entire project
-//            if (hasYamlFiles) {
-//                useYamlFormat = true;
-//                LOG.info("Using YAML format for project Object Repositories");
-//            } else if (hasXmlFiles) {
-//                useYamlFormat = false;
-//                LOG.info("Using XML format for project Object Repositories (legacy)");
-//            } else {
-//                // New project - default to YAML
-//                useYamlFormat = true;
-//                LOG.info("New project - using YAML format for Object Repositories");
-//            }
-//            
-//            // === SHARED ORs (always XML) ===
-//            File sharedFile = new File(getSharedORLocation());
-//            if (sharedFile.exists()) {
-//                webSharedOR = XML_MAPPER.readValue(sharedFile, WebOR.class);
-//                webSharedOR.setName("Shared Web Objects");
-//            } else {
-//                webSharedOR = new WebOR("Shared Web Objects");
-//            }
-//            
-//            File sharedmorFile = new File(getSharedMORLocation());
-//            if (sharedmorFile.exists()) {
-//                mobileSharedOR = XML_MAPPER.readValue(sharedmorFile, MobileOR.class);
-//                mobileSharedOR.setName("Shared Mobile Objects");
-//            } else {
-//                mobileSharedOR = new MobileOR("Shared Mobile Objects");
-//            }
-//            
-//            // === PROJECT ORs (YAML or XML based on detection) ===
-//            // Load Web Project OR
-//            if (useYamlFormat && yamlReader.webORExists(orRepLocation)) {
-//                webProjectOR = yamlReader.readWebOR(orRepLocation);
-//                webProjectOR.setName(sProject.getName());
-//            } else if (!useYamlFormat && new File(getORLocation()).exists()) {
-//                webProjectOR = XML_MAPPER.readValue(new File(getORLocation()), WebOR.class);
-//                webProjectOR.setName(sProject.getName());
-//            } else {
-//                webProjectOR = new WebOR(sProject.getName());
-//            }
-//            // Set ObjectRepository reference immediately to prevent directory creation
-//            if (webProjectOR != null) {
-//                webProjectOR.setObjectRepository(this);
-//                webProjectOR.setScope(ORScope.PROJECT);
-//            }
-//            
-//            // Load Mobile Project OR
-//            if (useYamlFormat && yamlReader.mobileORExists(orRepLocation)) {
-//                mobileProjectOR = yamlReader.readMobileOR(orRepLocation);
-//                mobileProjectOR.setName(sProject.getName());
-//            } else if (!useYamlFormat && new File(getMORLocation()).exists()) {
-//                mobileProjectOR = XML_MAPPER.readValue(new File(getMORLocation()), MobileOR.class);
-//                mobileProjectOR.setName(sProject.getName());
-//            } else {
-//                mobileProjectOR = new MobileOR(sProject.getName());
-//            }
-//            // Set ObjectRepository reference immediately
-//            if (mobileProjectOR != null) {
-//                mobileProjectOR.setObjectRepository(this);
-//                mobileProjectOR.setScope(MobileOR.ORScope.PROJECT);
-//            }
-//            
-//            // Load API Project OR
-//            if (useYamlFormat && yamlReader.apiORExists(orRepLocation)) {
-//                apiProjectOR = yamlReader.readAPIOR(orRepLocation);
-//                apiProjectOR.setName(sProject.getName());
-//            } else if (!useYamlFormat && new File(getAPIORLocation()).exists()) {
-//                apiProjectOR = XML_MAPPER.readValue(new File(getAPIORLocation()), APIOR.class);
-//                apiProjectOR.setName(sProject.getName());
-//            } else {
-//                apiProjectOR = new APIOR(sProject.getName());
-//            }
-//
-//            // Set ObjectRepository reference immediately
-//            if (apiProjectOR != null) {
-//                apiProjectOR.setObjectRepository(this);
-//            }
-//
-//            // Set remaining properties for shared and project ORs
-//            if (webSharedOR != null) {
-//                webSharedOR.setObjectRepository(this);
-//                webSharedOR.setSaved(true);
-//                webSharedOR.setRepLocationOverride(getSharedORRepLocation());
-//                webSharedOR.setScope(ORScope.SHARED);
-//            }
-//            if (webProjectOR != null) {
-//                webProjectOR.setSaved(true);
-//            }
-//            if (mobileSharedOR != null) {
-//                mobileSharedOR.setObjectRepository(this);
-//                mobileSharedOR.setSaved(true);
-//                mobileSharedOR.setRepLocationOverride(getSharedMORRepLocation());
-//                mobileSharedOR.setScope(MobileOR.ORScope.SHARED);
-//                
-//            }
-//            if (mobileProjectOR != null) {
-//                mobileProjectOR.setSaved(true);
-//            }
-//            if (apiProjectOR != null) {
-//                apiProjectOR.setObjectRepository(this);
-//                apiProjectOR.setSaved(true);
-//            }
-//
-//            LOG.log(Level.INFO, "Shared WebOR loaded: {0}", (webSharedOR != null));
-//            LOG.log(Level.INFO, "Project WebOR loaded: {0}", (webProjectOR != null));
-//            LOG.log(Level.INFO, "Shared MobileOR loaded: {0}", (mobileSharedOR != null));
-//            LOG.log(Level.INFO, "Project MobileOR loaded: {0}", (mobileProjectOR != null));
-//            
-//            // Try YAML format first (modern format)
-//            if (yamlReader.webORExists(orRepLocation)) {
-//                LOG.info("Loading Web OR from YAML format");
-//                webProjectOR = yamlReader.readWebOR(orRepLocation);
-//                webProjectOR.setName(sProject.getName());
-//                useYamlFormat = true;
-//            } else if (new File(getORLocation()).exists()) {
-//                // Fall back to XML format (legacy)
-//                LOG.info("Loading Web OR from XML format");
-//                webProjectOR = XML_MAPPER.readValue(new File(getORLocation()), WebOR.class);
-//                webProjectOR.setName(sProject.getName());
-//                useYamlFormat = false; // Use XML format for legacy projects
-//            } else {
-//                webProjectOR = new WebOR(sProject.getName());
-//                // useYamlFormat stays true for new projects
-//            }
-//            
-//            // Try YAML format first for Mobile OR
-//            if (yamlReader.mobileORExists(orRepLocation)) {
-//                LOG.info("Loading Mobile OR from YAML format");
-//                mobileProjectOR = yamlReader.readMobileOR(orRepLocation);
-//                mobileProjectOR.setName(sProject.getName());
-//                useYamlFormat = true;
-//            } else if (new File(getMORLocation()).exists()) {
-//                // Fall back to XML format (legacy)
-//                LOG.info("Loading Mobile OR from XML format");
-//                mobileProjectOR = XML_MAPPER.readValue(new File(getMORLocation()), MobileOR.class);
-//                mobileProjectOR.setName(sProject.getName());
-//                useYamlFormat = false; // Use XML format for legacy projects
-//            } else {
-//                mobileProjectOR = new MobileOR(sProject.getName());
-//                // useYamlFormat stays true for new projects
-//            }
-//
-//            // Try YAML format first for API OR
-//            if (yamlReader.apiORExists(orRepLocation)) {
-//                LOG.info("Loading API OR from YAML format");
-//                apiProjectOR = yamlReader.readAPIOR(orRepLocation);
-//                apiProjectOR.setName(sProject.getName());
-//                useYamlFormat = true;
-//            } else if (new File(getAPIORLocation()).exists()) {
-//                // Fall back to XML format (legacy)
-//                LOG.info("Loading API OR from XML format");
-//                apiProjectOR = XML_MAPPER.readValue(new File(getAPIORLocation()), APIOR.class);
-//                apiProjectOR.setName(sProject.getName());
-//                useYamlFormat = false; // Use XML format for legacy projects
-//            } else {
-//                apiProjectOR = new APIOR(sProject.getName());
-//                // useYamlFormat stays true for new projects
-//            }
-//
-//            webProjectOR.setObjectRepository(this);
-//            webProjectOR.setSaved(true);
-//            mobileProjectOR.setObjectRepository(this);
-//            apiProjectOR.setObjectRepository(this);
-//        
-//        } catch (IOException ex) {
-//            Logger.getLogger(ObjectRepository.class.getName()).log(Level.SEVERE, null, ex);
-//        }
-//    }
     private void init() {
         try {
             yamlReader = new YamlORReader();
             yamlWriter = new YamlORWriter();
-
             boolean xmlExists  = hasAnyXmlOR();
             boolean yamlExists = hasYamlOR();
-
             LOG.info("OR init: xmlExists=" + xmlExists + ", yamlExists=" + yamlExists);
-
-            // ======================================================
-            // CASE 1: Legacy project → migrate
-            // ======================================================
+            
             if (xmlExists && !yamlExists) {
-
                 LOG.info("Legacy XML detected. Loading XML for migration...");
-
                 loadXmlObjectRepositories();
-
                 convertXmlOrsToYamlAndArchive();
-
                 LOG.info("Loading YAML after migration");
                 loadYamlObjectRepositories();
-
                 useYamlFormat = true;
             }
-            // ======================================================
-            // CASE 2: YAML-first project
-            // ======================================================
             else {
                 LOG.info("YAML detected. Loading YAML only...");
                 loadYamlObjectRepositories();
@@ -317,6 +118,12 @@ public class ObjectRepository {
     public String getAPIORLocation() {
         return sProject.getLocation() + File.separator + "APIOR.object";
     }
+    public String getSharedORLocation() {
+        return "Shared" + File.separator + "SharedWebObjects" + File.separator + "SharedOR.object";
+    }
+    public String getSharedMORLocation() {
+        return "Shared" + File.separator + "SharedMobileObjects" + File.separator + "SharedMOR.object";
+    }
     public String getORRepLocation() {
         return sProject.getLocation() + File.separator + "ObjectRepository";
     }
@@ -329,17 +136,19 @@ public class ObjectRepository {
     public String getAPIORRepLocation() {
         return sProject.getLocation() + File.separator + "APIObjectRepository";
     }
-    public String getSharedORLocation() {
-        return "Shared" + File.separator + "SharedWebObjects" + File.separator + "SharedOR.object";
-    }
-    public String getSharedMORLocation() {
-        return "Shared" + File.separator + "SharedMobileObjects" + File.separator + "SharedMOR.object";
-    }
     public String getSharedORRepLocation() {
-        return "Shared" + File.separator + "SharedObjectRepository";
+        File projectDir = new File(sProject.getLocation());   
+        File projectsRoot = projectDir.getParentFile();       
+        File ingeniousRoot = projectsRoot.getParentFile();    
+        File sharedOR = new File(ingeniousRoot,"Shared" + File.separator + "SharedObjectRepository");
+        return sharedOR.getAbsolutePath();
     }
     public String getSharedMORRepLocation() {
-        return "Shared" + File.separator + "SharedMobileObjectRepository";
+        File projectDir = new File(sProject.getLocation());   
+        File projectsRoot = projectDir.getParentFile();       
+        File ingeniousRoot = projectsRoot.getParentFile();    
+        File sharedOR = new File(ingeniousRoot,"Shared" + File.separator + "SharedMobileObjectRepository");
+        return sharedOR.getAbsolutePath();
     }
     public Project getsProject() {
         return sProject;
@@ -475,28 +284,6 @@ public class ObjectRepository {
             LOG.log(Level.SEVERE, "Error saving Object Repository as YAML", ex);
         }
     }
-    
-    /**
-     * Convert existing XML-based OR to YAML format.
-     * This creates YAML files while preserving the original XML files.
-     */
-    public void convertToYaml() {
-        try {
-            File orRepLocation = new File(getORRepLocation());
-            yamlWriter.convertFromXml(webProjectOR, mobileProjectOR, orRepLocation);
-            useYamlFormat = true;
-            LOG.info("Converted Object Repository to YAML format");
-        } catch (IOException ex) {
-            LOG.log(Level.SEVERE, "Error converting Object Repository to YAML", ex);
-        }
-    }
-    
-    /**
-     * Set whether to use YAML format for saving.
-     */
-    public void setUsingYamlFormat(boolean useYaml) {
-        this.useYamlFormat = useYaml;
-    }
 
     private boolean hasProjectXmlOR() {
         return new File(getORLocation()).exists() || new File(getMORLocation()).exists();
@@ -517,9 +304,7 @@ public class ObjectRepository {
     }
     
     private void convertXmlOrsToYamlAndArchive() throws IOException {
-
         LOG.info("Legacy XML ORs detected. Converting to YAML...");
-
         XmlToYamlORConverter converter = new XmlToYamlORConverter(yamlWriter);
 
         File projectYamlRoot = new File(getORRepLocation());
@@ -574,7 +359,6 @@ public class ObjectRepository {
         if (dir == null || !dir.exists()) {
             return;
         }
-
         File[] contents = dir.listFiles();
         if (contents != null) {
             for (File file : contents) {
@@ -585,7 +369,6 @@ public class ObjectRepository {
                 }
             }
         }
-
         boolean deleted = dir.delete();
         if (deleted) {
             LOG.info("Deleted legacy XML directory: " + dir.getAbsolutePath());
@@ -595,18 +378,14 @@ public class ObjectRepository {
     }
 
     private void cleanupLegacySharedXmlFolders() {
-
         File sharedWebXmlDir = new File("Shared" + File.separator + "SharedWebObjects");
-
         File sharedMobileXmlDir = new File("Shared" + File.separator + "SharedMobileObjects");
-
         deleteDirectoryRecursively(sharedWebXmlDir);
         deleteDirectoryRecursively(sharedMobileXmlDir);
     }
 
     private void loadYamlObjectRepositories() throws IOException {
         File orRepRoot = new File(getORRepLocation());
-
         webProjectOR = yamlReader.readWebOR(orRepRoot);
         mobileProjectOR = yamlReader.readMobileOR(orRepRoot);
         apiProjectOR = yamlReader.readAPIOR(orRepRoot);
@@ -627,10 +406,7 @@ public class ObjectRepository {
 
        LOG.info("Loading legacy XML Object Repositories for migration...");
 
-       // ========================
        // PROJECT XML ORs
-       // ========================
-
        File projectWebXml = new File(getORLocation());
        if (projectWebXml.exists()) {
            webProjectOR = XML_MAPPER.readValue(projectWebXml, WebOR.class);
@@ -645,10 +421,7 @@ public class ObjectRepository {
            LOG.info("Loaded PROJECT Mobile XML OR");
        }
 
-       // ========================
        // SHARED XML ORs
-       // ========================
-
        File sharedWebXml = new File(getSharedORLocation());
        if (sharedWebXml.exists()) {
            webSharedOR = XML_MAPPER.readValue(sharedWebXml, WebOR.class);

--- a/Datalib/src/main/java/com/ing/datalib/or/XmlToYamlORConverter.java
+++ b/Datalib/src/main/java/com/ing/datalib/or/XmlToYamlORConverter.java
@@ -55,7 +55,7 @@ public class XmlToYamlORConverter {
 
         if (projectOR == null) return;
 
-        File pagesDir = new File(projectRoot, "Web/pages");
+        File pagesDir = new File(projectRoot, "Web");
         pagesDir.mkdirs();
 
         LOG.info("Writing PROJECT Web OR to " + pagesDir.getAbsolutePath());
@@ -70,7 +70,7 @@ public class XmlToYamlORConverter {
 
         if (projectOR == null) return;
 
-        File pagesDir = new File(projectRoot, "Mobile/pages");
+        File pagesDir = new File(projectRoot, "Mobile");
         pagesDir.mkdirs();
 
         LOG.info("Writing PROJECT Mobile OR to " + pagesDir.getAbsolutePath());
@@ -87,7 +87,7 @@ public class XmlToYamlORConverter {
 
         if (sharedOR == null) return;
 
-        File pagesDir = new File(sharedRoot, "Web/pages");
+        File pagesDir = new File(sharedRoot, "Web");
         pagesDir.mkdirs();
 
         LOG.info("Writing SHARED Web OR to " + pagesDir.getAbsolutePath());
@@ -102,7 +102,7 @@ public class XmlToYamlORConverter {
 
         if (sharedOR == null) return;
 
-        File pagesDir = new File(sharedRoot, "Mobile/pages");
+        File pagesDir = new File(sharedRoot, "Mobile");
         pagesDir.mkdirs();
 
         LOG.info("Writing SHARED Mobile OR to " + pagesDir.getAbsolutePath());

--- a/Datalib/src/main/java/com/ing/datalib/or/XmlToYamlORConverter.java
+++ b/Datalib/src/main/java/com/ing/datalib/or/XmlToYamlORConverter.java
@@ -25,7 +25,6 @@ public class XmlToYamlORConverter {
 
     private final YamlORWriter yamlWriter;
 
-    // ✅ FIX 1: Proper constructor
     public XmlToYamlORConverter(YamlORWriter yamlWriter) {
         this.yamlWriter = yamlWriter;
     }
@@ -47,8 +46,6 @@ public class XmlToYamlORConverter {
         writeProjectMobile(projectMobile, projectRoot);
         writeSharedMobile(sharedMobile, sharedRoot);
     }
-
-    /* ========== PROJECT ORs ========== */
 
     private void writeProjectWeb(WebOR projectOR, File projectRoot)
             throws IOException {
@@ -79,8 +76,6 @@ public class XmlToYamlORConverter {
             yamlWriter.writeMobilePage(page, pagesDir);
         }
     }
-
-    /* ========== SHARED ORs ========== */
 
     private void writeSharedWeb(WebOR sharedOR, File sharedRoot)
             throws IOException {

--- a/Datalib/src/main/java/com/ing/datalib/or/XmlToYamlORConverter.java
+++ b/Datalib/src/main/java/com/ing/datalib/or/XmlToYamlORConverter.java
@@ -1,0 +1,114 @@
+package com.ing.datalib.or;
+
+import com.ing.datalib.or.mobile.MobileOR;
+import com.ing.datalib.or.mobile.MobileORPage;
+import com.ing.datalib.or.web.WebOR;
+import com.ing.datalib.or.web.WebORPage;
+import com.ing.datalib.or.yaml.YamlORWriter;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.logging.Logger;
+
+/**
+ * Converts in-memory XML Object Repositories to YAML.
+ *
+ * Scope is determined by WHICH OR is passed:
+ * - Project OR → ObjectRepository
+ * - Shared OR  → Shared
+ *
+ * Pages do not carry scope.
+ */
+public class XmlToYamlORConverter {
+
+    private static final Logger LOG = Logger.getLogger(XmlToYamlORConverter.class.getName());
+
+    private final YamlORWriter yamlWriter;
+
+    // ✅ FIX 1: Proper constructor
+    public XmlToYamlORConverter(YamlORWriter yamlWriter) {
+        this.yamlWriter = yamlWriter;
+    }
+
+    /**
+     * Convert all ORs to YAML with correct folder separation.
+     */
+    public void convertAll(
+            WebOR projectWeb,
+            WebOR sharedWeb,
+            MobileOR projectMobile,
+            MobileOR sharedMobile,
+            File projectRoot,
+            File sharedRoot) throws IOException {
+
+        writeProjectWeb(projectWeb, projectRoot);
+        writeSharedWeb(sharedWeb, sharedRoot);
+
+        writeProjectMobile(projectMobile, projectRoot);
+        writeSharedMobile(sharedMobile, sharedRoot);
+    }
+
+    /* ========== PROJECT ORs ========== */
+
+    private void writeProjectWeb(WebOR projectOR, File projectRoot)
+            throws IOException {
+
+        if (projectOR == null) return;
+
+        File pagesDir = new File(projectRoot, "Web/pages");
+        pagesDir.mkdirs();
+
+        LOG.info("Writing PROJECT Web OR to " + pagesDir.getAbsolutePath());
+
+        for (WebORPage page : projectOR.getPages()) {
+            yamlWriter.writeWebPage(page, pagesDir);
+        }
+    }
+
+    private void writeProjectMobile(MobileOR projectOR, File projectRoot)
+            throws IOException {
+
+        if (projectOR == null) return;
+
+        File pagesDir = new File(projectRoot, "Mobile/pages");
+        pagesDir.mkdirs();
+
+        LOG.info("Writing PROJECT Mobile OR to " + pagesDir.getAbsolutePath());
+
+        for (MobileORPage page : projectOR.getPages()) {
+            yamlWriter.writeMobilePage(page, pagesDir);
+        }
+    }
+
+    /* ========== SHARED ORs ========== */
+
+    private void writeSharedWeb(WebOR sharedOR, File sharedRoot)
+            throws IOException {
+
+        if (sharedOR == null) return;
+
+        File pagesDir = new File(sharedRoot, "Web/pages");
+        pagesDir.mkdirs();
+
+        LOG.info("Writing SHARED Web OR to " + pagesDir.getAbsolutePath());
+
+        for (WebORPage page : sharedOR.getPages()) {
+            yamlWriter.writeWebPage(page, pagesDir);
+        }
+    }
+
+    private void writeSharedMobile(MobileOR sharedOR, File sharedRoot)
+            throws IOException {
+
+        if (sharedOR == null) return;
+
+        File pagesDir = new File(sharedRoot, "Mobile/pages");
+        pagesDir.mkdirs();
+
+        LOG.info("Writing SHARED Mobile OR to " + pagesDir.getAbsolutePath());
+
+        for (MobileORPage page : sharedOR.getPages()) {
+            yamlWriter.writeMobilePage(page, pagesDir);
+        }
+    }
+}

--- a/Datalib/src/main/java/com/ing/datalib/or/api/APIORObject.java
+++ b/Datalib/src/main/java/com/ing/datalib/or/api/APIORObject.java
@@ -88,7 +88,9 @@ public class APIORObject extends UndoRedoModel implements ORObjectInf {
             group.removeFromParent();
         }
         group.getObjects().remove(this);
-        FileUtils.deleteFile(getRepLocation());
+        if (!group.getParent().getRoot().getObjectRepository().isUsingYamlFormat()) {
+            FileUtils.deleteFile(getRepLocation());
+        } 
     }
 
     @JsonIgnore
@@ -310,28 +312,15 @@ public class APIORObject extends UndoRedoModel implements ORObjectInf {
     @JsonIgnore
     @Override
     public Boolean rename(String newName) {
-        Boolean flag = true;
-        if (getParent().getChildCount() == 1) {
-            flag = getParent().rename(newName);
+        if (newName == null || newName.isBlank()) {
+            return false;
         }
-        if (flag && getParent().getObjectByName(newName) == null) {
-            // Check if using YAML format
-            if (getParent().getParent().getRoot().getObjectRepository().isUsingYamlFormat()) {
-                // For YAML format, objects are stored within the page YAML file
-                // Just update the name and mark as needing save
-                setName(newName);
-                changeSave();
-                return true;
-            } else {
-                // Use original XML folder-based rename
-                if (FileUtils.renameFile(getRepLocation(), newName)) {
-                    setName(newName);
-                    changeSave();
-                    return true;
-                }
-            }
+        if (getParent().getObjectByName(newName) != null) {
+            return false;
         }
-        return false;
+        setName(newName);
+        changeSave();
+        return true;
     }
 
     @JsonIgnore

--- a/Datalib/src/main/java/com/ing/datalib/or/api/APIORPage.java
+++ b/Datalib/src/main/java/com/ing/datalib/or/api/APIORPage.java
@@ -85,7 +85,11 @@ public class APIORPage implements ORPageInf<APIORObject, APIOR> {
     public void removeFromParent() {
         root.setSaved(false);
         root.getPages().remove(this);
-        FileUtils.deleteFile(getRepLocation());
+        if (root.getObjectRepository().isUsingYamlFormat()) {
+            root.getObjectRepository().deleteWebPageYaml(getName());
+        } else {
+            FileUtils.deleteFile(getRepLocation());
+        }
     }
 
     @JsonIgnore
@@ -259,27 +263,9 @@ public class APIORPage implements ORPageInf<APIORObject, APIOR> {
     @JsonIgnore
     @Override
     public Boolean rename(String newName) {
-        // Check if using YAML format
-        if (root.getObjectRepository().isUsingYamlFormat()) {
-            // For YAML format, rename the page YAML file
-            if (root.getObjectRepository().renameAPIPageYaml(name, newName)) {
-                String oldName = name;
-                root.getObjectRepository().renamePage(this, newName);
-                setName(newName);
-                root.setSaved(false);
-                return true;
-            }
-            return false;
-        } else {
-            // Use original XML folder-based rename
-            if (FileUtils.renameFile(getRepLocation(), newName)) {
-                String oldName = name;
-                root.getObjectRepository().renamePage(this, newName);
-                setName(newName);
-                root.setSaved(false);
-                return true;
-            }
-        }
-        return false;
+        getRoot()
+            .getObjectRepository()
+            .renamePage(this, newName);
+        return true;
     }
 }

--- a/Datalib/src/main/java/com/ing/datalib/or/mobile/MobileOR.java
+++ b/Datalib/src/main/java/com/ing/datalib/or/mobile/MobileOR.java
@@ -103,6 +103,9 @@ public class MobileOR implements ORRootInf<MobileORPage> {
         this.pages = pages;
         for (MobileORPage page : pages) {
             page.setRoot(this);
+            if (page.getSource() == null) {
+                page.setSource(isShared() ? ORScope.SHARED : ORScope.PROJECT);
+            }
         }
     }
 

--- a/Datalib/src/main/java/com/ing/datalib/or/mobile/MobileOR.java
+++ b/Datalib/src/main/java/com/ing/datalib/or/mobile/MobileOR.java
@@ -282,6 +282,6 @@ public class MobileOR implements ORRootInf<MobileORPage> {
     }
     
     public void setSharedProjects(List<String> projects) {
-        this.projects = (projects == null) ? new ArrayList<>() : projects;
+        this.projects = projects;
     }
 }

--- a/Datalib/src/main/java/com/ing/datalib/or/mobile/MobileOR.java
+++ b/Datalib/src/main/java/com/ing/datalib/or/mobile/MobileOR.java
@@ -250,7 +250,7 @@ public class MobileOR implements ORRootInf<MobileORPage> {
     public String getRepLocation() {
         return repLocationOverride != null
                 ? repLocationOverride
-                : getObjectRepository().getMORRepLocation();
+                : getObjectRepository().getORRepLocation();
     }
 
     @JsonIgnore

--- a/Datalib/src/main/java/com/ing/datalib/or/mobile/MobileORObject.java
+++ b/Datalib/src/main/java/com/ing/datalib/or/mobile/MobileORObject.java
@@ -312,20 +312,21 @@ public class MobileORObject extends UndoRedoModel implements ORObjectInf {
         return String.class;
     }
 
+    @JsonIgnore
     @Override
     public Boolean rename(String newName) {
-        Boolean flag = true;
         if (getParent().getChildCount() == 1) {
-            flag = getParent().rename(newName);
+            getParent().rename(newName);
         }
-        if (flag && getParent().getObjectByName(newName) == null) {
-            if (FileUtils.renameFile(getRepLocation(), newName)) {
-                setName(newName);
-                changeSave();
-                return true;
-            }
+        if (newName == null || newName.isBlank()) {
+            return false;
         }
-        return false;
+        if (getParent().getObjectByName(newName) != null) {
+            return false;
+        }
+        setName(newName);
+        changeSave();
+        return true;
     }
 
     @JsonIgnore

--- a/Datalib/src/main/java/com/ing/datalib/or/mobile/MobileORObject.java
+++ b/Datalib/src/main/java/com/ing/datalib/or/mobile/MobileORObject.java
@@ -76,10 +76,11 @@ public class MobileORObject extends UndoRedoModel implements ORObjectInf {
         changeSave();
         if (group.getObjects().size() == 1) {
             group.removeFromParent();
-        } else {
-            group.getObjects().remove(this);
-            FileUtils.deleteFile(getRepLocation());
         }
+        group.getObjects().remove(this);
+        if (!group.getParent().getRoot().getObjectRepository().isUsingYamlFormat()) {
+            FileUtils.deleteFile(getRepLocation());
+        } 
     }
 
     @Override
@@ -313,28 +314,15 @@ public class MobileORObject extends UndoRedoModel implements ORObjectInf {
 
     @Override
     public Boolean rename(String newName) {
-        Boolean flag = true;
-        if (getParent().getChildCount() == 1) {
-            flag = getParent().rename(newName);
+        if (newName == null || newName.isBlank()) {
+            return false;
         }
-        if (flag && getParent().getObjectByName(newName) == null) {
-            // Check if using YAML format
-            if (getParent().getParent().getRoot().getObjectRepository().isUsingYamlFormat()) {
-                // For YAML format, objects are stored within the page YAML file
-                // Just update the name and mark as needing save
-                setName(newName);
-                changeSave();
-                return true;
-            } else {
-                // Use original XML folder-based rename
-                if (FileUtils.renameFile(getRepLocation(), newName)) {
-                    setName(newName);
-                    changeSave();
-                    return true;
-                }
-            }
+        if (getParent().getObjectByName(newName) != null) {
+            return false;
         }
-        return false;
+        setName(newName);
+        changeSave();
+        return true;
     }
 
     @JsonIgnore

--- a/Datalib/src/main/java/com/ing/datalib/or/mobile/MobileORObject.java
+++ b/Datalib/src/main/java/com/ing/datalib/or/mobile/MobileORObject.java
@@ -314,15 +314,18 @@ public class MobileORObject extends UndoRedoModel implements ORObjectInf {
 
     @Override
     public Boolean rename(String newName) {
-        if (newName == null || newName.isBlank()) {
-            return false;
+        Boolean flag = true;
+        if (getParent().getChildCount() == 1) {
+            flag = getParent().rename(newName);
         }
-        if (getParent().getObjectByName(newName) != null) {
-            return false;
+        if (flag && getParent().getObjectByName(newName) == null) {
+            if (FileUtils.renameFile(getRepLocation(), newName)) {
+                setName(newName);
+                changeSave();
+                return true;
+            }
         }
-        setName(newName);
-        changeSave();
-        return true;
+        return false;
     }
 
     @JsonIgnore

--- a/Datalib/src/main/java/com/ing/datalib/or/mobile/MobileORPage.java
+++ b/Datalib/src/main/java/com/ing/datalib/or/mobile/MobileORPage.java
@@ -90,7 +90,11 @@ public class MobileORPage implements ORPageInf<MobileORObject, MobileOR> {
     public void removeFromParent() {
         root.setSaved(false);
         root.getPages().remove(this);
-        FileUtils.deleteFile(getRepLocation());
+        if (root.getObjectRepository().isUsingYamlFormat()) {
+            root.getObjectRepository().deleteWebPageYaml(getName());
+        } else {
+            FileUtils.deleteFile(getRepLocation());
+        }
     }
 
     @JsonIgnore
@@ -256,28 +260,10 @@ public class MobileORPage implements ORPageInf<MobileORObject, MobileOR> {
 
     @Override
     public Boolean rename(String newName) {
-        if (getParent().getPageByName(newName) == null) {
-            String oldName = getName();
-            // Check if using YAML format
-            if (getRoot().getObjectRepository().isUsingYamlFormat()) {
-                // Rename the YAML file
-                if (getRoot().getObjectRepository().renameMobilePageYaml(oldName, newName)) {
-                    getRoot().getObjectRepository().renamePage(this, newName);
-                    setName(newName);
-                    getParent().setSaved(false);
-                    return true;
-                }
-            } else {
-                // Use original XML folder-based rename
-                if (FileUtils.renameFile(getRepLocation(), newName)) {
-                    getRoot().getObjectRepository().renamePage(this, newName);
-                    setName(newName);
-                    getParent().setSaved(false);
-                    return true;
-                }
-            }
-        }
-        return false;
+        getRoot()
+            .getObjectRepository()
+            .renamePage(this, newName);
+        return true;
     }
 
     @JsonIgnore

--- a/Datalib/src/main/java/com/ing/datalib/or/mobile/MobileORPage.java
+++ b/Datalib/src/main/java/com/ing/datalib/or/mobile/MobileORPage.java
@@ -91,7 +91,7 @@ public class MobileORPage implements ORPageInf<MobileORObject, MobileOR> {
         root.setSaved(false);
         root.getPages().remove(this);
         if (root.getObjectRepository().isUsingYamlFormat()) {
-            root.getObjectRepository().deleteWebPageYaml(getName());
+            root.getObjectRepository().deleteMobilePageYaml(getName());
         } else {
             FileUtils.deleteFile(getRepLocation());
         }

--- a/Datalib/src/main/java/com/ing/datalib/or/web/WebOR.java
+++ b/Datalib/src/main/java/com/ing/datalib/or/web/WebOR.java
@@ -296,6 +296,6 @@ public class WebOR implements ORRootInf<WebORPage> {
     }
 
     public void setSharedProjects(List<String> projects) {
-        this.projects = (projects == null) ? new ArrayList<>() : projects;
+        this.projects = projects;
     }
 }

--- a/Datalib/src/main/java/com/ing/datalib/or/web/WebORObject.java
+++ b/Datalib/src/main/java/com/ing/datalib/or/web/WebORObject.java
@@ -354,15 +354,18 @@ public class WebORObject extends UndoRedoModel implements ORObjectInf {
     @JsonIgnore
     @Override
     public Boolean rename(String newName) {
-        if (newName == null || newName.isBlank()) {
-            return false;
+        Boolean flag = true;
+        if (getParent().getChildCount() == 1) {
+            flag = getParent().rename(newName);
         }
-        if (getParent().getObjectByName(newName) != null) {
-            return false;
+        if (flag && getParent().getObjectByName(newName) == null) {
+            if (FileUtils.renameFile(getRepLocation(), newName)) {
+                setName(newName);
+                changeSave();
+                return true;
+            }
         }
-        setName(newName);
-        changeSave();
-        return true;
+        return false;
     }
 
     

--- a/Datalib/src/main/java/com/ing/datalib/or/web/WebORObject.java
+++ b/Datalib/src/main/java/com/ing/datalib/or/web/WebORObject.java
@@ -109,7 +109,9 @@ public class WebORObject extends UndoRedoModel implements ORObjectInf {
             group.removeFromParent();
         }
         group.getObjects().remove(this);
-        FileUtils.deleteFile(getRepLocation());
+        if (!group.getParent().getRoot().getObjectRepository().isUsingYamlFormat()) {
+            FileUtils.deleteFile(getRepLocation());
+        } 
     }
 
     @JsonIgnore
@@ -352,30 +354,22 @@ public class WebORObject extends UndoRedoModel implements ORObjectInf {
     @JsonIgnore
     @Override
     public Boolean rename(String newName) {
-        Boolean flag = true;
-        if (getParent().getChildCount() == 1) {
-            flag = getParent().rename(newName);
+        if (newName == null || newName.isBlank()) {
+            return false;
         }
-        if (flag && getParent().getObjectByName(newName) == null) {
-            // Check if using YAML format
-            if (getParent().getParent().getRoot().getObjectRepository().isUsingYamlFormat()) {
-                // For YAML format, objects are stored within the page YAML file
-                // Just update the name and mark as needing save
-                setName(newName);
-                changeSave();
-                return true;
-            } else {
-                // Use original XML folder-based rename
-                if (FileUtils.renameFile(getRepLocation(), newName)) {
-                    setName(newName);
-                    changeSave();
-                    return true;
-                }
-            }
+        if (getParent().getObjectByName(newName) != null) {
+            return false;
         }
-        return false;
+        setName(newName);
+        changeSave();
+        return true;
     }
 
+    
+    /**
+     * Returns filesystem path for legacy XML-based OR.
+     * MUST NOT be used in YAML mode.
+     */
     @JsonIgnore
     @Override
     public String getRepLocation() {

--- a/Datalib/src/main/java/com/ing/datalib/or/web/WebORObject.java
+++ b/Datalib/src/main/java/com/ing/datalib/or/web/WebORObject.java
@@ -354,20 +354,19 @@ public class WebORObject extends UndoRedoModel implements ORObjectInf {
     @JsonIgnore
     @Override
     public Boolean rename(String newName) {
-        Boolean flag = true;
         if (getParent().getChildCount() == 1) {
-            flag = getParent().rename(newName);
+            getParent().rename(newName);
         }
-        if (flag && getParent().getObjectByName(newName) == null) {
-            if (FileUtils.renameFile(getRepLocation(), newName)) {
-                setName(newName);
-                changeSave();
-                return true;
-            }
+        if (newName == null || newName.isBlank()) {
+            return false;
         }
-        return false;
+        if (getParent().getObjectByName(newName) != null) {
+            return false;
+        }
+        setName(newName);
+        changeSave();
+        return true;
     }
-
     
     /**
      * Returns filesystem path for legacy XML-based OR.

--- a/Datalib/src/main/java/com/ing/datalib/or/web/WebORPage.java
+++ b/Datalib/src/main/java/com/ing/datalib/or/web/WebORPage.java
@@ -90,7 +90,11 @@ public class WebORPage implements ORPageInf<WebORObject, WebOR> {
     public void removeFromParent() {
         root.setSaved(false);
         root.getPages().remove(this);
-        FileUtils.deleteFile(getRepLocation());
+        if (root.getObjectRepository().isUsingYamlFormat()) {
+            root.getObjectRepository().deleteWebPageYaml(getName());
+        } else {
+            FileUtils.deleteFile(getRepLocation());
+        }
     }
 
     @JsonIgnore
@@ -255,28 +259,10 @@ public class WebORPage implements ORPageInf<WebORObject, WebOR> {
 
     @Override
     public Boolean rename(String newName) {
-        if (getParent().getPageByName(newName) == null) {
-            String oldName = getName();
-            // Check if using YAML format
-            if (getRoot().getObjectRepository().isUsingYamlFormat()) {
-                // Rename the YAML file
-                if (getRoot().getObjectRepository().renameWebPageYaml(oldName, newName)) {
-                    getRoot().getObjectRepository().renamePage(this, newName);
-                    setName(newName);
-                    getParent().setSaved(false);
-                    return true;
-                }
-            } else {
-                // Use original XML folder-based rename
-                if (FileUtils.renameFile(getRepLocation(), newName)) {
-                    getRoot().getObjectRepository().renamePage(this, newName);
-                    setName(newName);
-                    getParent().setSaved(false);
-                    return true;
-                }
-            }
-        }
-        return false;
+        getRoot()
+            .getObjectRepository()
+            .renamePage(this, newName);
+        return true;
     }
 
     @JsonIgnore

--- a/Datalib/src/main/java/com/ing/datalib/or/yaml/YamlMobilePageDefinition.java
+++ b/Datalib/src/main/java/com/ing/datalib/or/yaml/YamlMobilePageDefinition.java
@@ -33,7 +33,7 @@ import java.util.Map;
  * </pre>
  */
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-@JsonPropertyOrder({"page", "packageName", "description", "platform", "tags", "elements"})
+@JsonPropertyOrder({"page", "scope", "packageName", "description", "platform", "tags", "elements"})
 public class YamlMobilePageDefinition {
     
     private String page;
@@ -42,6 +42,7 @@ public class YamlMobilePageDefinition {
     private String platform;     // "android" | "ios" | "both"
     private List<String> tags;
     private Map<String, YamlMobileElementDefinition> elements = new LinkedHashMap<>();
+    private MobileOR.ORScope scope;
     
     public YamlMobilePageDefinition() {
     }
@@ -58,6 +59,14 @@ public class YamlMobilePageDefinition {
 
     public void setPage(String page) {
         this.page = page;
+    }
+    
+    public MobileOR.ORScope getScope() {
+        return scope;
+    }
+
+    public void setScope(MobileOR.ORScope scope) {
+        this.scope = scope;
     }
 
     public String getPackageName() {
@@ -110,6 +119,10 @@ public class YamlMobilePageDefinition {
         yaml.setPage(page.getName());
         yaml.setPackageName(page.getPackageName());
         
+        if (page.getRoot() != null) {
+            yaml.setScope(page.getRoot().getScope());
+        }
+
         // Iterate through object groups and objects using Lists
         for (ObjectGroup<MobileORObject> group : page.getObjectGroups()) {
             for (MobileORObject obj : group.getObjects()) {
@@ -127,6 +140,12 @@ public class YamlMobilePageDefinition {
      */
     public MobileORPage toMobileORPage(MobileOR root) {
         MobileORPage page = new MobileORPage(this.page, root);
+        
+        
+        if (this.scope != null && root != null && this.scope != root.getScope()) { 
+            throw new IllegalStateException("Scope mismatch: YAML mobile page '" + page + "' declares scope " + scope + " but is loaded under OR scope " + root.getScope());
+        }
+
         if (this.packageName != null && !this.packageName.isEmpty()) {
             page.setPackageName(this.packageName);
         }

--- a/Datalib/src/main/java/com/ing/datalib/or/yaml/YamlMobilePageDefinition.java
+++ b/Datalib/src/main/java/com/ing/datalib/or/yaml/YamlMobilePageDefinition.java
@@ -140,8 +140,7 @@ public class YamlMobilePageDefinition {
      */
     public MobileORPage toMobileORPage(MobileOR root) {
         MobileORPage page = new MobileORPage(this.page, root);
-        
-        
+       
         if (this.scope != null && root != null && this.scope != root.getScope()) { 
             throw new IllegalStateException("Scope mismatch: YAML mobile page '" + page + "' declares scope " + scope + " but is loaded under OR scope " + root.getScope());
         }

--- a/Datalib/src/main/java/com/ing/datalib/or/yaml/YamlORReader.java
+++ b/Datalib/src/main/java/com/ing/datalib/or/yaml/YamlORReader.java
@@ -56,7 +56,7 @@ public class YamlORReader {
      * Check if a YAML-based Web OR exists.
      */
     public boolean webORExists(File orLocation) {
-        File webPagesDir = new File(orLocation, "Web/pages");
+        File webPagesDir = new File(orLocation, "Web");
         return webPagesDir.exists() && webPagesDir.isDirectory();
     }
     
@@ -64,7 +64,7 @@ public class YamlORReader {
      * Check if a YAML-based Mobile OR exists.
      */
     public boolean mobileORExists(File orLocation) {
-        File mobilePagesDir = new File(orLocation, "Mobile/pages");
+        File mobilePagesDir = new File(orLocation, "Mobile");
         return mobilePagesDir.exists() && mobilePagesDir.isDirectory();
     }
     
@@ -72,7 +72,7 @@ public class YamlORReader {
      * Check if a YAML-based API OR exists.
      */
     public boolean apiORExists(File orLocation) {
-        File apiPagesDir = new File(orLocation, "API/pages");
+        File apiPagesDir = new File(orLocation, "API");
         return apiPagesDir.exists() && apiPagesDir.isDirectory();
     }
     
@@ -84,7 +84,7 @@ public class YamlORReader {
      */
     public WebOR readWebOR(File orLocation) throws IOException {
         WebOR webOR = new WebOR();
-        File webPagesDir = new File(orLocation, "Web/pages");
+        File webPagesDir = new File(orLocation, "Web");
         
         if (orLocation.getPath().contains(File.separator + "Shared" + File.separator)) {
             webOR.setScope(WebOR.ORScope.SHARED);
@@ -122,7 +122,7 @@ public class YamlORReader {
      */
     public MobileOR readMobileOR(File orLocation) throws IOException {
         MobileOR mobileOR = new MobileOR();
-        File mobilePagesDir = new File(orLocation, "Mobile/pages");
+        File mobilePagesDir = new File(orLocation, "Mobile");
         
         if (orLocation.getPath().contains(File.separator + "Shared" + File.separator)) {
             mobileOR.setScope(MobileOR.ORScope.SHARED);
@@ -176,7 +176,7 @@ public class YamlORReader {
      */
     public APIOR readAPIOR(File orLocation) throws IOException {
         APIOR apiOR = new APIOR();
-        File apiPagesDir = new File(orLocation, "API/pages");
+        File apiPagesDir = new File(orLocation, "API");
         
         if (!apiPagesDir.exists()) {
             LOGGER.info("No API OR YAML directory found at: " + apiPagesDir.getAbsolutePath());

--- a/Datalib/src/main/java/com/ing/datalib/or/yaml/YamlORReader.java
+++ b/Datalib/src/main/java/com/ing/datalib/or/yaml/YamlORReader.java
@@ -86,6 +86,12 @@ public class YamlORReader {
         WebOR webOR = new WebOR();
         File webPagesDir = new File(orLocation, "Web/pages");
         
+        if (orLocation.getPath().contains(File.separator + "Shared" + File.separator)) {
+            webOR.setScope(WebOR.ORScope.SHARED);
+        } else {
+            webOR.setScope(WebOR.ORScope.PROJECT);
+        }
+        
         if (!webPagesDir.exists()) {
             LOGGER.info("No Web OR YAML directory found at: " + webPagesDir.getAbsolutePath());
             return webOR;
@@ -118,6 +124,12 @@ public class YamlORReader {
         MobileOR mobileOR = new MobileOR();
         File mobilePagesDir = new File(orLocation, "Mobile/pages");
         
+        if (orLocation.getPath().contains(File.separator + "Shared" + File.separator)) {
+            mobileOR.setScope(MobileOR.ORScope.SHARED);
+        } else {
+            mobileOR.setScope(MobileOR.ORScope.PROJECT);
+        }
+
         if (!mobilePagesDir.exists()) {
             LOGGER.info("No Mobile OR YAML directory found at: " + mobilePagesDir.getAbsolutePath());
             return mobileOR;

--- a/Datalib/src/main/java/com/ing/datalib/or/yaml/YamlORReader.java
+++ b/Datalib/src/main/java/com/ing/datalib/or/yaml/YamlORReader.java
@@ -9,6 +9,7 @@ import com.ing.datalib.or.web.WebORPage;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
+import com.ing.datalib.or.ObjectRepository;
 
 import java.io.File;
 import java.io.IOException;
@@ -44,11 +45,21 @@ public class YamlORReader {
     
     private final ObjectMapper yamlMapper;
     
+    private ObjectRepository objectRepository;
+    
     public YamlORReader() {
         YAMLFactory factory = new YAMLFactory();
         factory.disable(YAMLGenerator.Feature.WRITE_DOC_START_MARKER);
         this.yamlMapper = new ObjectMapper(factory);
         // Configure for clean YAML
+        this.yamlMapper.findAndRegisterModules();
+    }
+
+    public YamlORReader(ObjectRepository objectRepository) {
+        this.objectRepository = objectRepository;
+        YAMLFactory factory = new YAMLFactory();
+        factory.disable(YAMLGenerator.Feature.WRITE_DOC_START_MARKER);
+        this.yamlMapper = new ObjectMapper(factory);
         this.yamlMapper.findAndRegisterModules();
     }
     

--- a/Datalib/src/main/java/com/ing/datalib/or/yaml/YamlORWriter.java
+++ b/Datalib/src/main/java/com/ing/datalib/or/yaml/YamlORWriter.java
@@ -62,7 +62,7 @@ public class YamlORWriter {
      * @param orLocation The ObjectRepository directory
      */
     public void writeWebOR(WebOR webOR, File orLocation) throws IOException {
-        File webPagesDir = new File(orLocation, "Web/pages");
+        File webPagesDir = new File(orLocation, "Web");
         ensureDirectory(webPagesDir);
         
         List<WebORPage> pages = webOR.getPages();
@@ -80,7 +80,7 @@ public class YamlORWriter {
      * @param orLocation The ObjectRepository directory
      */
     public void writeMobileOR(MobileOR mobileOR, File orLocation) throws IOException {
-        File mobilePagesDir = new File(orLocation, "Mobile/pages");
+        File mobilePagesDir = new File(orLocation, "Mobile");
         ensureDirectory(mobilePagesDir);
         
         List<MobileORPage> pages = mobileOR.getPages();
@@ -98,7 +98,7 @@ public class YamlORWriter {
      * @param orLocation The ObjectRepository directory
      */
     public void writeAPIOR(APIOR apiOR, File orLocation) throws IOException {
-        File apiPagesDir = new File(orLocation, "API/pages");
+        File apiPagesDir = new File(orLocation, "API");
         ensureDirectory(apiPagesDir);
         
         List<APIORPage> pages = apiOR.getPages();
@@ -146,7 +146,7 @@ public class YamlORWriter {
      * Delete a Web page YAML file.
      */
     public boolean deleteWebPage(String pageName, File orLocation) {
-        File webPagesDir = new File(orLocation, "Web/pages");
+        File webPagesDir = new File(orLocation, "Web");
         File yamlFile = new File(webPagesDir, sanitizeFileName(pageName) + ".yaml");
         
         if (yamlFile.exists()) {
@@ -163,7 +163,7 @@ public class YamlORWriter {
      * Delete a Mobile page YAML file.
      */
     public boolean deleteMobilePage(String pageName, File orLocation) {
-        File mobilePagesDir = new File(orLocation, "Mobile/pages");
+        File mobilePagesDir = new File(orLocation, "Mobile");
         File yamlFile = new File(mobilePagesDir, sanitizeFileName(pageName) + ".yaml");
         
         if (yamlFile.exists()) {
@@ -180,7 +180,7 @@ public class YamlORWriter {
      * Delete an API page YAML file.
      */
     public boolean deleteAPIPage(String pageName, File orLocation) {
-        File apiPagesDir = new File(orLocation, "API/pages");
+        File apiPagesDir = new File(orLocation, "API");
         File yamlFile = new File(apiPagesDir, sanitizeFileName(pageName) + ".yaml");
         
         if (yamlFile.exists()) {
@@ -202,7 +202,7 @@ public class YamlORWriter {
      * @return true if rename was successful
      */
     public boolean renameWebPage(String oldName, String newName, File orLocation) {
-        File webPagesDir = new File(orLocation, "Web/pages");
+        File webPagesDir = new File(orLocation, "Web");
         File oldFile = new File(webPagesDir, sanitizeFileName(oldName) + ".yaml");
         File newFile = new File(webPagesDir, sanitizeFileName(newName) + ".yaml");
         
@@ -225,7 +225,7 @@ public class YamlORWriter {
      * @return true if rename was successful
      */
     public boolean renameMobilePage(String oldName, String newName, File orLocation) {
-        File mobilePagesDir = new File(orLocation, "Mobile/pages");
+        File mobilePagesDir = new File(orLocation, "Mobile");
         File oldFile = new File(mobilePagesDir, sanitizeFileName(oldName) + ".yaml");
         File newFile = new File(mobilePagesDir, sanitizeFileName(newName) + ".yaml");
         
@@ -248,7 +248,7 @@ public class YamlORWriter {
      * @return true if rename was successful
      */
     public boolean renameAPIPage(String oldName, String newName, File orLocation) {
-        File apiPagesDir = new File(orLocation, "API/pages");
+        File apiPagesDir = new File(orLocation, "API");
         File oldFile = new File(apiPagesDir, sanitizeFileName(oldName) + ".yaml");
         File newFile = new File(apiPagesDir, sanitizeFileName(newName) + ".yaml");
         

--- a/Datalib/src/main/java/com/ing/datalib/or/yaml/YamlORWriter.java
+++ b/Datalib/src/main/java/com/ing/datalib/or/yaml/YamlORWriter.java
@@ -13,8 +13,12 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.logging.Level;
+import java.util.Map;
+import java.util.Set;
 import java.util.logging.Logger;
 
 /**
@@ -66,7 +70,7 @@ public class YamlORWriter {
         ensureDirectory(webPagesDir);
         
         List<WebORPage> pages = webOR.getPages();
-        LOGGER.info("Writing " + pages.size() + " Web pages to YAML");
+        LOGGER.info(() -> "Writing " + pages.size() + " Web pages to YAML");
         
         for (WebORPage page : pages) {
             writeWebPage(page, webPagesDir);
@@ -84,7 +88,7 @@ public class YamlORWriter {
         ensureDirectory(mobilePagesDir);
         
         List<MobileORPage> pages = mobileOR.getPages();
-        LOGGER.info("Writing " + pages.size() + " Mobile pages to YAML");
+        LOGGER.info(() -> "Writing " + pages.size() + " Mobile pages to YAML");
         
         for (MobileORPage page : pages) {
             writeMobilePage(page, mobilePagesDir);
@@ -102,7 +106,7 @@ public class YamlORWriter {
         ensureDirectory(apiPagesDir);
         
         List<APIORPage> pages = apiOR.getPages();
-        LOGGER.info("Writing " + pages.size() + " API pages to YAML");
+        LOGGER.info(() -> "Writing " + pages.size() + " API pages to YAML");
         
         for (APIORPage page : pages) {
             writeAPIPage(page, apiPagesDir);
@@ -117,7 +121,7 @@ public class YamlORWriter {
         File yamlFile = new File(pagesDir, sanitizeFileName(page.getName()) + ".yaml");
         
         yamlMapper.writeValue(yamlFile, pageDef);
-        LOGGER.fine("Wrote Web page: " + yamlFile.getName());
+        LOGGER.fine(() -> "Wrote Web page: " + yamlFile.getName());
     }
     
     /**
@@ -128,7 +132,7 @@ public class YamlORWriter {
         File yamlFile = new File(pagesDir, sanitizeFileName(page.getName()) + ".yaml");
         
         yamlMapper.writeValue(yamlFile, pageDef);
-        LOGGER.fine("Wrote Mobile page: " + yamlFile.getName());
+        LOGGER.fine(() -> "Wrote Mobile page: " + yamlFile.getName());
     }
     
     /**
@@ -139,7 +143,7 @@ public class YamlORWriter {
         File yamlFile = new File(pagesDir, sanitizeFileName(page.getName()) + ".yaml");
         
         yamlMapper.writeValue(yamlFile, pageDef);
-        LOGGER.fine("Wrote API page: " + yamlFile.getName());
+        LOGGER.fine(() -> "Wrote API page: " + yamlFile.getName());
     }
     
     /**
@@ -152,7 +156,7 @@ public class YamlORWriter {
         if (yamlFile.exists()) {
             boolean deleted = yamlFile.delete();
             if (deleted) {
-                LOGGER.info("Deleted Web page YAML: " + pageName);
+                LOGGER.info(() -> "Deleted Web page YAML: " + pageName);
             }
             return deleted;
         }
@@ -169,7 +173,7 @@ public class YamlORWriter {
         if (yamlFile.exists()) {
             boolean deleted = yamlFile.delete();
             if (deleted) {
-                LOGGER.info("Deleted Mobile page YAML: " + pageName);
+                LOGGER.info(() -> "Deleted Mobile page YAML: " + pageName);
             }
             return deleted;
         }
@@ -186,7 +190,7 @@ public class YamlORWriter {
         if (yamlFile.exists()) {
             boolean deleted = yamlFile.delete();
             if (deleted) {
-                LOGGER.info("Deleted API page YAML: " + pageName);
+                LOGGER.info(() -> "Deleted API page YAML: " + pageName);
             }
             return deleted;
         }
@@ -209,7 +213,7 @@ public class YamlORWriter {
         if (oldFile.exists() && !newFile.exists()) {
             boolean renamed = oldFile.renameTo(newFile);
             if (renamed) {
-                LOGGER.info("Renamed Web page YAML: " + oldName + " -> " + newName);
+                LOGGER.info(() -> "Renamed Web page YAML: " + oldName + " -> " + newName);
             }
             return renamed;
         }
@@ -232,7 +236,7 @@ public class YamlORWriter {
         if (oldFile.exists() && !newFile.exists()) {
             boolean renamed = oldFile.renameTo(newFile);
             if (renamed) {
-                LOGGER.info("Renamed Mobile page YAML: " + oldName + " -> " + newName);
+                LOGGER.info(() -> "Renamed Mobile page YAML: " + oldName + " -> " + newName);
             }
             return renamed;
         }
@@ -255,7 +259,7 @@ public class YamlORWriter {
         if (oldFile.exists() && !newFile.exists()) {
             boolean renamed = oldFile.renameTo(newFile);
             if (renamed) {
-                LOGGER.info("Renamed API page YAML: " + oldName + " -> " + newName);
+                LOGGER.info(() -> "Renamed API page YAML: " + oldName + " -> " + newName);
             }
             return renamed;
         }
@@ -274,12 +278,14 @@ public class YamlORWriter {
         
         if (webOR != null && !webOR.getPages().isEmpty()) {
             writeWebOR(webOR, orLocation);
-            LOGGER.info("Converted " + webOR.getPages().size() + " Web pages to YAML");
+            writeSharedMetadata(webOR, orLocation);
+            LOGGER.info(() -> "Converted " + webOR.getPages().size() + " Web pages to YAML");
         }
         
         if (mobileOR != null && !mobileOR.getPages().isEmpty()) {
             writeMobileOR(mobileOR, orLocation);
-            LOGGER.info("Converted " + mobileOR.getPages().size() + " Mobile pages to YAML");
+            writeSharedMetadata(mobileOR, orLocation);
+            LOGGER.info(() -> "Converted " + mobileOR.getPages().size() + " Mobile pages to YAML");
         }
     }
     
@@ -312,5 +318,72 @@ public class YamlORWriter {
      */
     public ObjectMapper getYamlMapper() {
         return yamlMapper;
+    }
+
+    private void writeSharedMetadataInternal(String orType, List<String> newProjects, String fileName, File sharedRoot) throws IOException {
+        if (newProjects == null || newProjects.isEmpty()) {
+            return;
+        }
+        File metadataFile = new File(sharedRoot, fileName);
+
+        Set<String> mergedProjects = new LinkedHashSet<>();
+        mergedProjects.addAll(readExistingProjects(metadataFile));
+        mergedProjects.addAll(newProjects);
+
+        Map<String, Object> metadata = new LinkedHashMap<>();
+        metadata.put("type", orType);
+        metadata.put("scope", "SHARED");
+        metadata.put("projects", new ArrayList<>(mergedProjects));
+
+        yamlMapper.writeValue(metadataFile, metadata);
+    }
+
+    public boolean sharedMetadataExists(String fileName, File sharedRoot) {
+        return new File(sharedRoot, fileName).exists();
+    }
+    
+    @SuppressWarnings("unchecked")
+    public List<String> readExistingProjects(File metadataFile) {
+        if (metadataFile == null || !metadataFile.exists()) {
+            return List.of();
+        }
+        try {
+            Map<String, Object> data = yamlMapper.readValue(metadataFile, Map.class);
+            Object projectsObj = data.get("projects");
+            if (projectsObj instanceof List<?>) {
+                List<String> result = new ArrayList<>();
+                for (Object o : (List<?>) projectsObj) {
+                    if (o != null) {
+                        result.add(o.toString().trim());
+                    }
+                }
+                return result;
+            }
+        } catch (Exception e) {
+        }
+        return List.of();
+    }
+    public void writeSharedMetadata(WebOR webSharedOR, File sharedRoot) throws IOException {
+        if (webSharedOR == null || !webSharedOR.isShared()) {
+            return;
+        }
+        writeSharedMetadataInternal(
+            "WebOR",
+            webSharedOR.getSharedProjects(),
+            "webor-projectsdata.yaml",
+            sharedRoot
+        );
+    }
+
+    public void writeSharedMetadata(MobileOR mobileSharedOR, File sharedRoot) throws IOException {
+        if (mobileSharedOR == null || !mobileSharedOR.isShared()) {
+            return;
+        }
+        writeSharedMetadataInternal(
+            "MobileOR",
+            mobileSharedOR.getSharedProjects(),
+            "mobileor-projectsdata.yaml",
+            sharedRoot
+        );
     }
 }

--- a/Datalib/src/main/java/com/ing/datalib/or/yaml/YamlPageDefinition.java
+++ b/Datalib/src/main/java/com/ing/datalib/or/yaml/YamlPageDefinition.java
@@ -30,7 +30,7 @@ import java.util.Map;
  * </pre>
  */
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-@JsonPropertyOrder({"page", "description", "urlPattern", "tags", "elements"})
+@JsonPropertyOrder({"page", "scope", "description", "urlPattern", "tags", "elements"})
 public class YamlPageDefinition {
     
     private String page;
@@ -38,6 +38,7 @@ public class YamlPageDefinition {
     private String urlPattern;
     private List<String> tags;
     private Map<String, YamlElementDefinition> elements = new LinkedHashMap<>();
+    private WebOR.ORScope scope;
     
     public YamlPageDefinition() {
     }
@@ -54,6 +55,14 @@ public class YamlPageDefinition {
 
     public void setPage(String page) {
         this.page = page;
+    }
+
+    public WebOR.ORScope getScope() {
+        return scope;
+    }
+
+    public void setScope(WebOR.ORScope scope) {
+        this.scope = scope;
     }
 
     public String getDescription() {
@@ -97,6 +106,10 @@ public class YamlPageDefinition {
         YamlPageDefinition yaml = new YamlPageDefinition();
         yaml.setPage(page.getName());
         
+        if (page.getRoot() != null) {
+            yaml.setScope(page.getRoot().getScope());
+        }
+
         // Iterate through object groups and objects using Lists
         for (ObjectGroup<WebORObject> group : page.getObjectGroups()) {
             for (WebORObject obj : group.getObjects()) {
@@ -115,6 +128,10 @@ public class YamlPageDefinition {
     public WebORPage toWebORPage(WebOR root) {
         WebORPage page = new WebORPage(this.page, root);
         
+        if (this.scope != null && root != null && this.scope != root.getScope()) { 
+            throw new IllegalStateException("Scope mismatch: YAML page '" + page + "' declares scope " + scope + " but is loaded under OR scope " + root.getScope());
+        }
+
         // Convert each element to WebORObject using direct list manipulation
         // to avoid calling factory methods that require ObjectRepository
         for (Map.Entry<String, YamlElementDefinition> entry : elements.entrySet()) {

--- a/Datalib/src/test/java/com/ing/datalib/or/yaml/YamlORTest.java
+++ b/Datalib/src/test/java/com/ing/datalib/or/yaml/YamlORTest.java
@@ -203,7 +203,7 @@ public class YamlORTest {
         writer.writeWebOR(webOR, tempDir.toFile());
         
         // Verify file exists
-        File yamlFile = new File(tempDir.toFile(), "Web/pages/HomePage.yaml");
+        File yamlFile = new File(tempDir.toFile(), "Web/HomePage.yaml");
         assertThat(yamlFile).exists();
         
         // Read back
@@ -233,7 +233,7 @@ public class YamlORTest {
         writer.writeMobileOR(mobileOR, tempDir.toFile());
         
         // Verify file exists
-        File yamlFile = new File(tempDir.toFile(), "Mobile/pages/LoginScreen.yaml");
+        File yamlFile = new File(tempDir.toFile(), "Mobile/LoginScreen.yaml");
         assertThat(yamlFile).exists();
         
         // Read back

--- a/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/or/ObjectPopupMenu.java
+++ b/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/or/ObjectPopupMenu.java
@@ -38,7 +38,7 @@ public class ObjectPopupMenu extends JPopupMenu {
     private JMenuItem renameObject;
     private JMenuItem deleteObject;
     private JMenuItem removeUnusedObject;
-    private JMenuItem copyToShared;
+    private JMenuItem moveToShared;
 
     private JMenuItem openPageDump;
 
@@ -63,18 +63,24 @@ public class ObjectPopupMenu extends JPopupMenu {
         add(renamePage = create("Rename Page", Keystroke.RENAME));
         add(deletePage = create("Delete Page", Keystroke.DELETE));
         addSeparator();
+        
         add(addObject = create("Add Object", Keystroke.NEW));
         add(renameObject = create("Rename Object", Keystroke.RENAME));
         add(deleteObject = create("Delete Object", Keystroke.DELETE));
         add(removeUnusedObject = create("Remove Unused Object",Keystroke.REMOVE_OBJECT));
         addSeparator();
-        copyToShared = create("Copy to Shared", null);
-        add(copyToShared);
+
+        moveToShared = create("Move to Shared", null);
+        moveToShared.setActionCommand("Move to Shared");
+        moveToShared.addActionListener(listener);
+        add(moveToShared);
         add(openPageDump = create("Open Page Dump", null));
         add(impactAnalysis = create("Get Impacted TestCases", null));
         addSeparator();
+        
         setCCP();
         addSeparator();
+        
         add(sort = create("Sort", null));
         sort.setIcon(Canvas.EmptyIcon);
     }
@@ -93,7 +99,7 @@ public class ObjectPopupMenu extends JPopupMenu {
         } else if (selected instanceof ORObjectInf) {
             forObject();
         }
-        copyToShared.setEnabled(!isSharedSelection(selected));
+        moveToShared.setEnabled(!isSharedSelection(currentSelection));
         removeUnusedObject.setEnabled(!isSharedSelection(selected));
     }
 

--- a/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/or/ObjectPopupMenu.java
+++ b/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/or/ObjectPopupMenu.java
@@ -4,17 +4,14 @@ package com.ing.ide.main.mainui.components.testdesign.or;
 import com.ing.datalib.or.common.ORObjectInf;
 import com.ing.datalib.or.common.ORPageInf;
 import com.ing.datalib.or.common.ORRootInf;
-//import com.ing.datalib.or.common.ObjectGroup;
-import com.ing.ide.main.utils.dnd.TransferActionListener;
+import com.ing.ide.main.mainui.components.testdesign.or.clipboard.ORClipboardManager;
 import com.ing.ide.main.utils.keys.Keystroke;
 import com.ing.ide.util.Canvas;
 import java.awt.event.ActionListener;
 import java.awt.event.KeyEvent;
-import javax.swing.Action;
 import javax.swing.JMenuItem;
 import javax.swing.JPopupMenu;
 import javax.swing.KeyStroke;
-import javax.swing.TransferHandler;
 
 /**
  * Context (right-click) popup menu for Object Repository (OR) tree nodes in the Test Design UI.
@@ -36,8 +33,6 @@ public class ObjectPopupMenu extends JPopupMenu {
     private JMenuItem addPage;
     private JMenuItem renamePage;
     private JMenuItem deletePage;
-    private JMenuItem renameObjectGroup;
-    private JMenuItem deleteObjectGroup;
     private JMenuItem addObject;
     private JMenuItem renameObject;
     private JMenuItem deleteObject;
@@ -54,6 +49,8 @@ public class ObjectPopupMenu extends JPopupMenu {
     private JMenuItem sort;
 
     private final ActionListener listener;
+    
+    private Object currentSelection;
 
     public ObjectPopupMenu(ActionListener listener) {
         this.listener = listener;
@@ -64,9 +61,6 @@ public class ObjectPopupMenu extends JPopupMenu {
         add(addPage = create("Add Page", Keystroke.NEW));
         add(renamePage = create("Rename Page", Keystroke.RENAME));
         add(deletePage = create("Delete Page", Keystroke.DELETE));
-//        addSeparator();
-//        add(renameObjectGroup = create("Rename Object Group", Keystroke.RENAME));
-//        add(deleteObjectGroup = create("Delete Object Group", Keystroke.DELETE));
         addSeparator();
         add(addObject = create("Add Object", Keystroke.NEW));
         add(renameObject = create("Rename Object", Keystroke.RENAME));
@@ -75,13 +69,9 @@ public class ObjectPopupMenu extends JPopupMenu {
         addSeparator();
         copyToShared = create("Copy to Shared", null);
         add(copyToShared);
-
-
         add(openPageDump = create("Open Page Dump", null));
         add(impactAnalysis = create("Get Impacted TestCases", null));
-
         addSeparator();
-
         setCCP();
         addSeparator();
         add(sort = create("Sort", null));
@@ -89,15 +79,16 @@ public class ObjectPopupMenu extends JPopupMenu {
     }
 
     public void togglePopupMenu(Object selected) {
-        copyToShared.setEnabled(false);
+        this.currentSelection = selected;
+        copy.setEnabled(false);
+        cut.setEnabled(false);
+        paste.setEnabled((currentSelection instanceof ORPageInf || currentSelection instanceof ORObjectInf)&& ORClipboardManager.hasData());
 
         if (selected instanceof ORRootInf) {
             forRoot();
             return;
         } else if (selected instanceof ORPageInf) {
             forPage();
-//        } else if (selected instanceof ObjectGroup) {
-//            forObjectGroup();
         } else if (selected instanceof ORObjectInf) {
             forObject();
         }
@@ -110,8 +101,6 @@ public class ObjectPopupMenu extends JPopupMenu {
         deletePage.setEnabled(true);
 
         addPage.setEnabled(false);
-//        renameObjectGroup.setEnabled(false);
-//        deleteObjectGroup.setEnabled(false);
 
         addObject.setEnabled(true);
         renameObject.setEnabled(false);
@@ -120,41 +109,13 @@ public class ObjectPopupMenu extends JPopupMenu {
         
         impactAnalysis.setEnabled(false);
 
-//        copy.setEnabled(true);
-//        cut.setEnabled(true);
-//        paste.setEnabled(true);
-
         sort.setEnabled(true);
     }
-
-//    private void forObjectGroup() {
-//        addPage.setEnabled(false);
-//        renamePage.setEnabled(false);
-//        deletePage.setEnabled(false);
-//
-//        renameObjectGroup.setEnabled(true);
-//        deleteObjectGroup.setEnabled(true);
-//
-//        addObject.setEnabled(true);
-//        renameObject.setEnabled(false);
-//        deleteObject.setEnabled(false);
-//
-//        impactAnalysis.setEnabled(true);
-//
-//        copy.setEnabled(true);
-//        cut.setEnabled(true);
-//        paste.setEnabled(true);
-//
-//        sort.setEnabled(false);
-//    }
 
     private void forObject() {
         addPage.setEnabled(false);
         renamePage.setEnabled(false);
         deletePage.setEnabled(false);
-
-//        renameObjectGroup.setEnabled(false);
-//        deleteObjectGroup.setEnabled(false);
 
         addObject.setEnabled(false);
         renameObject.setEnabled(true);
@@ -163,7 +124,7 @@ public class ObjectPopupMenu extends JPopupMenu {
         impactAnalysis.setEnabled(true);
 
         copy.setEnabled(true);
-        cut.setEnabled(true);
+        cut.setEnabled(!isSharedSelection(currentSelection));
         paste.setEnabled(true);
 
         sort.setEnabled(false);
@@ -176,18 +137,11 @@ public class ObjectPopupMenu extends JPopupMenu {
         renamePage.setEnabled(false);
         deletePage.setEnabled(false);
 
-//        renameObjectGroup.setEnabled(false);
-//        deleteObjectGroup.setEnabled(false);
-
         addObject.setEnabled(false);
         renameObject.setEnabled(false);
         deleteObject.setEnabled(false);
 
         impactAnalysis.setEnabled(false);
-
-        copy.setEnabled(false);
-        cut.setEnabled(false);
-        paste.setEnabled(false);
 
         sort.setEnabled(true);
     }
@@ -199,29 +153,44 @@ public class ObjectPopupMenu extends JPopupMenu {
         menuItem.addActionListener(listener);
         return menuItem;
     }
-
     private void setCCP() {
-        TransferActionListener actionListener = new TransferActionListener();
         cut = new JMenuItem("Cut");
-        cut.setActionCommand((String) TransferHandler.getCutAction().getValue(Action.NAME));
-        cut.addActionListener(actionListener);
         cut.setAccelerator(Keystroke.CUT);
         cut.setMnemonic(KeyEvent.VK_T);
+        cut.addActionListener(e -> handleCut());
         add(cut);
 
         copy = new JMenuItem("Copy");
-        copy.setActionCommand((String) TransferHandler.getCopyAction().getValue(Action.NAME));
-        copy.addActionListener(actionListener);
         copy.setAccelerator(Keystroke.COPY);
         copy.setMnemonic(KeyEvent.VK_C);
+        copy.addActionListener(e -> handleCopy());
         add(copy);
 
         paste = new JMenuItem("Paste");
-        paste.setActionCommand((String) TransferHandler.getPasteAction().getValue(Action.NAME));
-        paste.addActionListener(actionListener);
         paste.setAccelerator(Keystroke.PASTE);
         paste.setMnemonic(KeyEvent.VK_P);
+        paste.setActionCommand("Paste Object");
+        paste.addActionListener(listener);
         add(paste);
+    }
+
+    private void handleCopy() {
+        if (!(currentSelection instanceof ORObjectInf)) {
+            return;
+        }
+        ORObjectInf object = (ORObjectInf) currentSelection;
+        ORClipboardManager.copy(object);
+    }
+
+    private void handleCut() {
+        if (!(currentSelection instanceof ORObjectInf)) {
+            return;
+        }
+        if (isSharedSelection(currentSelection)) {
+            return;
+        }
+        ORObjectInf object = (ORObjectInf) currentSelection;
+        ORClipboardManager.cut(object);
     }
 
     private boolean isSharedSelection(Object selected) {
@@ -230,10 +199,8 @@ public class ObjectPopupMenu extends JPopupMenu {
             page = (ORPageInf) selected;
         } else if (selected instanceof ORObjectInf) {
             page = ((ORObjectInf) selected).getPage();
-        } 
-//        else if (selected instanceof ObjectGroup) {
-//            page = ((ObjectGroup) selected).getParent();
-//        }
+        }
+        
         if (page != null && page.getRoot() instanceof com.ing.datalib.or.web.WebOR) {
             com.ing.datalib.or.web.WebOR root = (com.ing.datalib.or.web.WebOR) page.getRoot();
             return root.isShared();

--- a/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/or/ObjectPopupMenu.java
+++ b/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/or/ObjectPopupMenu.java
@@ -5,6 +5,7 @@ import com.ing.datalib.or.common.ORObjectInf;
 import com.ing.datalib.or.common.ORPageInf;
 import com.ing.datalib.or.common.ORRootInf;
 import com.ing.ide.main.mainui.components.testdesign.or.clipboard.ORClipboardManager;
+import com.ing.ide.main.mainui.components.testdesign.or.clipboard.ORObjectClipboard;
 import com.ing.ide.main.utils.keys.Keystroke;
 import com.ing.ide.util.Canvas;
 import java.awt.event.ActionListener;
@@ -108,6 +109,10 @@ public class ObjectPopupMenu extends JPopupMenu {
         removeUnusedObject.setEnabled(true);
         
         impactAnalysis.setEnabled(false);
+        
+        copy.setEnabled(true);
+        cut.setEnabled(!isSharedSelection(currentSelection));
+        paste.setEnabled(true);
 
         sort.setEnabled(true);
     }
@@ -131,6 +136,8 @@ public class ObjectPopupMenu extends JPopupMenu {
     }
 
     private void forRoot() {
+        boolean hasClipboard = ORClipboardManager.hasData();
+        
         addPage.setEnabled(true);
         removeUnusedObject.setEnabled(false);
 
@@ -142,6 +149,8 @@ public class ObjectPopupMenu extends JPopupMenu {
         deleteObject.setEnabled(false);
 
         impactAnalysis.setEnabled(false);
+        
+        paste.setEnabled( hasClipboard && ORClipboardManager.get().getType() == ORObjectClipboard.Type.PAGE);
 
         sort.setEnabled(true);
     }
@@ -153,44 +162,28 @@ public class ObjectPopupMenu extends JPopupMenu {
         menuItem.addActionListener(listener);
         return menuItem;
     }
+
     private void setCCP() {
         cut = new JMenuItem("Cut");
+        cut.setActionCommand("Cut");           // for Pages
         cut.setAccelerator(Keystroke.CUT);
         cut.setMnemonic(KeyEvent.VK_T);
-        cut.addActionListener(e -> handleCut());
+        cut.addActionListener(listener);
         add(cut);
 
         copy = new JMenuItem("Copy");
+        copy.setActionCommand("Copy");         // for Pages
         copy.setAccelerator(Keystroke.COPY);
         copy.setMnemonic(KeyEvent.VK_C);
-        copy.addActionListener(e -> handleCopy());
+        copy.addActionListener(listener);
         add(copy);
 
         paste = new JMenuItem("Paste");
+        paste.setActionCommand("Paste");       // for Pages
         paste.setAccelerator(Keystroke.PASTE);
         paste.setMnemonic(KeyEvent.VK_P);
-        paste.setActionCommand("Paste Object");
         paste.addActionListener(listener);
         add(paste);
-    }
-
-    private void handleCopy() {
-        if (!(currentSelection instanceof ORObjectInf)) {
-            return;
-        }
-        ORObjectInf object = (ORObjectInf) currentSelection;
-        ORClipboardManager.copy(object);
-    }
-
-    private void handleCut() {
-        if (!(currentSelection instanceof ORObjectInf)) {
-            return;
-        }
-        if (isSharedSelection(currentSelection)) {
-            return;
-        }
-        ORObjectInf object = (ORObjectInf) currentSelection;
-        ORClipboardManager.cut(object);
     }
 
     private boolean isSharedSelection(Object selected) {

--- a/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/or/ObjectPopupMenu.java
+++ b/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/or/ObjectPopupMenu.java
@@ -106,7 +106,6 @@ public class ObjectPopupMenu extends JPopupMenu {
             forObject();
         }
         moveToShared.setEnabled(!isSharedSelection(currentSelection));
-        removeUnusedObject.setEnabled(!isSharedSelection(selected));
     }
 
     private void forPage() {
@@ -120,7 +119,7 @@ public class ObjectPopupMenu extends JPopupMenu {
         addObject.setEnabled(true);
         renameObject.setEnabled(false);
         deleteObject.setEnabled(false);
-        removeUnusedObject.setEnabled(true);
+        removeUnusedObject.setEnabled(!isSharedSelection(currentSelection));
         
         impactAnalysis.setEnabled(false);
         
@@ -142,6 +141,7 @@ public class ObjectPopupMenu extends JPopupMenu {
         addObject.setEnabled(true);
         renameObject.setEnabled(false);
         deleteObject.setEnabled(false);
+        removeUnusedObject.setEnabled(false);
 
         impactAnalysis.setEnabled(true);
 

--- a/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/or/ObjectPopupMenu.java
+++ b/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/or/ObjectPopupMenu.java
@@ -4,7 +4,7 @@ package com.ing.ide.main.mainui.components.testdesign.or;
 import com.ing.datalib.or.common.ORObjectInf;
 import com.ing.datalib.or.common.ORPageInf;
 import com.ing.datalib.or.common.ORRootInf;
-import com.ing.datalib.or.common.ObjectGroup;
+//import com.ing.datalib.or.common.ObjectGroup;
 import com.ing.ide.main.utils.dnd.TransferActionListener;
 import com.ing.ide.main.utils.keys.Keystroke;
 import com.ing.ide.util.Canvas;
@@ -64,9 +64,9 @@ public class ObjectPopupMenu extends JPopupMenu {
         add(addPage = create("Add Page", Keystroke.NEW));
         add(renamePage = create("Rename Page", Keystroke.RENAME));
         add(deletePage = create("Delete Page", Keystroke.DELETE));
-        addSeparator();
-        add(renameObjectGroup = create("Rename Object Group", Keystroke.RENAME));
-        add(deleteObjectGroup = create("Delete Object Group", Keystroke.DELETE));
+//        addSeparator();
+//        add(renameObjectGroup = create("Rename Object Group", Keystroke.RENAME));
+//        add(deleteObjectGroup = create("Delete Object Group", Keystroke.DELETE));
         addSeparator();
         add(addObject = create("Add Object", Keystroke.NEW));
         add(renameObject = create("Rename Object", Keystroke.RENAME));
@@ -96,8 +96,8 @@ public class ObjectPopupMenu extends JPopupMenu {
             return;
         } else if (selected instanceof ORPageInf) {
             forPage();
-        } else if (selected instanceof ObjectGroup) {
-            forObjectGroup();
+//        } else if (selected instanceof ObjectGroup) {
+//            forObjectGroup();
         } else if (selected instanceof ORObjectInf) {
             forObject();
         }
@@ -110,8 +110,8 @@ public class ObjectPopupMenu extends JPopupMenu {
         deletePage.setEnabled(true);
 
         addPage.setEnabled(false);
-        renameObjectGroup.setEnabled(false);
-        deleteObjectGroup.setEnabled(false);
+//        renameObjectGroup.setEnabled(false);
+//        deleteObjectGroup.setEnabled(false);
 
         addObject.setEnabled(true);
         renameObject.setEnabled(false);
@@ -120,43 +120,43 @@ public class ObjectPopupMenu extends JPopupMenu {
         
         impactAnalysis.setEnabled(false);
 
-        copy.setEnabled(true);
-        cut.setEnabled(true);
-        paste.setEnabled(true);
+//        copy.setEnabled(true);
+//        cut.setEnabled(true);
+//        paste.setEnabled(true);
 
         sort.setEnabled(true);
     }
 
-    private void forObjectGroup() {
-        addPage.setEnabled(false);
-        renamePage.setEnabled(false);
-        deletePage.setEnabled(false);
-
-        renameObjectGroup.setEnabled(true);
-        deleteObjectGroup.setEnabled(true);
-
-        addObject.setEnabled(true);
-        renameObject.setEnabled(false);
-        deleteObject.setEnabled(false);
-
-        impactAnalysis.setEnabled(true);
-
-        copy.setEnabled(true);
-        cut.setEnabled(true);
-        paste.setEnabled(true);
-
-        sort.setEnabled(false);
-    }
+//    private void forObjectGroup() {
+//        addPage.setEnabled(false);
+//        renamePage.setEnabled(false);
+//        deletePage.setEnabled(false);
+//
+//        renameObjectGroup.setEnabled(true);
+//        deleteObjectGroup.setEnabled(true);
+//
+//        addObject.setEnabled(true);
+//        renameObject.setEnabled(false);
+//        deleteObject.setEnabled(false);
+//
+//        impactAnalysis.setEnabled(true);
+//
+//        copy.setEnabled(true);
+//        cut.setEnabled(true);
+//        paste.setEnabled(true);
+//
+//        sort.setEnabled(false);
+//    }
 
     private void forObject() {
         addPage.setEnabled(false);
         renamePage.setEnabled(false);
         deletePage.setEnabled(false);
 
-        renameObjectGroup.setEnabled(false);
-        deleteObjectGroup.setEnabled(false);
+//        renameObjectGroup.setEnabled(false);
+//        deleteObjectGroup.setEnabled(false);
 
-        addObject.setEnabled(true);
+        addObject.setEnabled(false);
         renameObject.setEnabled(true);
         deleteObject.setEnabled(true);
 
@@ -176,8 +176,8 @@ public class ObjectPopupMenu extends JPopupMenu {
         renamePage.setEnabled(false);
         deletePage.setEnabled(false);
 
-        renameObjectGroup.setEnabled(false);
-        deleteObjectGroup.setEnabled(false);
+//        renameObjectGroup.setEnabled(false);
+//        deleteObjectGroup.setEnabled(false);
 
         addObject.setEnabled(false);
         renameObject.setEnabled(false);
@@ -230,9 +230,10 @@ public class ObjectPopupMenu extends JPopupMenu {
             page = (ORPageInf) selected;
         } else if (selected instanceof ORObjectInf) {
             page = ((ORObjectInf) selected).getPage();
-        } else if (selected instanceof ObjectGroup) {
-            page = ((ObjectGroup) selected).getParent();
-        }
+        } 
+//        else if (selected instanceof ObjectGroup) {
+//            page = ((ObjectGroup) selected).getParent();
+//        }
         if (page != null && page.getRoot() instanceof com.ing.datalib.or.web.WebOR) {
             com.ing.datalib.or.web.WebOR root = (com.ing.datalib.or.web.WebOR) page.getRoot();
             return root.isShared();

--- a/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/or/ObjectPopupMenu.java
+++ b/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/or/ObjectPopupMenu.java
@@ -34,6 +34,8 @@ public class ObjectPopupMenu extends JPopupMenu {
     private JMenuItem addPage;
     private JMenuItem renamePage;
     private JMenuItem deletePage;
+    private JMenuItem renameObjectGroup;
+    private JMenuItem deleteObjectGroup;
     private JMenuItem addObject;
     private JMenuItem renameObject;
     private JMenuItem deleteObject;
@@ -62,6 +64,10 @@ public class ObjectPopupMenu extends JPopupMenu {
         add(addPage = create("Add Page", Keystroke.NEW));
         add(renamePage = create("Rename Page", Keystroke.RENAME));
         add(deletePage = create("Delete Page", Keystroke.DELETE));
+        addSeparator();
+        
+        add(renameObjectGroup = create("Rename Object Group", Keystroke.RENAME));
+        add(deleteObjectGroup = create("Delete Object Group", Keystroke.DELETE));
         addSeparator();
         
         add(addObject = create("Add Object", Keystroke.NEW));
@@ -104,11 +110,13 @@ public class ObjectPopupMenu extends JPopupMenu {
     }
 
     private void forPage() {
+        addPage.setEnabled(false);
         renamePage.setEnabled(true);
         deletePage.setEnabled(true);
-
-        addPage.setEnabled(false);
-
+        
+        renameObjectGroup.setEnabled(false);
+        deleteObjectGroup.setEnabled(false);
+        
         addObject.setEnabled(true);
         renameObject.setEnabled(false);
         deleteObject.setEnabled(false);
@@ -122,15 +130,40 @@ public class ObjectPopupMenu extends JPopupMenu {
 
         sort.setEnabled(true);
     }
+    
+    private void forObjectGroup() {
+        addPage.setEnabled(false);
+        renamePage.setEnabled(false);
+        deletePage.setEnabled(false);
+
+        renameObjectGroup.setEnabled(true);
+        deleteObjectGroup.setEnabled(true);
+
+        addObject.setEnabled(true);
+        renameObject.setEnabled(false);
+        deleteObject.setEnabled(false);
+
+        impactAnalysis.setEnabled(true);
+
+        copy.setEnabled(true);
+        cut.setEnabled(!isSharedSelection(currentSelection));
+        paste.setEnabled(true);
+
+        sort.setEnabled(true);
+    }
 
     private void forObject() {
         addPage.setEnabled(false);
         renamePage.setEnabled(false);
         deletePage.setEnabled(false);
+        
+        renameObjectGroup.setEnabled(false);
+        deleteObjectGroup.setEnabled(false);
 
         addObject.setEnabled(false);
         renameObject.setEnabled(true);
         deleteObject.setEnabled(true);
+        removeUnusedObject.setEnabled(false);
 
         impactAnalysis.setEnabled(true);
 
@@ -145,19 +178,20 @@ public class ObjectPopupMenu extends JPopupMenu {
         boolean hasClipboard = ORClipboardManager.hasData();
         
         addPage.setEnabled(true);
-        removeUnusedObject.setEnabled(false);
-
         renamePage.setEnabled(false);
         deletePage.setEnabled(false);
+        
+        renameObjectGroup.setEnabled(false);
+        deleteObjectGroup.setEnabled(false);
 
         addObject.setEnabled(false);
         renameObject.setEnabled(false);
         deleteObject.setEnabled(false);
+        removeUnusedObject.setEnabled(false);
 
         impactAnalysis.setEnabled(false);
         
         paste.setEnabled( hasClipboard && ORClipboardManager.get().getType() == ORObjectClipboard.Type.PAGE);
-
         sort.setEnabled(true);
     }
 

--- a/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/or/ObjectRepDnD.java
+++ b/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/or/ObjectRepDnD.java
@@ -4,6 +4,8 @@ package com.ing.ide.main.mainui.components.testdesign.or;
 import com.ing.datalib.or.common.ORObjectInf;
 import com.ing.datalib.or.common.ORPageInf;
 import com.ing.datalib.or.common.ObjectGroup;
+import com.ing.datalib.or.mobile.MobileOR;
+import com.ing.datalib.or.web.WebOR;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -102,11 +104,18 @@ public class ObjectRepDnD {
     }
     
     private String scopeOf(ORPageInf page) {
-        try {
-            var m = page.getClass().getMethod("getSource");
-            Object src = m.invoke(page);
-            if (src != null && src.toString().equalsIgnoreCase("SHARED")) return "SHARED";
-        } catch (Exception ignore) { }
+        if (page == null) {
+            return "PROJECT";
+        }
+        Object parent = page.getParent();
+        if (parent instanceof WebOR) {
+            WebOR root = (WebOR) parent;
+            return root.getScope().name();
+        }
+        if (parent instanceof MobileOR) {
+            MobileOR root = (MobileOR) parent;
+            return root.getScope().name();
+        }
         return "PROJECT";
     }
 

--- a/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/or/ObjectTree.java
+++ b/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/or/ObjectTree.java
@@ -13,6 +13,7 @@ import com.ing.datalib.or.common.ObjectGroup;
 import com.ing.datalib.or.mobile.MobileOR;
 import com.ing.datalib.or.mobile.MobileORObject;
 import com.ing.datalib.or.mobile.MobileORPage;
+import com.ing.datalib.or.mobile.ResolvedMobileObject;
 import com.ing.datalib.or.web.ResolvedWebObject;
 import com.ing.datalib.or.web.WebOR;
 import com.ing.datalib.or.web.WebORObject;
@@ -924,7 +925,28 @@ public abstract class ObjectTree implements ActionListener {
                 Notification.show("Moved Object '" + newName + "' to Shared OR");
             }
         }
-        // TODO: mirror same logic for Mobile OR
+        if (isMobile) {
+            ResolvedMobileObject resolved =
+                repo.resolveMobileObject(
+                    new ResolvedMobileObject.PageRef(
+                        page.getName(),
+                        WebOR.ORScope.PROJECT
+                    ),
+                    objectName
+                );
+            if (resolved == null || !resolved.isPresent()) {
+                Notification.show("Mobile Object not found in Project OR");
+                return;
+            }
+            String newName = repo.copyMobileObject(resolved, page.getName());
+            if (newName != null) {
+                objectRemoved(obj);
+                obj.removeFromParent();
+                repo.save();
+                refreshSharedTree();
+                Notification.show("Moved Mobile Object '" + newName + "' to Shared OR");
+            }
+        }
     }
 
     private void movePageToShared(ORPageInf page) {
@@ -933,8 +955,7 @@ public abstract class ObjectTree implements ActionListener {
         boolean isWeb = root instanceof WebOR;
         boolean isMobile = root instanceof MobileOR;
         if (isWeb) {
-            String newPageName =
-                repo.copyWebPage(page.getName(), page.getName());
+            String newPageName = repo.copyWebPage(page.getName(), page.getName());
             if (newPageName != null) {
                 pageRemoved(page);
                 page.removeFromParent();
@@ -943,7 +964,16 @@ public abstract class ObjectTree implements ActionListener {
                 Notification.show( "Moved Page '" + page.getName() + "' to Shared OR");
             }
         }
-        // TODO: mirror same logic for Mobile OR
+        if (isMobile) {
+            String newPageName = repo.copyMobilePage(page.getName(), page.getName());
+            if (newPageName != null) {
+                pageRemoved(page);
+                page.removeFromParent();
+                repo.save();
+                refreshSharedTree();
+                Notification.show("Moved Mobile Page '" + page.getName() + "' to Shared OR");
+            }
+        }
     }
 
     private void refreshSharedTree() {

--- a/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/or/ObjectTree.java
+++ b/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/or/ObjectTree.java
@@ -311,8 +311,14 @@ public abstract class ObjectTree implements ActionListener {
             case "Copy to Shared":
                 copyToShared();
                 break;
-            case "Paste Object":
-                pasteObject();
+            case "Copy":
+                copySelection();
+                break;
+            case "Cut":
+                cutSelection();
+                break;
+            case "Paste":
+                pasteSelection();
                 break;
             default:
                 throw new UnsupportedOperationException();
@@ -1176,7 +1182,7 @@ public abstract class ObjectTree implements ActionListener {
         ORObjectInf source = clipboard.getObject();
         boolean cut = clipboard.isCut();
         if (cut && isSharedScope()) {
-            Notification.show("Cut is not allowed in Shared Object Repository");
+            Notification.show("Cut is not allowed in Shared Object Repository. Use `Moved to Shared` instead.");
             return;
         }
         ORObjectInf newObject = null;
@@ -1241,4 +1247,86 @@ public abstract class ObjectTree implements ActionListener {
         }
         return false;
     }
+    
+    private void copySelection() {
+        if (getSelectedObject() != null) {
+            ORClipboardManager.copy(getSelectedObject());
+            return;
+        }
+        if (getSelectedPage() != null) {
+            ORClipboardManager.copy(getSelectedPage());
+        }
+    }
+
+    private void cutSelection() {
+        if (isSharedScope()) {
+            Notification.show("Cut is not allowed in Shared Object Repository. Use `Move to Shared` instead");
+            return;
+        }
+        if (getSelectedObject() != null) {
+            ORClipboardManager.cut(getSelectedObject());
+            return;
+        }
+        if (getSelectedPage() != null) {
+            ORClipboardManager.cut(getSelectedPage());
+        }
+    }
+
+    private void pasteSelection() {
+        if (!ORClipboardManager.hasData()) {
+            return;
+        }
+        ORObjectClipboard cb = ORClipboardManager.get();
+        if (cb.getType() == ORObjectClipboard.Type.OBJECT) {
+            pasteObject();
+            return;
+        }
+        if (cb.getType() == ORObjectClipboard.Type.PAGE) {
+            pastePage();
+        }
+    }
+
+    private void pastePage() {
+        ORObjectClipboard cb = ORClipboardManager.get();
+        ORPageInf sourcePage = cb.getPage();
+        boolean cut = cb.isCut();
+        if (cut && isSharedScope()) {
+            Notification.show("Cut is not allowed in Shared Object Repository. Use `Move to Shared` instead");
+            return;
+        }
+        String newPageName = cut
+                ? sourcePage.getName()
+                : computeCopyPageName(sourcePage);
+        ORPageInf newPage = getOR().addPage(newPageName);
+        pageAdded(newPage);
+        for (Object o : sourcePage.getObjectGroups()) {
+            ObjectGroup sourceGroup = (ObjectGroup) o;
+            Enumeration<?> children = sourceGroup.children();
+            while (children.hasMoreElements()) {
+                ORObjectInf sourceObject =
+                        (ORObjectInf) children.nextElement();
+                String objectName = cut
+                        ? sourceObject.getName().toString()
+                        : computeCopyName(newPage, sourceObject);
+                ORObjectInf newObject = newPage.addObject(objectName);
+                objectAddedPage(newObject);
+            }
+        }
+        if (cut) {
+            pageRemoved(sourcePage);
+            sourcePage.removeFromParent();
+            ORClipboardManager.clear();
+        }
+    }
+
+    private String computeCopyPageName(ORPageInf source) {
+        String base = source.getName().replaceAll("_Copy_\\d+$", "");
+        int i = 1;
+        String candidate;
+        do {
+            candidate = base + "_Copy_" + i++;
+        } while (getOR().getPageByName(candidate) != null);
+        return candidate;
+    }
+
 }

--- a/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/or/ObjectTree.java
+++ b/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/or/ObjectTree.java
@@ -38,6 +38,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import com.ing.ide.main.mainui.AppMainFrame;
+import com.ing.ide.main.mainui.components.testdesign.or.clipboard.ORClipboardManager;
+import com.ing.ide.main.mainui.components.testdesign.or.clipboard.ORObjectClipboard;
 import java.awt.Toolkit;
 import java.awt.event.KeyEvent;
 import java.util.List;
@@ -71,6 +73,7 @@ import org.w3c.dom.Node;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.Iterator;
 
@@ -307,6 +310,9 @@ public abstract class ObjectTree implements ActionListener {
                 break;
             case "Copy to Shared":
                 copyToShared();
+                break;
+            case "Paste Object":
+                pasteObject();
                 break;
             default:
                 throw new UnsupportedOperationException();
@@ -1160,5 +1166,79 @@ public abstract class ObjectTree implements ActionListener {
                     + String.join(", ", projects);
         }
         return "";
+    }
+    
+    private void pasteObject() {
+        if (!ORClipboardManager.hasData()) {
+            return;
+        }
+        ORObjectClipboard clipboard = ORClipboardManager.get();
+        ORObjectInf source = clipboard.getObject();
+        boolean cut = clipboard.isCut();
+        if (cut && isSharedScope()) {
+            Notification.show("Cut is not allowed in Shared Object Repository");
+            return;
+        }
+        ORObjectInf newObject = null;
+        if (getSelectedPage() != null) {
+            ORPageInf page = getSelectedPage();
+            String newName = cut
+                    ? source.getName()
+                    : computeCopyName(page, source);
+            newObject = page.addObject(newName);
+            objectAddedPage(newObject);
+        } else if (getSelectedObjectGroup() != null) {
+            ObjectGroup group = getSelectedObjectGroup();
+            ORPageInf page = group.getParent();
+            String newName = cut
+                    ? source.getName()
+                    : computeCopyName(page, source);
+            newObject = group.addObject(newName);
+            objectAddedGroup(newObject);
+        } else if (getSelectedObject() != null) {
+            ObjectGroup group = (ObjectGroup) getSelectedObject().getParent();
+            ORPageInf page = group.getParent();
+            String newName = cut
+                    ? source.getName()
+                    : computeCopyName(page, source);
+            newObject = group.addObject(newName);
+            objectAdded(newObject);
+        }
+        if (newObject == null) {
+            return;
+        }
+        if (cut) {
+            objectRemoved(source);
+            source.removeFromParent();
+            ORClipboardManager.clear();
+        }
+    }
+
+    private String computeCopyName(ORPageInf page, ORObjectInf source) {
+        String original = source.getName();
+        String base = original.replaceAll("_Copy_\\d+$", "");
+        int index = 1;
+        String candidate;
+        do {
+            candidate = base + "_Copy_" + index++;
+        } while (objectNameExists(page, candidate));
+        return candidate;
+    }
+
+    private boolean objectNameExists(ORPageInf page, String name) {
+        for (Object groupObj : page.getObjectGroups()) {
+            ObjectGroup group = (ObjectGroup) groupObj;
+            Enumeration<?> children = group.children();
+            while (children.hasMoreElements()) {
+                Object child = children.nextElement();
+                if (child instanceof ORObjectInf) {
+                    ORObjectInf obj = (ORObjectInf) child;
+                    if (name.equals(obj.getName())) {
+                        return true;
+                    }
+                }
+            }
+        }
+        return false;
     }
 }

--- a/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/or/ObjectTree.java
+++ b/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/or/ObjectTree.java
@@ -40,6 +40,10 @@ import java.util.Set;
 import com.ing.ide.main.mainui.AppMainFrame;
 import com.ing.ide.main.mainui.components.testdesign.or.clipboard.ORClipboardManager;
 import com.ing.ide.main.mainui.components.testdesign.or.clipboard.ORObjectClipboard;
+import com.ing.ide.main.mainui.components.testdesign.or.mobile.MobileORPanel;
+import com.ing.ide.main.mainui.components.testdesign.or.mobile.MobileObjectTree;
+import com.ing.ide.main.mainui.components.testdesign.or.web.WebORPanel;
+import com.ing.ide.main.mainui.components.testdesign.or.web.WebObjectTree;
 import java.awt.Toolkit;
 import java.awt.event.KeyEvent;
 import java.util.List;
@@ -308,8 +312,8 @@ public abstract class ObjectTree implements ActionListener {
             case "Open Page Dump":
                 openPageDump();
                 break;
-            case "Copy to Shared":
-                copyToShared();
+            case "Move to Shared":
+                moveToShared();
                 break;
             case "Copy":
                 copySelection();
@@ -877,121 +881,79 @@ public abstract class ObjectTree implements ActionListener {
         }
     }
 
-    private void copyToShared() {
-        ORObjectInf obj = getSelectedObject();
-        ObjectGroup group = getSelectedObjectGroup();
-        ORPageInf selectedPage = getSelectedPage();
-
-        if (obj == null && group == null && selectedPage == null) {
-            com.ing.ide.util.Notification.show("Select an Object, Object Group, or Page.");
+    private void moveToShared() {
+        if (isSharedScope()) {
+            Notification.show("Objects already in Shared Repository");
             return;
         }
-
-        ORPageInf page = (obj != null) ? obj.getPage()
-                : (group != null) ? group.getParent()
-                : selectedPage;
-
-        ObjectRepository repo = getProject().getObjectRepository();
-
-        ORRootInf root = getOR();
-        boolean isWeb = (root instanceof com.ing.datalib.or.web.WebOR);
-        boolean isMobile = (root instanceof com.ing.datalib.or.mobile.MobileOR);
-
-        if (obj == null && group == null && selectedPage != null) {
-            if (isWeb) {
-                String newName = repo.copyWebPage(page.getName(), page.getName());
-                if (newName != null) {
-                    com.ing.ide.util.Notification.show("Copied Page '" + page.getName() + "' to Shared Web Object successfully as '" + newName + "'.");
-                } else {
-                    com.ing.ide.util.Notification.show("Copy failed. Could not copy Page '" + page.getName() + "' to Shared Web Objects.");
-                }
-                if (newName != null) {
-                    if (this instanceof com.ing.ide.main.mainui.components.testdesign.or.web.WebObjectTree) {
-                        com.ing.ide.main.mainui.components.testdesign.or.web.WebORPanel panel =
-                            ((com.ing.ide.main.mainui.components.testdesign.or.web.WebObjectTree) this).getORPanel();
-                        panel.getSharedTree().load();
-                    } else {
-                        reload();
-                    }
-                }
-                return;
-            } else if (isMobile) {
-                String newName = repo.copyMobilePage(page.getName(), page.getName());
-                if (newName != null) {
-                    com.ing.ide.util.Notification.show("Copied Page '" + page.getName() + "' to Shared Mobile Object successfully as '" + newName + "'.");
-                } else {
-                    com.ing.ide.util.Notification.show("Copy failed. Could not copy Page '" + page.getName() + "' to Shared Mobile Objects.");
-                }
-                if (newName != null) {
-                    if (this instanceof com.ing.ide.main.mainui.components.testdesign.or.mobile.MobileObjectTree) {
-                        com.ing.ide.main.mainui.components.testdesign.or.mobile.MobileORPanel panel =
-                            ((com.ing.ide.main.mainui.components.testdesign.or.mobile.MobileObjectTree) this).getORPanel();
-                        panel.getSharedTree().load();
-                    } else {
-                        reload();
-                    }
-                }
-                return;
-            }
+        if (getSelectedObject() != null) {
+            moveObjectToShared(getSelectedObject());
+            return;
         }
+        if (getSelectedPage() != null) {
+            movePageToShared(getSelectedPage());
+        }
+    }
 
-        String objectName = (obj != null) ? obj.getName() : group.getName();
-
+    private void moveObjectToShared(ORObjectInf obj) {
+        ObjectRepository repo = getProject().getObjectRepository();
+        ORPageInf page = obj.getPage();
+        ORRootInf root = getOR();
+        boolean isWeb = root instanceof WebOR;
+        boolean isMobile = root instanceof MobileOR;
+        String objectName = obj.getName().toString();
         if (isWeb) {
             ResolvedWebObject resolved =
                 repo.resolveWebObject(
-                    new ResolvedWebObject.PageRef(page.getName(), com.ing.datalib.or.web.WebOR.ORScope.PROJECT),
-                    objectName
-                );
-            if (resolved == null) {
-                com.ing.ide.util.Notification.show("Object '" + objectName + "' not found in Project OR (Page '" + page.getName() + "').");
-                return;
-            }
-
-            String copiedName = repo.copyWebObject(resolved, page.getName());
-            if (copiedName != null) {
-                com.ing.ide.util.Notification.show("Copied Object '" + copiedName + "' from Page '" + page.getName() + "' to Shared Web Object successfully.");
-            } else {
-                com.ing.ide.util.Notification.show("Copy failed. Could not copy Object '" + objectName + "' to Shared Web Object (Page '" + page.getName() + "').");
-            }
-            if (copiedName != null) {
-                if (this instanceof com.ing.ide.main.mainui.components.testdesign.or.web.WebObjectTree) {
-                    com.ing.ide.main.mainui.components.testdesign.or.web.WebORPanel panel =
-                        ((com.ing.ide.main.mainui.components.testdesign.or.web.WebObjectTree) this).getORPanel();
-                    panel.getSharedTree().load();
-                } else {
-                    reload();
-                }
-            }
-        } else if (isMobile) {
-            com.ing.datalib.or.mobile.ResolvedMobileObject mresolved =
-                repo.resolveMobileObject(
-                    new com.ing.datalib.or.mobile.ResolvedMobileObject.PageRef(
+                    new ResolvedWebObject.PageRef(
                         page.getName(),
-                        com.ing.datalib.or.web.WebOR.ORScope.PROJECT
+                        WebOR.ORScope.PROJECT
                     ),
                     objectName
                 );
-            if (mresolved == null) {
-                com.ing.ide.util.Notification.show("Object '" + objectName + "' not found in Project Mobile OR (Page '" + page.getName() + "').");
+            if (resolved == null) {
+                Notification.show("Object not found in Project OR");
                 return;
             }
+            String newName = repo.copyWebObject(resolved, page.getName());
+            if (newName != null) {
+                objectRemoved(obj);
+                obj.removeFromParent();
+                repo.save();
+                refreshSharedTree();
+                Notification.show("Moved Object '" + newName + "' to Shared OR");
+            }
+        }
+        // TODO: mirror same logic for Mobile OR
+    }
 
-            String copiedName = repo.copyMobileObject(mresolved, page.getName());
-            if (copiedName != null) {
-                com.ing.ide.util.Notification.show("Copied Object '" + copiedName + "' from Page '" + page.getName() + "' to Shared Mobile Object successfully.");
-            } else {
-                com.ing.ide.util.Notification.show("Copy failed. Could not copy Object '" + objectName + "' to Shared Mobile Object (Page '" + page.getName() + "').");
+    private void movePageToShared(ORPageInf page) {
+        ObjectRepository repo = getProject().getObjectRepository();
+        ORRootInf root = getOR();
+        boolean isWeb = root instanceof WebOR;
+        boolean isMobile = root instanceof MobileOR;
+        if (isWeb) {
+            String newPageName =
+                repo.copyWebPage(page.getName(), page.getName());
+            if (newPageName != null) {
+                pageRemoved(page);
+                page.removeFromParent();
+                repo.save();
+                refreshSharedTree();
+                Notification.show( "Moved Page '" + page.getName() + "' to Shared OR");
             }
-            if (copiedName != null) {
-                if (this instanceof com.ing.ide.main.mainui.components.testdesign.or.mobile.MobileObjectTree) {
-                    com.ing.ide.main.mainui.components.testdesign.or.mobile.MobileORPanel panel =
-                        ((com.ing.ide.main.mainui.components.testdesign.or.mobile.MobileObjectTree) this).getORPanel();
-                    panel.getSharedTree().load();
-                } else {
-                    reload();
-                }
-            }
+        }
+        // TODO: mirror same logic for Mobile OR
+    }
+
+    private void refreshSharedTree() {
+        if (this instanceof WebObjectTree) {
+            WebORPanel panel = ((WebObjectTree) this).getORPanel();
+            panel.getSharedTree().load();
+
+        } else if (this instanceof MobileObjectTree) {
+            MobileORPanel panel = ((MobileObjectTree) this).getORPanel();
+            panel.getSharedTree().load();
         }
     }
 

--- a/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/or/ObjectTree.java
+++ b/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/or/ObjectTree.java
@@ -2,14 +2,21 @@
 package com.ing.ide.main.mainui.components.testdesign.or;
 
 import com.ing.datalib.component.Project;
+import com.ing.datalib.component.Scenario;
 import com.ing.datalib.component.TestCase;
+import com.ing.datalib.component.TestStep;
 import com.ing.datalib.or.ObjectRepository;
 import com.ing.datalib.or.common.ORObjectInf;
 import com.ing.datalib.or.common.ORPageInf;
 import com.ing.datalib.or.common.ORRootInf;
 import com.ing.datalib.or.common.ObjectGroup;
+import com.ing.datalib.or.mobile.MobileOR;
+import com.ing.datalib.or.mobile.MobileORObject;
+import com.ing.datalib.or.mobile.MobileORPage;
 import com.ing.datalib.or.web.ResolvedWebObject;
 import com.ing.datalib.or.web.WebOR;
+import com.ing.datalib.or.web.WebORObject;
+import com.ing.datalib.or.web.WebORPage;
 import com.ing.ide.main.help.Help;
 
 import com.ing.ide.main.utils.keys.Keystroke;
@@ -31,7 +38,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import com.ing.ide.main.mainui.AppMainFrame;
-import com.ing.ide.main.mainui.components.testdesign.or.web.WebObjectTree;
 import java.awt.Toolkit;
 import java.awt.event.KeyEvent;
 import java.util.List;
@@ -52,7 +58,6 @@ import javax.swing.tree.DefaultTreeModel;
 import javax.swing.tree.TreeNode;
 import javax.swing.tree.TreePath;
 import java.io.File;
-import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerFactory;
@@ -62,12 +67,12 @@ import javax.xml.xpath.XPathConstants;
 import javax.xml.xpath.XPathExpression;
 import javax.xml.xpath.XPathFactory;
 import org.w3c.dom.Document;
-import org.w3c.dom.Element;
 import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.HashSet;
+import java.util.Iterator;
 
 /**
  * Base abstract class representing a fully interactive Object Repository (OR) tree.
@@ -471,116 +476,155 @@ public abstract class ObjectTree implements ActionListener {
             }
         }
     }
-    
+
     private void removeUnusedObject() {
+        boolean webDeletionPerformed = false;
+        boolean mobileDeletionPerformed = false;
         try {
-            Map<String, List> allORObject = new HashMap<String, List>();
-            Map<String, List> unUsedbject = new HashMap<String, List>();
-            List<String> objects = new ArrayList<>();
-            List<ORPageInf> pages = getSelectedPages();
-            if (!pages.isEmpty()) {
-                for (ORPageInf selectedPage : pages) {
-                    String page = selectedPage.toString();
-                    String orFilePath = getProject().getLocation() + "/OR.object";
-                    DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
-                    DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();
-                    Document doc = documentBuilder.parse(orFilePath);
-                    NodeList pageList = doc.getElementsByTagName("Page");
-                    for (int i = 0; i < pageList.getLength(); i++) {
-
-                        Node pageNode = pageList.item(i);
-                        if (pageNode.getNodeType() == Node.ELEMENT_NODE) {
-                            Element pageElement = (Element) pageNode;
-                            String pageName = pageElement.getAttribute("ref");
-                            if (pageName.equals(page)) {
-                                NodeList objectGroupNodeList = pageElement.getChildNodes();
-                                for (int j = 0; j < objectGroupNodeList.getLength(); j++) {
-
-                                    Node objectGroupNode = objectGroupNodeList.item(j);
-                                    if (objectGroupNode.getNodeType() == Node.ELEMENT_NODE) {
-                                        if (pageNode.getNodeType() == Node.ELEMENT_NODE) {
-                                            Element objectGroupElement = (Element) objectGroupNode;
-                                            NodeList objectList = objectGroupElement.getChildNodes();
-
-                                            for (int k = 0; k < objectList.getLength(); k++) {
-                                                Node objectNode = objectList.item(k);
-                                                if (objectNode.getNodeType() == Node.ELEMENT_NODE) {
-
-                                                    Element objectElement = (Element) objectNode;
-                                                    String objectName = objectElement.getAttribute("ref");
-                                                    if (!allORObject.containsKey(page)) {
-                                                        allORObject.put(page, new ArrayList<String>());
-                                                        allORObject.get(page).add(objectName);
-                                                    } else {
-                                                        allORObject.get(page).add(objectName);
-                                                    }
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
+            List<ORPageInf> selectedPages = getSelectedPages();
+            if (selectedPages == null || selectedPages.isEmpty()) {
+                return;
+            }
+            ObjectRepository repo = getProject().getObjectRepository();
+            WebOR projectWebOR = repo.getWebOR();
+            MobileOR projectMobileOR = repo.getMobileOR();
+            Set<String> usedProjectObjects = new HashSet<>();
+            for (Scenario scenario : getProject().getAllScenarios()) {
+                for (TestCase testCase : scenario.getTestCases()) {
+                    testCase.loadTableModel();
+                    for (TestStep step : testCase.getTestSteps()) {
+                        if (!step.isPageObjectStep()) {
+                            continue;
+                        }
+                        String ref = step.getReference();
+                        if (ref == null || ref.isBlank()) {
+                            continue;
+                        }
+                        String pageName = normalizePageRef(ref);
+                        String objectName = step.getObject();
+                        if (!pageName.isBlank() && !objectName.isBlank()) {
+                            usedProjectObjects.add(pageName + "@" + objectName);
+                        }
+                    }
+                }
+            }
+            for (ORPageInf selectedPage : selectedPages) {
+                String pageName = selectedPage.getName();
+                WebORPage webPage = projectWebOR.getPageByName(pageName);
+                if (webPage == null) {
+                    continue;
+                }
+                List<String> unusedWebObjects = new ArrayList<>();
+                for (ObjectGroup group : webPage.getObjectGroups()) {
+                    if (!usedProjectObjects.contains(pageName + "@" + group.getName())) {
+                        unusedWebObjects.add(group.getName());
+                    }
+                }
+                if (!unusedWebObjects.isEmpty()) {
+                    int option = JOptionPane.showConfirmDialog(
+                        null,
+                        "<html><body><p style='width: 260px;'>"
+                        + "Delete the following Web objects from page [ "
+                        + pageName + " ]?<br>"
+                        + unusedWebObjects
+                        + "</p></body></html>",
+                        "Delete Web Objects",
+                        JOptionPane.YES_NO_OPTION
+                    );
+                    if (option == JOptionPane.YES_OPTION) {
+                        Iterator<ObjectGroup<WebORObject>> it = webPage.getObjectGroups().iterator();
+                        while (it.hasNext()) {
+                            ObjectGroup group = it.next();
+                            if (unusedWebObjects.contains(group.getName())) {
+                                it.remove();
+                                projectWebOR.setSaved(false);
+                                webDeletionPerformed = true;
                             }
                         }
-                    }
-                }
-            }
-            unUsedbject = UnusedObject(allORObject, usedObject());
-            int unusedObjectCount = 0;
-            for (String page : unUsedbject.keySet()) {
-
-                List<String> unUsedobjects = unUsedbject.get(page);
-                if (!unUsedobjects.isEmpty()) {
-                    unusedObjectCount = unusedObjectCount + 1;
-                    int option = JOptionPane.showConfirmDialog(null,
-                            "<html><body><p style='width: 200px;'>"
-                            + "Are you sure want to delete the following Objects from page [ "
-                            + page
-                            + " ]"
-                            + " ?<br>"
-                            + unUsedobjects
-                            + "</p></body></html>",
-                            "Delete Objects",
-                            JOptionPane.YES_NO_OPTION);
-                    if (option == JOptionPane.YES_OPTION) {
-                        for (String objectName : unUsedobjects) {
-                            deleteUnusedObject(page, objectName);
-
+                        if (webDeletionPerformed) {
+                            repo.saveWebPageNow(webPage);
                         }
-
                     }
                 }
-
             }
-            if (unusedObjectCount != 0) {
-                int option = JOptionPane.showConfirmDialog(null,
-                        "<html><body><p style='width: 200px;'>"
-                        + "Do you want to restart INGenious to load updated Object Repository ?"
-                        + " <br>"
+            for (ORPageInf selectedPage : selectedPages) {
+                String pageName = selectedPage.getName();
+                MobileORPage mobilePage = projectMobileOR.getPageByName(pageName);
+                if (mobilePage == null) {
+                    continue;
+                }
+                List<String> unusedMobileObjects = new ArrayList<>();
+                for (ObjectGroup group : mobilePage.getObjectGroups()) {
+                    if (!usedProjectObjects.contains(pageName + "@" + group.getName())) {
+                        unusedMobileObjects.add(group.getName());
+                    }
+                }
+                if (!unusedMobileObjects.isEmpty()) {
+                    int option = JOptionPane.showConfirmDialog(
+                        null,
+                        "<html><body><p style='width: 260px;'>"
+                        + "Delete the following Mobile objects from page [ "
+                        + pageName + " ]?<br>"
+                        + unusedMobileObjects
                         + "</p></body></html>",
-                        "Restart INGenious",
-                        JOptionPane.YES_NO_OPTION);
+                        "Delete Mobile Objects",
+                        JOptionPane.YES_NO_OPTION
+                    );
+                    if (option == JOptionPane.YES_OPTION) {
+                        Iterator<ObjectGroup<MobileORObject>> it = mobilePage.getObjectGroups().iterator();
+                        while (it.hasNext()) {
+                            ObjectGroup group = it.next();
+                            if (unusedMobileObjects.contains(group.getName())) {
+                                it.remove();
+                                projectMobileOR.setSaved(false);
+                                mobileDeletionPerformed = true;
+                            }
+                        }
+                        if (mobileDeletionPerformed) {
+                            repo.saveMobilePageNow(mobilePage);
+                        }
+                    }
+                }
+            }
+            if (webDeletionPerformed || mobileDeletionPerformed) {
+                repo.save();
+                int option = JOptionPane.showConfirmDialog(
+                    null,
+                    "<html><body><p style='width: 260px;'>"
+                    + "Do you want to restart INGenious to load the updated Object Repository?"
+                    + "</p></body></html>",
+                    "Restart INGenious",
+                    JOptionPane.YES_NO_OPTION
+                );
                 if (option == JOptionPane.YES_OPTION) {
-                    AppMainFrame s = new AppMainFrame();
-                    s.restart();
+                    new AppMainFrame().restart();
                 }
             } else {
-                 
-                 JOptionPane.showMessageDialog(null,
-                        "<html><body><p style='width: 200px;'>"
-                        + "No unused object found"
-                        + " <br>"
-                        + "</p></body></html>",
-                        "Unused Object",
-                        JOptionPane.OK_OPTION);
+                JOptionPane.showMessageDialog(
+                    null,
+                    "<html><body><p style='width: 240px;'>"
+                    + "No unused object found or removal was cancelled."
+                    + "</p></body></html>",
+                    "Unused Object",
+                    JOptionPane.INFORMATION_MESSAGE
+                );
             }
-
+            ((DefaultTreeModel) tree.getModel()).reload();
+            tree.updateUI();
         } catch (Exception e) {
             e.printStackTrace();
         }
+    }
 
+    private String normalizePageRef(String ref) {
+        if (ref == null) return "";
+        ref = ref.trim();
+        if (ref.startsWith("[Project] ")) return ref.substring(10).trim();
+        if (ref.startsWith("[Shared] "))  return ref.substring(9).trim();
+        return ref;
     }
     
-        public Map usedObject() {   
+    public Map usedObject() {   
         Map<String, ArrayList<String>> attributeMap = new HashMap<>();
         ArrayList<String> records = new ArrayList<>();
         try {

--- a/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/or/clipboard/ORClipboardManager.java
+++ b/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/or/clipboard/ORClipboardManager.java
@@ -1,0 +1,52 @@
+
+package com.ing.ide.main.mainui.components.testdesign.or.clipboard;
+
+import com.ing.datalib.or.common.ORObjectInf;
+
+/**
+ * Simple application-level clipboard manager
+ * for OR objects.
+ */
+public final class ORClipboardManager {
+
+    private static ORObjectClipboard clipboard;
+
+    private ORClipboardManager() {
+        // Prevent instantiation
+    }
+
+    /**
+     * Copy an OR object.
+     */
+    public static void copy(ORObjectInf object) {
+        clipboard = new ORObjectClipboard(object, false);
+    }
+
+    /**
+     * Cut an OR object.
+     */
+    public static void cut(ORObjectInf object) {
+        clipboard = new ORObjectClipboard(object, true);
+    }
+
+    /**
+     * Returns the current clipboard content.
+     */
+    public static ORObjectClipboard get() {
+        return clipboard;
+    }
+
+    /**
+     * Clears the clipboard.
+     */
+    public static void clear() {
+        clipboard = null;
+    }
+
+    /**
+     * Checks if clipboard has OR data.
+     */
+    public static boolean hasData() {
+        return clipboard != null;
+    }
+}

--- a/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/or/clipboard/ORClipboardManager.java
+++ b/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/or/clipboard/ORClipboardManager.java
@@ -2,6 +2,7 @@
 package com.ing.ide.main.mainui.components.testdesign.or.clipboard;
 
 import com.ing.datalib.or.common.ORObjectInf;
+import com.ing.datalib.or.common.ORPageInf;
 
 /**
  * Simple application-level clipboard manager
@@ -11,42 +12,31 @@ public final class ORClipboardManager {
 
     private static ORObjectClipboard clipboard;
 
-    private ORClipboardManager() {
-        // Prevent instantiation
-    }
-
-    /**
-     * Copy an OR object.
-     */
     public static void copy(ORObjectInf object) {
         clipboard = new ORObjectClipboard(object, false);
     }
 
-    /**
-     * Cut an OR object.
-     */
     public static void cut(ORObjectInf object) {
         clipboard = new ORObjectClipboard(object, true);
     }
 
-    /**
-     * Returns the current clipboard content.
-     */
+    public static void copy(ORPageInf page) {
+        clipboard = new ORObjectClipboard(page, false);
+    }
+
+    public static void cut(ORPageInf page) {
+        clipboard = new ORObjectClipboard(page, true);
+    }
+
+    public static boolean hasData() {
+        return clipboard != null;
+    }
+
     public static ORObjectClipboard get() {
         return clipboard;
     }
 
-    /**
-     * Clears the clipboard.
-     */
     public static void clear() {
         clipboard = null;
-    }
-
-    /**
-     * Checks if clipboard has OR data.
-     */
-    public static boolean hasData() {
-        return clipboard != null;
     }
 }

--- a/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/or/clipboard/ORObjectClipboard.java
+++ b/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/or/clipboard/ORObjectClipboard.java
@@ -2,6 +2,7 @@
 package com.ing.ide.main.mainui.components.testdesign.or.clipboard;
 
 import com.ing.datalib.or.common.ORObjectInf;
+import com.ing.datalib.or.common.ORPageInf;
 
 /**
  * Holds a single OR object in clipboard along with
@@ -11,25 +12,37 @@ import com.ing.datalib.or.common.ORObjectInf;
  */
 public class ORObjectClipboard {
 
-    private final ORObjectInf object;
+    public enum Type { OBJECT, PAGE }
+
+    private final Object data;     // ORObjectInf or ORPageInf
     private final boolean cut;
+    private final Type type;
 
     public ORObjectClipboard(ORObjectInf object, boolean cut) {
-        this.object = object;
+        this.data = object;
         this.cut = cut;
+        this.type = Type.OBJECT;
     }
 
-    /**
-     * Returns the OR object that was copied or cut.
-     */
-    public ORObjectInf getObject() {
-        return object;
+    public ORObjectClipboard(ORPageInf page, boolean cut) {
+        this.data = page;
+        this.cut = cut;
+        this.type = Type.PAGE;
     }
 
-    /**
-     * Returns true if the action was CUT, false if COPY.
-     */
     public boolean isCut() {
         return cut;
+    }
+
+    public Type getType() {
+        return type;
+    }
+
+    public ORObjectInf getObject() {
+        return (ORObjectInf) data;
+    }
+
+    public ORPageInf getPage() {
+        return (ORPageInf) data;
     }
 }

--- a/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/or/clipboard/ORObjectClipboard.java
+++ b/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/or/clipboard/ORObjectClipboard.java
@@ -1,0 +1,35 @@
+
+package com.ing.ide.main.mainui.components.testdesign.or.clipboard;
+
+import com.ing.datalib.or.common.ORObjectInf;
+
+/**
+ * Holds a single OR object in clipboard along with
+ * the action type (copy or cut).
+ *
+ * This is a UI-level helper class.
+ */
+public class ORObjectClipboard {
+
+    private final ORObjectInf object;
+    private final boolean cut;
+
+    public ORObjectClipboard(ORObjectInf object, boolean cut) {
+        this.object = object;
+        this.cut = cut;
+    }
+
+    /**
+     * Returns the OR object that was copied or cut.
+     */
+    public ORObjectInf getObject() {
+        return object;
+    }
+
+    /**
+     * Returns true if the action was CUT, false if COPY.
+     */
+    public boolean isCut() {
+        return cut;
+    }
+}

--- a/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/testcase/TestCaseTableDnD.java
+++ b/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/testcase/TestCaseTableDnD.java
@@ -2,6 +2,7 @@
 package com.ing.ide.main.mainui.components.testdesign.testcase;
 
 import com.ing.datalib.component.TestCase;
+import com.ing.datalib.component.TestStep;
 import com.ing.datalib.component.TestStep.HEADERS;
 import com.ing.datalib.or.ObjectRepository;
 import com.ing.datalib.or.common.ORPageInf;
@@ -126,10 +127,12 @@ public class TestCaseTableDnD extends TransferHandler {
                     testCase.fireTableRowsUpdated(row, row);
                 } else {
                     ObjectRepository or = testCase.getProject().getObjectRepository();
+                    TestStep tempStep = new TestStep(testCase);
                     ResolvedWebObject rwo =
                         or.resolveWebObjectWithScope(
                             objs.getPageName(val),
-                            objs.getObjectName(val)
+                            objs.getObjectName(val),
+                            tempStep
                         );
                     if (rwo != null) {
                         testCase.addObjectStep(row, rwo);

--- a/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/testcase/TestCaseTableDnD.java
+++ b/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/testcase/TestCaseTableDnD.java
@@ -3,7 +3,9 @@ package com.ing.ide.main.mainui.components.testdesign.testcase;
 
 import com.ing.datalib.component.TestCase;
 import com.ing.datalib.component.TestStep.HEADERS;
+import com.ing.datalib.or.ObjectRepository;
 import com.ing.datalib.or.common.ORPageInf;
+import com.ing.datalib.or.web.ResolvedWebObject;
 import com.ing.ide.main.mainui.components.testdesign.or.ObjectDnD;
 import com.ing.ide.main.mainui.components.testdesign.or.ObjectRepDnD;
 import com.ing.ide.main.mainui.components.testdesign.testdata.TestDataDetail;
@@ -123,7 +125,15 @@ public class TestCaseTableDnD extends TransferHandler {
                     testCase.setValueAt(objs.getPageName(val), row, HEADERS.Reference.getIndex());
                     testCase.fireTableRowsUpdated(row, row);
                 } else {
-                    testCase.addObjectStep(row, objs.getObjectName(val), objs.getPageName(val));
+                    ObjectRepository or = testCase.getProject().getObjectRepository();
+                    ResolvedWebObject rwo =
+                        or.resolveWebObjectWithScope(
+                            objs.getPageName(val),
+                            objs.getObjectName(val)
+                        );
+                    if (rwo != null) {
+                        testCase.addObjectStep(row, rwo);
+                    }
                 }
                 row++;
             }

--- a/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/testcase/validation/ObjectRenderer.java
+++ b/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/testcase/validation/ObjectRenderer.java
@@ -24,29 +24,31 @@ public class ObjectRenderer extends AbstractRenderer {
 
     @Override
     public void render(JComponent comp, TestStep step, Object value) {
-        if (!step.isCommented()) {
-            if (isEmpty(value)) {
-                setEmpty(comp);
-            } else if ("Execute".equals(Objects.toString(value, "").trim())) {
-                setExecute(comp);
-            } else if (step.isPageObjectStep()) {
-                if (isObjectPresent(step)) {
-                    setDefault(comp);
-                } else {
-                    setNotPresent(comp, objNotPresent);
-                }
-            } else if (isValidObject(value)) {
+            String objectName = Objects.toString(step.getObject(), "").trim();
+            String reference  = Objects.toString(step.getReference(), "").trim();
+
+            if (objectName.isEmpty() || reference.isEmpty()) {
                 setDefault(comp);
-            } else {
-                setNotPresent(comp, objNotPresent);
+                return;
             }
-        } else {
-            setDefault(comp);
-            Color c = UIManager.getColor("ing.commentedForeground");
-            comp.setForeground(c != null ? c : Color.lightGray);
-            comp.setFont(new Font("Default", Font.ITALIC, 11));
+            String pageName = reference
+                    .replace("[Project] ", "")
+                    .replace("[Shared] ", "")
+                    .trim();
+
+            ResolvedWebObject rwo =
+                step.getProject()
+                    .getObjectRepository()
+                    .resolveWebObjectWithScope(pageName, objectName, step);
+
+            if (rwo == null) {
+                setNotPresent(comp, objNotPresent);
+            } else {
+                setDefault(comp);
+                comp.setEnabled(true);
+                comp.setFont(comp.getFont().deriveFont(java.awt.Font.BOLD));
+            }
         }
-    }
 
     private Boolean isObjectPresent(TestStep step) {
         var repo = step.getProject().getObjectRepository();

--- a/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/testcase/validation/ObjectRenderer.java
+++ b/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/testcase/validation/ObjectRenderer.java
@@ -1,6 +1,7 @@
 package com.ing.ide.main.mainui.components.testdesign.testcase.validation;
 
 import com.ing.datalib.component.TestStep;
+import com.ing.datalib.or.ObjectRepository;
 import com.ing.datalib.or.web.ResolvedWebObject;
 import com.ing.datalib.or.mobile.ResolvedMobileObject;
 
@@ -24,31 +25,36 @@ public class ObjectRenderer extends AbstractRenderer {
 
     @Override
     public void render(JComponent comp, TestStep step, Object value) {
-            String objectName = Objects.toString(step.getObject(), "").trim();
-            String reference  = Objects.toString(step.getReference(), "").trim();
+        setDefault(comp);
+        comp.setFont(comp.getFont().deriveFont(java.awt.Font.PLAIN));
+        comp.setEnabled(true);
+        comp.setToolTipText(null);
 
-            if (objectName.isEmpty() || reference.isEmpty()) {
-                setDefault(comp);
-                return;
-            }
-            String pageName = reference
-                    .replace("[Project] ", "")
-                    .replace("[Shared] ", "")
-                    .trim();
+        String objectName = Objects.toString(step.getObject(), "").trim();
+        String reference  = Objects.toString(step.getReference(), "").trim();
 
-            ResolvedWebObject rwo =
-                step.getProject()
-                    .getObjectRepository()
-                    .resolveWebObjectWithScope(pageName, objectName, step);
-
-            if (rwo == null) {
-                setNotPresent(comp, objNotPresent);
-            } else {
-                setDefault(comp);
-                comp.setEnabled(true);
-                comp.setFont(comp.getFont().deriveFont(java.awt.Font.BOLD));
-            }
+        if (objectName.isEmpty() && reference.isEmpty()) {
+            return;
         }
+
+        if (isValidObject(objectName)) {
+            comp.setFont(comp.getFont().deriveFont(java.awt.Font.BOLD));
+            return;
+        }
+
+        if (!objectName.isEmpty() && reference.isEmpty()) {
+            setNotPresent(comp, "Reference is missing");
+            comp.setFont(comp.getFont().deriveFont(java.awt.Font.BOLD));
+            return;
+        }
+        if (!isObjectPresent(step)) {
+            setNotPresent(comp, objNotPresent);
+            comp.setFont(comp.getFont().deriveFont(java.awt.Font.BOLD));
+            return;
+        }
+
+        comp.setFont(comp.getFont().deriveFont(java.awt.Font.BOLD));
+    }
 
     private Boolean isObjectPresent(TestStep step) {
         var repo = step.getProject().getObjectRepository();

--- a/IDE/src/main/java/com/ing/ide/main/playwrightrecording/PlaywrightRecordingParser.java
+++ b/IDE/src/main/java/com/ing/ide/main/playwrightrecording/PlaywrightRecordingParser.java
@@ -1,9 +1,12 @@
 package com.ing.ide.main.playwrightrecording;
 
+import com.ing.datalib.or.common.ObjectGroup;
+import com.ing.datalib.or.web.WebOR;
+import com.ing.datalib.or.web.WebORObject;
+import com.ing.datalib.or.web.WebORPage;
 import com.ing.ide.main.mainui.AppMainFrame;
-import com.ing.ide.util.logging.UILogger;
+
 import java.io.File;
-import java.io.IOException;
 import java.io.PrintWriter;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -15,26 +18,11 @@ import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.parsers.ParserConfigurationException;
-import javax.xml.transform.Transformer;
-import javax.xml.transform.TransformerException;
-import javax.xml.transform.TransformerFactory;
-import javax.xml.transform.dom.DOMSource;
-import javax.xml.transform.stream.StreamResult;
 
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.w3c.dom.DOMException;
-import org.w3c.dom.Document;
-import org.w3c.dom.Element;
-import org.xml.sax.SAXException;
 
 public class PlaywrightRecordingParser {
 
@@ -52,226 +40,127 @@ public class PlaywrightRecordingParser {
         this.sMainFrame = sMainFrame;
     }
 
-    public void playwrightParser(File file) throws ParserConfigurationException, TransformerException, SAXException, IOException {
-        if (file != null && file.exists()) {
-            try {
-                filePath.put("projectPath", sMainFrame.getProject().getLocation());
-                filePath.put("importPlaywrightRecordingFilePath", file.getAbsolutePath());
-                File PlaywrightRecordingfile = new File(filePath.get("importPlaywrightRecordingFilePath"));
-                filePath.put("orFilePath", (filePath.get("projectPath") + "/OR.object"));
-                String baseName = FilenameUtils.getBaseName(filePath.get("importPlaywrightRecordingFilePath"));
-                testCase.put("fileName", StringUtils.capitalize(baseName));
-                File OrFile = new File(filePath.get("orFilePath"));
-                Element objectFrame = null;
-                testCase.put("pageName", testCase.get("fileName"));
-                testCase.put("testScenarioName", (filePath.get("projectPath") + "/TestPlan/" + testCase.get("fileName")).replace("\\", "/"));
-                File testScenario = new File(testCase.get("testScenarioName"));
-                if (!testScenario.exists()) {
-                    testScenario.mkdirs();
-                }
-                testCase.put("pageName", getPageName(testScenario, testCase.get("pageName")));
-
-                if (!OrFile.exists()) {
-                    boolean orExistFlag = false;
-                    DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
-                    DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
-                    Document doc = dBuilder.newDocument();
-                    Element rootElement = doc.createElement("Root");
-                    doc.appendChild(rootElement);
-                    rootElement.setAttribute("ref", testCase.get("fileName"));
-                    rootElement.setAttribute("type", "OR");
-                    Element page = doc.createElement("Page");
-                    rootElement.appendChild(page);
-
-                    List l = readFileInList(
-                            filePath.get("importPlaywrightRecordingFilePath"));
-
-                    Iterator<String> iterator = l.iterator();
-                    executeParse(iterator, objectFrame, testCase.get("testScenarioName"), filePath.get("orFilePath"), page, doc, orExistFlag, rootElement);
-                    allObjectMaping.clear();
-                } else {
-                    boolean orExistFlag = true;
-                    DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
-                    DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();
-                    Document doc = documentBuilder.parse(new File(filePath.get("orFilePath")));
-                    doc.getDocumentElement().normalize();
-                    Element root = doc.getDocumentElement();
-                    Element page = doc.createElement("Page");
-                    List l = readFileInList(
-                            filePath.get("importPlaywrightRecordingFilePath"));
-
-                    Iterator<String> iterator = l.iterator();
-                    executeParse(iterator, objectFrame, testCase.get("testScenarioName"), filePath.get("orFilePath"), page, doc, orExistFlag, root);
-                    allObjectMaping.clear();
-                }
-                testCase.clear();
-                attribute.clear();
-                filePath.clear();
-                ObjectNameList.clear();
-            } catch (Exception ex) {
-                Logger.getLogger(PlaywrightRecordingParser.class.getName()).log(Level.SEVERE, null, ex);
+    public void playwrightParser(File file) {
+        if (file == null || !file.exists()) {
+            return;
+        }
+        try {
+            filePath.put("projectPath", sMainFrame.getProject().getLocation());
+            filePath.put("importPlaywrightRecordingFilePath", file.getAbsolutePath());
+            String baseName = FilenameUtils.getBaseName(file.getAbsolutePath());
+            testCase.put("fileName", StringUtils.capitalize(baseName));
+            testCase.put("pageName", testCase.get("fileName"));
+            String testScenarioName = filePath.get("projectPath") + "/TestPlan/" + testCase.get("fileName");
+            testScenarioName = testScenarioName.replace("\\", "/");
+            testCase.put("testScenarioName", testScenarioName);
+            File testScenario = new File(testScenarioName);
+            if (!testScenario.exists()) {
+                testScenario.mkdirs();
             }
+            WebOR webOR = sMainFrame.getProject().getObjectRepository().getWebOR();
+            String basePageName = testCase.get("pageName");
+            String pageName = basePageName;
+            if (webOR.getPageByName(pageName) != null) {
+                int counter = 1;
+                while (webOR.getPageByName(basePageName + "_" + counter) != null) {
+                    counter++;
+                }
+                pageName = basePageName + "_" + counter;
+            }
+            testCase.put("pageName", pageName);
+            WebORPage page = webOR.addPage(pageName);
+            List<String> lines = readFileInList(filePath.get("importPlaywrightRecordingFilePath"));
+            Iterator<String> iterator = lines.iterator();
+            executeParse(iterator, page, testScenarioName);
+            page.getRoot() .getObjectRepository() .saveWebPageNow(page);
+        } catch (Exception ex) {
+            Logger.getLogger(PlaywrightRecordingParser.class.getName()).log(Level.SEVERE, null, ex);
         }
     }
 
-    private void executeParse(Iterator iterator, Element objectFrame, String testScenarioName, String orFilePath, Element page, Document doc, boolean orExistFlag, Element root) throws TransformerException {
-
+    private void executeParse(Iterator<String> iterator, WebORPage page, String testScenarioName) {
         StringBuilder stepBuilder = new StringBuilder();
         testCaseParameter();
         attributeDeclaration();
         int stepNumber = 1;
-        stepBuilder.append("Step" + "," + "ObjectName" + "," + "Description" + "," + "Action" + "," + "Input" + ","
-                + "Condition" + "," + "Reference");
-        stepBuilder.append("\n");
-        page.setAttribute("ref", testCase.get("pageName"));
-        page.setAttribute("title", "");
         int playwrightSteps = 0;
+        stepBuilder.append("Step,ObjectName,Description,Action,Input,Condition,Reference\n");
         while (iterator.hasNext()) {
             attributeDeclaration();
             testCaseParameter();
-            String line = (String) iterator.next();
+            String line = iterator.next();
             checkPageSwitch(line);
             storePageIndex(line);
             if (line.trim().startsWith("page")) {
                 pageMapping.put("currentPage", line.trim().split("\\.")[0]);
             }
-            if (!line.contains("System.out.println(") && !line.contains(pageMapping.get("currentPage") + ".onceDialog(dialog") && !line.contains(".waitForPopup(() ->")) {
-
+            if (!line.contains("System.out.println(")
+                    && !line.contains(pageMapping.get("currentPage") + ".onceDialog(dialog")
+                    && !line.contains(".waitForPopup(() ->")) {
                 if (line.trim().startsWith("page")) {
-                    playwrightSteps = playwrightSteps + 1;
+                    playwrightSteps++;
                 }
-
-                if (playwrightSteps >= 1) {
-                    if (!line.contains("}")) {
-                        int matchingAttribute = 0;
-                        testCaseMap(getAction(line), getInput(line));
-                        attributeInitialization(line);
-                        if (!testCase.get("ObjectName").equals("Browser")) {
-                            if (!allObjectMaping.isEmpty() && allObjectMaping.containsKey(testCase.get("ObjectName"))) {
-                                if (objectFrameMap.get(testCase.get("ObjectName")).equals(testCase.get("frame"))) {
-                                    HashMap<String, String> objectAttributeMap = allObjectMaping.get(testCase.get("ObjectName"));
-
-                                    Set<String> attributesKey = objectAttributeMap.keySet();
-                                    for (String allObjectAttributeKey : attributesKey) {
-                                        if (objectAttributeMap.get(allObjectAttributeKey).equals(attribute.get(allObjectAttributeKey))) {
-                                            matchingAttribute = matchingAttribute + 1;
-                                        }
-                                    }
-                                }
-                            }
-
-                            if (!testCase.get("ObjectName").equals("Browser")) {
-                                ObjectNameList.add(testCase.get("ObjectName"));
-                                int j = 0;
-                                int k = 0;
-                                for (String Locator : ObjectNameList) {
-                                    if ((Locator.trim()).equals(testCase.get("ObjectName").trim())) {
-                                        j++;
-                                    }
-                                    if (j > 1) {
-                                        k = (j - 1);
-                                    }
-                                }
-                                String locatorNumber = Integer.toString(k);
-                                if (attribute.size() != matchingAttribute || testCase.get("ObjectName").contains("Refactor_Object")) {
-                                    if (!locatorNumber.equals("0")) {
-                                        testCase.put("ObjectName", testCase.get("ObjectName") + "_" + locatorNumber);
-                                    }
-                                }
-
-                            }
-                            Map<String, String> objectAttribute = new HashMap<>();
-                            Set a = attribute.keySet();
-                            for (Object key : a) {
-                                String newKey = key.toString();
-                                objectAttribute.put(newKey, attribute.get(newKey));
-                            }
-                            objectFrameMap.put(testCase.get("ObjectName"), testCase.get("frame"));
-
-                            allObjectMaping.put(testCase.get("ObjectName"), (HashMap) objectAttribute);
-                            if (attribute.size() != matchingAttribute || testCase.get("ObjectName").contains("Refactor_Object")) {
-                                if (!testCase.get("ObjectName").equals("Browser")) {
-                                    Element objectGroup = doc.createElement("ObjectGroup");
-                                    page.appendChild(objectGroup);
-                                    objectGroup.setAttribute("ref", testCase.get("ObjectName"));
-                                    objectFrame = doc.createElement("Object");
-                                    objectGroup.appendChild(objectFrame);
-                                    objectFrame.setAttribute("frame", testCase.get("frame"));
-                                    objectFrame.setAttribute("ref", testCase.get("ObjectName"));
-
-                                    for (int p = 0; p < attribute.size(); p++) {
-                                        Element Property = doc.createElement("Property");
-                                        objectFrame.appendChild(Property);
-                                        String key = (String) attribute.keySet().toArray()[p];
-                                        Property.setAttribute("ref", key);
-                                        Property.setAttribute("value", attribute.get(key));
-                                        String prefNumber = Integer.toString(p + 1);
-                                        Property.setAttribute("pref", prefNumber);
-                                    }
-                                }
-
+                if (playwrightSteps >= 1 && !line.contains("}")) {
+                    testCaseMap(getAction(line), getInput(line));
+                    attributeInitialization(line);
+                    if (!"Browser".equals(testCase.get("ObjectName"))) {
+                        String objectName = testCase.get("ObjectName");
+                        ObjectGroup group = page.getObjectGroupByName(objectName);
+                        if (group == null) {
+                            group = new ObjectGroup(objectName, page);
+                            page.getObjectGroups().add(group);
+                        }
+                        WebORObject obj = new WebORObject(objectName, group);
+                        for (Map.Entry<String, String> entry : attribute.entrySet()) {
+                            String key = entry.getKey();
+                            String value = entry.getValue();
+                            if (value != null && !value.isEmpty()) {
+                                obj.setAttributeByName(key, value);
                             }
                         }
-                        if (stepNumber > 1) {
-                            if (!pageMapping.get("currentPage").equals(pageMapping.get("previousPage")) && !pageMapping.get("switchedPageName").equals(pageMapping.get("currentPage"))) {
-                                testCase.put("step", String.valueOf(stepNumber));
-                                String pageIndex = "@" + pageMapping.get(pageMapping.get("currentPage"));
-                                String stepAppenderString = testCase.get("step") + "," + "Browser" + "," + "" + "," + "switchToPageByIndex" + "," + pageIndex + ","
-                                        + "" + "," + "";
-                                testCase.put("stepAppender", stepAppenderString);
-                                stepBuilder.append(testCase.get("stepAppender"));
-                                stepBuilder.append("\n");
-                                testCase.put("input", "");
-                                stepNumber++;
-                            }
+                        if (!testCase.get("frame").isEmpty()) {
+                            obj.setFrame(testCase.get("frame"));
                         }
-                        if (line.trim().startsWith("page")) {
-                            pageMapping.put("previousPage", line.trim().split("\\.")[0]);
-                        }
-                        attributeDeclaration();
-                        if (!testCase.get("action").equals("Open")) {
-                            testCase.put("step", String.valueOf(stepNumber));
-
-                            String stepAppenderString = testCase.get("step") + "," + testCase.get("ObjectName") + "," + "" + "," + testCase.get("action") + "," + testCase.get("input") + ","
-                                    + testCase.get("Condition") + "," + testCase.get("pageName");
-                            testCase.put("stepAppender", stepAppenderString);
-                            stepBuilder.append(testCase.get("stepAppender"));
-                            stepBuilder.append("\n");
-                            testCase.put("input", "");
-                            stepNumber++;
-                        }
-
-                        if (testCase.get("action").equals("Open")) {
-                            testCase.put("step", String.valueOf(stepNumber));
-                            String stepAppenderValue = testCase.get("step") + "," + testCase.get("ObjectName") + "," + "" + "," + testCase.get("action") + "," + testCase.get("input") + ","
-                                    + testCase.get("Condition") + "," + "";
-                            testCase.put("stepAppender", stepAppenderValue);
-                            stepBuilder.append(testCase.get("stepAppender"));
-                            stepBuilder.append("\n");
-                            testCase.put("input", "");
-                            stepNumber++;
-                        }
-                        testCase.put("csvFileName", testCase.get("pageName"));
-                        filePath.put("csvFilePath", (testScenarioName + "/" + testCase.get("csvFileName") + ".csv"));
-                        File file = new File(filePath.get("csvFilePath"));
-                        try (PrintWriter printWriter = new PrintWriter(file)) {
-                            printWriter.write(stepBuilder.toString());
-                            printWriter.flush();
-                        } catch (Exception ex) {
-
-                        }
+                        group.getObjects().clear();
+                        group.getObjects().add(obj);
                     }
+                    testCase.put("step", String.valueOf(stepNumber));
+                    String stepAppender =
+                            testCase.get("step") + "," +
+                            testCase.get("ObjectName") + "," +
+                            "" + "," +
+                            testCase.get("action") + "," +
+                            testCase.get("input") + "," +
+                            testCase.get("Condition") + "," +
+                            testCase.get("pageName");
+                    stepBuilder.append(stepAppender).append("\n");
+                    stepNumber++;
+                    testCase.put("input", "");
                 }
             }
+            if (line.trim().startsWith("page")) {
+                pageMapping.put(
+                        "previousPage",
+                        line.trim().split("\\.")[0]
+                );
+            }
         }
-        if (orExistFlag) {
-            root.appendChild(page);
+        try {
+            testCase.put("csvFileName", testCase.get("pageName"));
+            filePath.put(
+                    "csvFilePath",
+                    testScenarioName + "/"
+                            + testCase.get("csvFileName")
+                            + ".csv"
+            );
+            File csvFile = new File(filePath.get("csvFilePath"));
+            try (PrintWriter printWriter = new PrintWriter(csvFile)) {
+                printWriter.write(stepBuilder.toString());
+                printWriter.flush();
+            }
+        } catch (Exception e) {
+            Logger.getLogger(PlaywrightRecordingParser.class.getName()).log(Level.WARNING, "Failed to write CSV", e);
         }
-        TransformerFactory transformerFactory = TransformerFactory.newInstance();
-        Transformer transformer = transformerFactory.newTransformer();
-        DOMSource source = new DOMSource(doc);
-        StreamResult result = new StreamResult(new File(orFilePath));
-        transformer.transform(source, result);
     }
 
     public void attributeDeclaration() {


### PR DESCRIPTION
- Existing XML files should be converted to YAML (Project and Shared)
- New Projects created should be using YAML moving forward
- Import playwright recording should be converted to YAML as well (WebOR)
-  Menu options for OR should be working as expected (Add, Rename, Delete, Get Impacted Cases, Removed Unused Objects)
-  Disabled Add Object for Object lvl selection (to prevent creation of objectgroup)
- Fixed faulty CCP (Cut, Copy, Paste)
- Copy to Shared replaced with Moved to Shared