### PR TITLE
Migration feature to convert OR.object to YAML

### DIFF
--- a/Datalib/src/main/java/com/ing/datalib/component/Project.java
+++ b/Datalib/src/main/java/com/ing/datalib/component/Project.java
@@ -11,6 +11,8 @@ import com.ing.datalib.settings.ProjectSettings;
 import com.ing.datalib.util.data.FileScanner;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ing.datalib.or.mobile.MobileOR;
+import com.ing.datalib.or.web.WebOR;
 import com.ing.datalib.or.web.WebOR.ORScope;
 import java.io.File;
 import java.nio.file.Files;
@@ -567,6 +569,26 @@ public class Project {
     public void refactorObjectName(ORScope scope, String pageName, String oldName, String newName) {
         for (Scenario scenario : scenarios) {
             scenario.refactorObjectName(scope, pageName, oldName, newName);
+        }
+    }
+    
+    /**
+     * Refactors Mobile OR object references in TestSteps.
+     * Mobile scope is mapped to Web scope because Scenarios/TestSteps
+     * are tool-agnostic and only care about PROJECT vs SHARED.
+     */
+    public void refactorMobileObjectName(MobileOR.ORScope scope, String pageName, String oldName, String newName) {
+        for (Scenario scenario : scenarios) {
+            WebOR.ORScope webScope =
+            (scope == MobileOR.ORScope.SHARED)
+                ? WebOR.ORScope.SHARED
+                : WebOR.ORScope.PROJECT;
+            scenario.refactorObjectName(
+                webScope,
+                pageName,
+                oldName,
+                newName
+            );
         }
     }
 

--- a/Datalib/src/main/java/com/ing/datalib/component/TestCase.java
+++ b/Datalib/src/main/java/com/ing/datalib/component/TestCase.java
@@ -4,6 +4,7 @@ package com.ing.datalib.component;
 import com.ing.datalib.component.TestStep.HEADERS;
 import com.ing.datalib.component.utils.FileUtils;
 import com.ing.datalib.component.utils.SaveListener;
+import com.ing.datalib.or.web.ResolvedWebObject;
 import com.ing.datalib.or.web.WebOR.ORScope;
 import java.io.File;
 import java.io.FileWriter;
@@ -213,6 +214,11 @@ public class TestCase extends DataModel {
 
     public void addObjectStep(int index, String objectName, String pageName) {
         TestStep step = new TestStep(this).asObjectStep(objectName, pageName);
+        addStep(index, step);
+    }
+
+    public void addObjectStep(int index, ResolvedWebObject rwo) {
+        TestStep step = new TestStep(this).asObjectStep(rwo);
         addStep(index, step);
     }
 

--- a/Datalib/src/main/java/com/ing/datalib/component/TestStep.java
+++ b/Datalib/src/main/java/com/ing/datalib/component/TestStep.java
@@ -1,6 +1,8 @@
 
 package com.ing.datalib.component;
 
+import com.ing.datalib.or.mobile.ResolvedMobileObject;
+import com.ing.datalib.or.web.ResolvedWebObject;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -203,6 +205,28 @@ public class TestStep {
     public TestStep asObjectStep(String objectName, String pageName) {
         setObject(objectName);
         setReference(pageName);
+        return this;
+    }
+
+    public TestStep asObjectStep(ResolvedWebObject rwo) {
+        setObject(rwo.getObjectName());
+        setReference(
+            new ResolvedWebObject.PageRef(
+                rwo.getPageName(),
+                rwo.getScope()
+            ).qualified()
+        );
+        return this;
+    }
+
+    public TestStep asObjectStep(ResolvedMobileObject rmo) {
+        setObject(rmo.getObjectName());
+        setReference(
+            new ResolvedMobileObject.PageRef(
+                rmo.getPageName(),
+                rmo.getScope()
+            ).qualified()
+        );
         return this;
     }
 

--- a/Datalib/src/main/java/com/ing/datalib/or/ObjectRepository.java
+++ b/Datalib/src/main/java/com/ing/datalib/or/ObjectRepository.java
@@ -2,7 +2,7 @@
 package com.ing.datalib.or;
 
 import com.ing.datalib.component.Project;
-import com.ing.datalib.or.api.APIOR;
+import com.ing.datalib.or.structureddata.StructuredData;
 import com.ing.datalib.or.common.ORPageInf;
 import com.ing.datalib.or.common.ObjectGroup;
 import com.ing.datalib.or.mobile.MobileOR;
@@ -15,6 +15,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
+import com.ing.datalib.or.structureddata.StructuredDataORObject;
+import com.ing.datalib.or.structureddata.StructuredDataORPage;
+import com.ing.datalib.or.structureddata.ResolvedStructuredDataObject;
 import com.ing.datalib.or.mobile.ResolvedMobileObject;
 import com.ing.datalib.or.web.ResolvedWebObject;
 import com.ing.datalib.or.web.WebOR.ORScope;
@@ -45,7 +48,8 @@ public class ObjectRepository {
     private WebOR webProjectOR;
     private MobileOR mobileProjectOR;
     private MobileOR mobileSharedOR;
-    private APIOR apiProjectOR;
+    private StructuredData structuredDataProjectOR;
+    private StructuredData structuredDataSharedOR;
     
     private final Set<String> sharedUsageProjects = new HashSet<>();
     
@@ -88,10 +92,10 @@ public class ObjectRepository {
             // Check if YAML or XML files exist for project ORs
             boolean hasYamlFiles = yamlReader.webORExists(orRepLocation) 
                                 || yamlReader.mobileORExists(orRepLocation) 
-                                || yamlReader.apiORExists(orRepLocation);
+                                || yamlReader.structuredDataORExists(orRepLocation);
             boolean hasXmlFiles = new File(getORLocation()).exists() 
                                || new File(getMORLocation()).exists() 
-                               || new File(getAPIORLocation()).exists();
+                               || new File(getStructuredDataORLocation()).exists();
             
             // Set format once for entire project
             if (hasYamlFiles) {
@@ -156,20 +160,20 @@ public class ObjectRepository {
                 mobileProjectOR.setScope(MobileOR.ORScope.PROJECT);
             }
             
-            // Load API Project OR
-            if (useYamlFormat && yamlReader.apiORExists(orRepLocation)) {
-                apiProjectOR = yamlReader.readAPIOR(orRepLocation);
-                apiProjectOR.setName(sProject.getName());
-            } else if (!useYamlFormat && new File(getAPIORLocation()).exists()) {
-                apiProjectOR = XML_MAPPER.readValue(new File(getAPIORLocation()), APIOR.class);
-                apiProjectOR.setName(sProject.getName());
+            // Load Structured Data Project OR
+            if (useYamlFormat && yamlReader.structuredDataORExists(orRepLocation)) {
+                structuredDataProjectOR = yamlReader.readStructuredDataOR(orRepLocation);
+                structuredDataProjectOR.setName(sProject.getName());
+            } else if (!useYamlFormat && new File(getStructuredDataORLocation()).exists()) {
+                structuredDataProjectOR = XML_MAPPER.readValue(new File(getStructuredDataORLocation()), StructuredData.class);
+                structuredDataProjectOR.setName(sProject.getName());
             } else {
-                apiProjectOR = new APIOR(sProject.getName());
+                structuredDataProjectOR = new StructuredData(sProject.getName());
             }
 
             // Set ObjectRepository reference immediately
-            if (apiProjectOR != null) {
-                apiProjectOR.setObjectRepository(this);
+            if (structuredDataProjectOR != null) {
+                structuredDataProjectOR.setObjectRepository(this);
             }
 
             // Set remaining properties for shared and project ORs
@@ -192,9 +196,9 @@ public class ObjectRepository {
             if (mobileProjectOR != null) {
                 mobileProjectOR.setSaved(true);
             }
-            if (apiProjectOR != null) {
-                apiProjectOR.setObjectRepository(this);
-                apiProjectOR.setSaved(true);
+            if (structuredDataProjectOR != null) {
+                structuredDataProjectOR.setObjectRepository(this);
+                structuredDataProjectOR.setSaved(true);
             }
 
             LOG.log(Level.INFO, "Shared WebOR loaded: {0}", (webSharedOR != null));
@@ -236,27 +240,27 @@ public class ObjectRepository {
                 // useYamlFormat stays true for new projects
             }
 
-            // Try YAML format first for API OR
-            if (yamlReader.apiORExists(orRepLocation)) {
-                LOG.info("Loading API OR from YAML format");
-                apiProjectOR = yamlReader.readAPIOR(orRepLocation);
-                apiProjectOR.setName(sProject.getName());
+            // Try YAML format first for Structured Data OR
+            if (yamlReader.structuredDataORExists(orRepLocation)) {
+                LOG.info("Loading Structured Data OR from YAML format");
+                structuredDataProjectOR = yamlReader.readStructuredDataOR(orRepLocation);
+                structuredDataProjectOR.setName(sProject.getName());
                 useYamlFormat = true;
-            } else if (new File(getAPIORLocation()).exists()) {
+            } else if (new File(getStructuredDataORLocation()).exists()) {
                 // Fall back to XML format (legacy)
-                LOG.info("Loading API OR from XML format");
-                apiProjectOR = XML_MAPPER.readValue(new File(getAPIORLocation()), APIOR.class);
-                apiProjectOR.setName(sProject.getName());
+                LOG.info("Loading Structured Data OR from XML format");
+                structuredDataProjectOR = XML_MAPPER.readValue(new File(getStructuredDataORLocation()), StructuredData.class);
+                structuredDataProjectOR.setName(sProject.getName());
                 useYamlFormat = false; // Use XML format for legacy projects
             } else {
-                apiProjectOR = new APIOR(sProject.getName());
+                structuredDataProjectOR = new StructuredData(sProject.getName());
                 // useYamlFormat stays true for new projects
             }
 
             webProjectOR.setObjectRepository(this);
             webProjectOR.setSaved(true);
             mobileProjectOR.setObjectRepository(this);
-            apiProjectOR.setObjectRepository(this);
+            structuredDataProjectOR.setObjectRepository(this);
         
         } catch (IOException ex) {
             Logger.getLogger(ObjectRepository.class.getName()).log(Level.SEVERE, null, ex);
@@ -275,8 +279,8 @@ public class ObjectRepository {
     public String getMORLocation() {
         return sProject.getLocation() + File.separator + "MOR.object";
     }
-    public String getAPIORLocation() {
-        return sProject.getLocation() + File.separator + "APIOR.object";
+    public String getStructuredDataORLocation() {
+        return sProject.getLocation() + File.separator + "StructuredDataOR.object";
     }
     public String getSharedMORLocation() {
         return "Shared" + File.separator + "SharedMobileObjects" + File.separator + "SharedMOR.object";
@@ -293,8 +297,8 @@ public class ObjectRepository {
     public String getMORRepLocation() {
         return sProject.getLocation() + File.separator + "MobileObjectRepository";
     }
-    public String getAPIORRepLocation() {
-        return sProject.getLocation() + File.separator + "APIObjectRepository";
+    public String getStructuredDataORRepLocation() {
+        return sProject.getLocation() + File.separator + "StructuredDataObjectRepository";
     }
     public String getSharedMORRepLocation() {
         return "Shared" + File.separator + "SharedMobileObjects" + File.separator + "MobileObjectRepository";
@@ -314,8 +318,11 @@ public class ObjectRepository {
     public MobileOR getMobileSharedOR() {
         return mobileSharedOR;
     }
-    public APIOR getAPIOR() {
-        return apiProjectOR;
+    public StructuredData getStructuredDataOR() {
+        return structuredDataProjectOR;
+    }
+    public StructuredData getStructuredDataSharedOR() {
+        return structuredDataSharedOR;
     }
 
     /**
@@ -380,10 +387,10 @@ public class ObjectRepository {
                     yamlWriter.writeMobileOR(mobileProjectOR, morRepLocation);
                     mobileProjectOR.setSaved(true);
                 }
-                if (apiProjectOR != null && !apiProjectOR.isSaved()) {
-                    File apiorRepLocation = new File(getAPIORRepLocation());
-                    yamlWriter.writeAPIOR(apiProjectOR, apiorRepLocation);
-                    apiProjectOR.setSaved(true);
+                if (structuredDataProjectOR != null && !structuredDataProjectOR.isSaved()) {
+                    File structuredDataRepLocation = new File(getStructuredDataORRepLocation());
+                    yamlWriter.writeStructuredDataOR(structuredDataProjectOR, structuredDataRepLocation);
+                    structuredDataProjectOR.setSaved(true);
                 }
                 LOG.info("Saved project ORs in YAML format");
             } else {
@@ -402,12 +409,12 @@ public class ObjectRepository {
                             .writeValue(morFile, mobileProjectOR);
                     mobileProjectOR.setSaved(true);
                 }
-                if (apiProjectOR != null && !apiProjectOR.isSaved()) {
-                    File apiorFile = new File(getAPIORLocation());
-                    apiorFile.getParentFile().mkdirs();
+                if (structuredDataProjectOR != null && !structuredDataProjectOR.isSaved()) {
+                    File structuredDataORFile = new File(getStructuredDataORLocation());
+                    structuredDataORFile.getParentFile().mkdirs();
                     XML_MAPPER.writerWithDefaultPrettyPrinter()
-                            .writeValue(apiorFile, apiProjectOR);
-                    apiProjectOR.setSaved(true);
+                            .writeValue(structuredDataORFile, structuredDataProjectOR);
+                    structuredDataProjectOR.setSaved(true);
                 }
                 LOG.info("Saved project ORs in XML format");
             }
@@ -425,7 +432,7 @@ public class ObjectRepository {
             File orRepLocation = new File(getORRepLocation());
             yamlWriter.writeWebOR(webProjectOR, orRepLocation);
             yamlWriter.writeMobileOR(mobileProjectOR, orRepLocation);
-            yamlWriter.writeAPIOR(apiProjectOR, orRepLocation);
+            yamlWriter.writeStructuredDataOR(structuredDataProjectOR, orRepLocation);
             webProjectOR.setSaved(true);
             useYamlFormat = true;
             LOG.info("Saved Object Repository in YAML format");
@@ -642,6 +649,28 @@ public class ObjectRepository {
         }
         return resolveMobileObjectWithScope(pageRef.name, objectName);
     }
+    
+    public ResolvedStructuredDataObject resolveStructuredDataObject(ResolvedStructuredDataObject.PageRef pageRef, String objectName) {
+        if (pageRef == null || objectName == null) return null;
+        if (pageRef.scope == ORScope.PROJECT) {
+            var g = getFrom(structuredDataProjectOR, pageRef.name, objectName);
+            if (g != null) {
+                String actualPageName = g.getParent() != null ? g.getParent().getName() : pageRef.name;
+                return new ResolvedStructuredDataObject(ORScope.PROJECT, actualPageName, objectName, g);
+            }
+            return null;
+        }
+        if (pageRef.scope == ORScope.SHARED) {
+            var g = getFrom(structuredDataSharedOR, pageRef.name, objectName);
+            if (g != null) {
+                markSharedUsage();
+                String actualPageName = g.getParent() != null ? g.getParent().getName() : pageRef.name;
+                return new ResolvedStructuredDataObject(ORScope.SHARED, actualPageName, objectName, g);
+            }
+            return null;
+        }
+        return resolveStructuredDataObjectWithScope(pageRef.name, objectName);
+    }
 
     /**
      * Resolves a WebOR object by searching project scope first, then shared scope.
@@ -686,6 +715,28 @@ public class ObjectRepository {
        }
        return null;
    }
+   
+   /**
+    * Resolves a StructuredDataOR object by searching project scope first, then shared scope.
+    *
+    * @param pageName page to search
+    * @param objectName object group name
+    * @return resolved StructuredDataOR object with scope metadata
+    */
+   public ResolvedStructuredDataObject resolveStructuredDataObjectWithScope(String pageName, String objectName) {
+       var proj = getFrom(structuredDataProjectOR, pageName, objectName);
+       if (proj != null) {
+           String actualPageName = proj.getParent() != null ? proj.getParent().getName() : pageName;
+           return new ResolvedStructuredDataObject(ORScope.PROJECT, actualPageName, objectName, proj);
+       }
+       var shared = getFrom(structuredDataSharedOR, pageName, objectName);
+       if (shared != null) {
+           markSharedUsage();
+           String actualPageName = shared.getParent() != null ? shared.getParent().getName() : pageName;
+           return new ResolvedStructuredDataObject(ORScope.SHARED, actualPageName, objectName, shared);
+       }
+       return null;
+   }
 
     private ObjectGroup<WebORObject> getFrom(WebOR or, String page, String obj) {
         if (or == null) return null;
@@ -696,6 +747,12 @@ public class ObjectRepository {
     private ObjectGroup<MobileORObject> getFrom(MobileOR or, String page, String obj) {
         if (or == null) return null;
         MobileORPage p = or.getPageByName(page);
+        return (p == null) ? null : p.getObjectGroupByName(obj);
+    }
+    
+    private ObjectGroup<StructuredDataORObject> getFrom(StructuredData or, String page, String obj) {
+        if (or == null) return null;
+        StructuredDataORPage p = or.getPageByName(page);
         return (p == null) ? null : p.getObjectGroupByName(obj);
     }
     
@@ -981,22 +1038,22 @@ public class ObjectRepository {
     }
     
     /**
-     * Save an API page immediately.
+     * Save an Structured Data page immediately.
      * For YAML format, writes individual page file.
      * For XML format, this is a no-op as XML saves the entire OR at once.
      * @param page the page to save
      */
-    public void saveAPIPageNow(com.ing.datalib.or.api.APIORPage page) {
+    public void saveStructuredDataPageNow(com.ing.datalib.or.structureddata.StructuredDataORPage page) {
         if (useYamlFormat && yamlWriter != null) {
             try {
-                File apiorRepLocation = new File(getAPIORRepLocation());
-                File apiPagesDir = new File(apiorRepLocation, "API/pages");
-                if (!apiPagesDir.exists()) {
-                    apiPagesDir.mkdirs();
+                File structuredDataOrRepLocation = new File(getStructuredDataORRepLocation());
+                File structuredDataPagesDir = new File(structuredDataOrRepLocation, "StructuredData/pages");
+                if (!structuredDataPagesDir.exists()) {
+                    structuredDataPagesDir.mkdirs();
                 }
-                yamlWriter.writeAPIPage(page, apiPagesDir);
+                yamlWriter.writeStructuredDataPage(page, structuredDataPagesDir);
             } catch (IOException e) {
-                LOG.log(Level.SEVERE, "Failed to save API page: " + page.getName(), e);
+                LOG.log(Level.SEVERE, "Failed to save Structured Data page: " + page.getName(), e);
             }
         }
         // XML format doesn't need per-page saves
@@ -1043,21 +1100,21 @@ public class ObjectRepository {
     }
     
     /**
-     * Rename an API page YAML file.
+     * Rename an Structured Data page YAML file.
      * Only works in YAML format mode.
      * @param oldName old page name
      * @param newName new page name
      * @return true if renamed successfully, false otherwise
      */
-    public boolean renameAPIPageYaml(String oldName, String newName) {
+    public boolean renameStructuredDataPageYaml(String oldName, String newName) {
         if (!useYamlFormat || yamlWriter == null) {
             return true; // XML mode - no-op
         }
         try {
-            File apiorRepLocation = new File(getAPIORRepLocation());
-            return yamlWriter.renameAPIPage(oldName, newName, apiorRepLocation);
+            File structuredDataRepLocation = new File(getStructuredDataORRepLocation());
+            return yamlWriter.renameStructuredDataPage(oldName, newName, structuredDataRepLocation);
         } catch (Exception e) {
-            LOG.log(Level.SEVERE, "Failed to rename API page from " + oldName + " to " + newName, e);
+            LOG.log(Level.SEVERE, "Failed to rename Structured Data page from " + oldName + " to " + newName, e);
             return false;
         }
     }

--- a/Datalib/src/main/java/com/ing/datalib/or/ObjectRepository.java
+++ b/Datalib/src/main/java/com/ing/datalib/or/ObjectRepository.java
@@ -2,7 +2,8 @@
 package com.ing.datalib.or;
 
 import com.ing.datalib.component.Project;
-import com.ing.datalib.or.structureddata.StructuredData;
+import com.ing.datalib.component.TestStep;
+import com.ing.datalib.or.structureddata.StructuredDataOR;
 import com.ing.datalib.or.common.ORPageInf;
 import com.ing.datalib.or.common.ObjectGroup;
 import com.ing.datalib.or.mobile.MobileOR;
@@ -21,6 +22,8 @@ import com.ing.datalib.or.structureddata.ResolvedStructuredDataObject;
 import com.ing.datalib.or.mobile.ResolvedMobileObject;
 import com.ing.datalib.or.web.ResolvedWebObject;
 import com.ing.datalib.or.web.WebOR.ORScope;
+import static com.ing.datalib.or.web.WebOR.ORScope.PROJECT;
+import static com.ing.datalib.or.web.WebOR.ORScope.SHARED;
 import com.ing.datalib.or.web.WebORObject;
 import com.ing.datalib.or.web.WebORPage;
 import java.io.File;
@@ -41,30 +44,25 @@ import java.util.logging.Logger;
  */
 public class ObjectRepository {
     private static final XmlMapper XML_MAPPER = new XmlMapper();
-    private static final ObjectMapper YAML_MAPPER = createYamlMapper();
     private static final Logger LOG = Logger.getLogger(ObjectRepository.class.getName());
     private final Project sProject;
     private WebOR webSharedOR;
     private WebOR webProjectOR;
     private MobileOR mobileProjectOR;
     private MobileOR mobileSharedOR;
-    private StructuredData structuredDataProjectOR;
-    private StructuredData structuredDataSharedOR;
+    private StructuredDataOR structuredDataProjectOR;
+    private StructuredDataOR structuredDataSharedOR;
     
-    private final Set<String> sharedUsageProjects = new HashSet<>();
-    
+    private final Set<String> webSharedUsageProjects = new HashSet<>();
+    private final Set<String> mobileSharedUsageProjects = new HashSet<>();
+    private List<String> webSharedProjectsFromXml = List.of();
+    private List<String> mobileSharedProjectsFromXml = List.of();
+
     // YAML support
     private boolean useYamlFormat = true; // Default to YAML for new projects
     private YamlORReader yamlReader;
     private YamlORWriter yamlWriter;
     
-    private static ObjectMapper createYamlMapper() {
-        YAMLFactory factory = new YAMLFactory();
-        factory.disable(YAMLGenerator.Feature.WRITE_DOC_START_MARKER);
-        factory.enable(YAMLGenerator.Feature.MINIMIZE_QUOTES);
-        return new ObjectMapper(factory);
-    }
-
     /**
      * Creates an ObjectRepository for the given project and loads all OR files
      * (project WebOR, shared WebOR, and MobileOR), initializing defaults when missing.
@@ -82,196 +80,61 @@ public class ObjectRepository {
      */
     private void init() {
         try {
-            // Initialize YAML support
-            yamlReader = new YamlORReader();
+            yamlReader = new YamlORReader(this);
             yamlWriter = new YamlORWriter();
-            
-            File orRepLocation = new File(getORRepLocation());
-            
-            // Determine format once for PROJECT ORs only
-            // Check if YAML or XML files exist for project ORs
-            boolean hasYamlFiles = yamlReader.webORExists(orRepLocation) 
-                                || yamlReader.mobileORExists(orRepLocation) 
-                                || yamlReader.structuredDataORExists(orRepLocation);
-            boolean hasXmlFiles = new File(getORLocation()).exists() 
-                               || new File(getMORLocation()).exists() 
-                               || new File(getStructuredDataORLocation()).exists();
-            
-            // Set format once for entire project
-            if (hasYamlFiles) {
+
+            boolean projectYamlExists = hasYamlOR();
+            boolean sharedYamlExists  = hasSharedYamlOR();
+            boolean xmlExists = hasAnyXmlOR();
+
+            if (xmlExists) {
+                loadXmlObjectRepositories();
+                convertXmlOrsToYamlAndArchive();
+                loadYamlObjectRepositories();
                 useYamlFormat = true;
-                LOG.info("Using YAML format for project Object Repositories");
-            } else if (hasXmlFiles) {
-                useYamlFormat = false;
-                LOG.info("Using XML format for project Object Repositories (legacy)");
-            } else {
-                // New project - default to YAML
+            }
+            
+            else if (projectYamlExists || sharedYamlExists) {
+                loadYamlObjectRepositories();
                 useYamlFormat = true;
-                LOG.info("New project - using YAML format for Object Repositories");
             }
             
-            // === SHARED ORs (always XML) ===
-            File sharedFile = new File(getSharedORLocation());
-            if (sharedFile.exists()) {
-                webSharedOR = XML_MAPPER.readValue(sharedFile, WebOR.class);
-                webSharedOR.setName("Shared Web Objects");
-            } else {
-                webSharedOR = new WebOR("Shared Web Objects");
-            }
-            
-            File sharedmorFile = new File(getSharedMORLocation());
-            if (sharedmorFile.exists()) {
-                mobileSharedOR = XML_MAPPER.readValue(sharedmorFile, MobileOR.class);
-                mobileSharedOR.setName("Shared Mobile Objects");
-            } else {
-                mobileSharedOR = new MobileOR("Shared Mobile Objects");
-            }
-            
-            // === PROJECT ORs (YAML or XML based on detection) ===
-            // Load Web Project OR
-            if (useYamlFormat && yamlReader.webORExists(orRepLocation)) {
-                webProjectOR = yamlReader.readWebOR(orRepLocation);
-                webProjectOR.setName(sProject.getName());
-            } else if (!useYamlFormat && new File(getORLocation()).exists()) {
-                webProjectOR = XML_MAPPER.readValue(new File(getORLocation()), WebOR.class);
-                webProjectOR.setName(sProject.getName());
-            } else {
-                webProjectOR = new WebOR(sProject.getName());
-            }
-            // Set ObjectRepository reference immediately to prevent directory creation
-            if (webProjectOR != null) {
+            else {
+                webProjectOR = new WebOR();
+                webProjectOR.setScope(WebOR.ORScope.PROJECT);
                 webProjectOR.setObjectRepository(this);
-                webProjectOR.setScope(ORScope.PROJECT);
-            }
-            
-            // Load Mobile Project OR
-            if (useYamlFormat && yamlReader.mobileORExists(orRepLocation)) {
-                mobileProjectOR = yamlReader.readMobileOR(orRepLocation);
-                mobileProjectOR.setName(sProject.getName());
-            } else if (!useYamlFormat && new File(getMORLocation()).exists()) {
-                mobileProjectOR = XML_MAPPER.readValue(new File(getMORLocation()), MobileOR.class);
-                mobileProjectOR.setName(sProject.getName());
-            } else {
-                mobileProjectOR = new MobileOR(sProject.getName());
-            }
-            // Set ObjectRepository reference immediately
-            if (mobileProjectOR != null) {
-                mobileProjectOR.setObjectRepository(this);
-                mobileProjectOR.setScope(MobileOR.ORScope.PROJECT);
-            }
-            
-            // Load Structured Data Project OR
-            if (useYamlFormat && yamlReader.structuredDataORExists(orRepLocation)) {
-                structuredDataProjectOR = yamlReader.readStructuredDataOR(orRepLocation);
-                structuredDataProjectOR.setName(sProject.getName());
-            } else if (!useYamlFormat && new File(getStructuredDataORLocation()).exists()) {
-                structuredDataProjectOR = XML_MAPPER.readValue(new File(getStructuredDataORLocation()), StructuredData.class);
-                structuredDataProjectOR.setName(sProject.getName());
-            } else {
-                structuredDataProjectOR = new StructuredData(sProject.getName());
-            }
-
-            // Set ObjectRepository reference immediately
-            if (structuredDataProjectOR != null) {
-                structuredDataProjectOR.setObjectRepository(this);
-            }
-
-            // Set remaining properties for shared and project ORs
-            if (webSharedOR != null) {
-                webSharedOR.setObjectRepository(this);
-                webSharedOR.setSaved(true);
-                webSharedOR.setRepLocationOverride(getSharedORRepLocation());
-                webSharedOR.setScope(ORScope.SHARED);
-            }
-            if (webProjectOR != null) {
-                webProjectOR.setSaved(true);
-            }
-            if (mobileSharedOR != null) {
-                mobileSharedOR.setObjectRepository(this);
-                mobileSharedOR.setSaved(true);
-                mobileSharedOR.setRepLocationOverride(getSharedMORRepLocation());
-                mobileSharedOR.setScope(MobileOR.ORScope.SHARED);
+                webProjectOR.setName(sProject.getName());
                 
-            }
-            if (mobileProjectOR != null) {
-                mobileProjectOR.setSaved(true);
-            }
-            if (structuredDataProjectOR != null) {
+                mobileProjectOR = new MobileOR();
+                mobileProjectOR.setScope(MobileOR.ORScope.PROJECT);
+                mobileProjectOR.setObjectRepository(this);
+                mobileProjectOR.setName(sProject.getName());
+                
+                structuredDataProjectOR = new StructuredDataOR();
                 structuredDataProjectOR.setObjectRepository(this);
-                structuredDataProjectOR.setSaved(true);
-            }
-
-            LOG.log(Level.INFO, "Shared WebOR loaded: {0}", (webSharedOR != null));
-            LOG.log(Level.INFO, "Project WebOR loaded: {0}", (webProjectOR != null));
-            LOG.log(Level.INFO, "Shared MobileOR loaded: {0}", (mobileSharedOR != null));
-            LOG.log(Level.INFO, "Project MobileOR loaded: {0}", (mobileProjectOR != null));
-            
-            // Try YAML format first (modern format)
-            if (yamlReader.webORExists(orRepLocation)) {
-                LOG.info("Loading Web OR from YAML format");
-                webProjectOR = yamlReader.readWebOR(orRepLocation);
-                webProjectOR.setName(sProject.getName());
-                useYamlFormat = true;
-            } else if (new File(getORLocation()).exists()) {
-                // Fall back to XML format (legacy)
-                LOG.info("Loading Web OR from XML format");
-                webProjectOR = XML_MAPPER.readValue(new File(getORLocation()), WebOR.class);
-                webProjectOR.setName(sProject.getName());
-                useYamlFormat = false; // Use XML format for legacy projects
-            } else {
-                webProjectOR = new WebOR(sProject.getName());
-                // useYamlFormat stays true for new projects
-            }
-            
-            // Try YAML format first for Mobile OR
-            if (yamlReader.mobileORExists(orRepLocation)) {
-                LOG.info("Loading Mobile OR from YAML format");
-                mobileProjectOR = yamlReader.readMobileOR(orRepLocation);
-                mobileProjectOR.setName(sProject.getName());
-                useYamlFormat = true;
-            } else if (new File(getMORLocation()).exists()) {
-                // Fall back to XML format (legacy)
-                LOG.info("Loading Mobile OR from XML format");
-                mobileProjectOR = XML_MAPPER.readValue(new File(getMORLocation()), MobileOR.class);
-                mobileProjectOR.setName(sProject.getName());
-                useYamlFormat = false; // Use XML format for legacy projects
-            } else {
-                mobileProjectOR = new MobileOR(sProject.getName());
-                // useYamlFormat stays true for new projects
-            }
-
-            // Try YAML format first for Structured Data OR
-            if (yamlReader.structuredDataORExists(orRepLocation)) {
-                LOG.info("Loading Structured Data OR from YAML format");
-                structuredDataProjectOR = yamlReader.readStructuredDataOR(orRepLocation);
                 structuredDataProjectOR.setName(sProject.getName());
                 useYamlFormat = true;
-            } else if (new File(getStructuredDataORLocation()).exists()) {
-                // Fall back to XML format (legacy)
-                LOG.info("Loading Structured Data OR from XML format");
-                structuredDataProjectOR = XML_MAPPER.readValue(new File(getStructuredDataORLocation()), StructuredData.class);
-                structuredDataProjectOR.setName(sProject.getName());
-                useYamlFormat = false; // Use XML format for legacy projects
-            } else {
-                structuredDataProjectOR = new StructuredData(sProject.getName());
-                // useYamlFormat stays true for new projects
+                
+                if (webSharedOR == null && !sharedYamlExists) {
+                    webSharedOR = new WebOR("Shared Web Objects");
+                    webSharedOR.setScope(WebOR.ORScope.SHARED);
+                    webSharedOR.setObjectRepository(this);
+                    webSharedOR.setSaved(true);
+                }
+                if (mobileSharedOR == null && !sharedYamlExists) {
+                    mobileSharedOR = new MobileOR("Shared Mobile Objects");
+                    mobileSharedOR.setScope(MobileOR.ORScope.SHARED);
+                    mobileSharedOR.setObjectRepository(this);
+                    mobileSharedOR.setSaved(true);
+                }
             }
-
-            webProjectOR.setObjectRepository(this);
-            webProjectOR.setSaved(true);
-            mobileProjectOR.setObjectRepository(this);
-            structuredDataProjectOR.setObjectRepository(this);
-        
-        } catch (IOException ex) {
-            Logger.getLogger(ObjectRepository.class.getName()).log(Level.SEVERE, null, ex);
+        } catch (IOException e) {
+            LOG.log(Level.SEVERE, "Failed to initialize ObjectRepository", e);
         }
     }
 
     public String getORLocation() {
         return sProject.getLocation() + File.separator + "OR.object";
-    }
-    public String getSharedORLocation() {
-        return "Shared" + File.separator + "SharedWebObjects" + File.separator + "SharedOR.object";
     }
     public String getIORLocation() {
         return sProject.getLocation() + File.separator + "IOR.object";
@@ -282,26 +145,27 @@ public class ObjectRepository {
     public String getStructuredDataORLocation() {
         return sProject.getLocation() + File.separator + "StructuredDataOR.object";
     }
+    public String getSharedORLocation() {
+        return "Shared" + File.separator + "SharedWebObjects" + File.separator + "SharedOR.object";
+    }
     public String getSharedMORLocation() {
         return "Shared" + File.separator + "SharedMobileObjects" + File.separator + "SharedMOR.object";
     }
     public String getORRepLocation() {
         return sProject.getLocation() + File.separator + "ObjectRepository";
     }
-    public String getSharedORRepLocation() {
-        return "Shared" + File.separator + "SharedWebObjects" + File.separator + "SharedObjectRepository";
-    }
     public String getIORRepLocation() {
         return sProject.getLocation() + File.separator + "ImageObjectRepository";
-    }
-    public String getMORRepLocation() {
-        return sProject.getLocation() + File.separator + "MobileObjectRepository";
     }
     public String getStructuredDataORRepLocation() {
         return sProject.getLocation() + File.separator + "StructuredDataObjectRepository";
     }
-    public String getSharedMORRepLocation() {
-        return "Shared" + File.separator + "SharedMobileObjects" + File.separator + "MobileObjectRepository";
+    public String getSharedORRepLocation() {
+        File projectDir = new File(sProject.getLocation());   
+        File projectsRoot = projectDir.getParentFile();       
+        File ingeniousRoot = projectsRoot.getParentFile();    
+        File sharedOR = new File(ingeniousRoot,"Shared" + File.separator + "SharedObjectRepository");
+        return sharedOR.getAbsolutePath();
     }
     public Project getsProject() {
         return sProject;
@@ -318,10 +182,10 @@ public class ObjectRepository {
     public MobileOR getMobileSharedOR() {
         return mobileSharedOR;
     }
-    public StructuredData getStructuredDataOR() {
+    public StructuredDataOR getStructuredDataOR() {
         return structuredDataProjectOR;
     }
-    public StructuredData getStructuredDataSharedOR() {
+    public StructuredDataOR getStructuredDataSharedOR() {
         return structuredDataSharedOR;
     }
 
@@ -331,101 +195,71 @@ public class ObjectRepository {
      */
     public void save() {
         try {
-            List<String> existingProjects = (webSharedOR != null) ? webSharedOR.getSharedProjects() : java.util.List.of();
-            LinkedHashSet<String> mergedProjects = new LinkedHashSet<>();
-            if (existingProjects != null) mergedProjects.addAll(existingProjects);
-            mergedProjects.addAll(sharedUsageProjects);
-            boolean projectsChanged = false;
+            boolean webProjectsChanged = false;
             if (webSharedOR != null) {
-                ArrayList<String> mergedList = new ArrayList<>(mergedProjects);
+                LinkedHashSet<String> webMerged = new LinkedHashSet<>();
+                webMerged.addAll(webSharedProjectsFromXml);
+                webMerged.addAll(webSharedUsageProjects);
+                File sharedRoot = new File(getSharedORRepLocation());
+                File webMetaFile = new File(sharedRoot, "webor-projectsdata.yaml");
+                webMerged.addAll(yamlWriter.readExistingProjects(webMetaFile));
                 List<String> current = webSharedOR.getSharedProjects();
-                projectsChanged = (current == null) || !new LinkedHashSet<>(current).equals(mergedProjects);
-                if (projectsChanged) {
-                    webSharedOR.setSharedProjects(mergedList);
+                webProjectsChanged = current == null || !new LinkedHashSet<>(current).equals(webMerged);
+                if (webProjectsChanged) {
+                    webSharedOR.setSharedProjects(
+                        new ArrayList<>(webMerged)
+                    );
                 }
             }
-            List<String> mExisting = (mobileSharedOR != null) ? mobileSharedOR.getSharedProjects() : java.util.List.of();
-            LinkedHashSet<String> mMerged = new LinkedHashSet<>();
-            if (mExisting != null) mMerged.addAll(mExisting);
-            mMerged.addAll(sharedUsageProjects);
-            boolean mProjectsChanged = false;
+            
+            boolean mobileProjectsChanged = false;
             if (mobileSharedOR != null) {
-                ArrayList<String> mList = new ArrayList<>(mMerged);
-                List<String> mCurrent = mobileSharedOR.getSharedProjects();
-                mProjectsChanged = (mCurrent == null) || !new LinkedHashSet<>(mCurrent).equals(mMerged);
-                if (mProjectsChanged) {
-                    mobileSharedOR.setSharedProjects(mList);
+                LinkedHashSet<String> mobileMerged = new LinkedHashSet<>();
+                mobileMerged.addAll(mobileSharedProjectsFromXml);
+                mobileMerged.addAll(mobileSharedUsageProjects);
+                File sharedRoot = new File(getSharedORRepLocation());
+                File mobileMetaFile = new File(sharedRoot, "mobileor-projectsdata.yaml");
+                mobileMerged.addAll(yamlWriter.readExistingProjects(mobileMetaFile));
+                List<String> current = mobileSharedOR.getSharedProjects();
+                mobileProjectsChanged = current == null || !new LinkedHashSet<>(current).equals(mobileMerged);
+                if (mobileProjectsChanged) {
+                    mobileSharedOR.setSharedProjects(
+                        new ArrayList<>(mobileMerged)
+                    );
                 }
             }
-            
-            // === SHARED ORs (always XML) ===
-            if (webSharedOR != null && (!webSharedOR.isSaved() || projectsChanged)) {
-                File sharedORFile = new File(getSharedORLocation());
-                sharedORFile.getParentFile().mkdirs();
-                XML_MAPPER.writerWithDefaultPrettyPrinter()
-                    .writeValue(sharedORFile, webSharedOR);
-                webSharedOR.setSaved(true);
-            }
-            if (mobileSharedOR != null && (!mobileSharedOR.isSaved() || mProjectsChanged)) {
-                File sharedMORFile = new File(getSharedMORLocation());
-                sharedMORFile.getParentFile().mkdirs();
-                XML_MAPPER.writerWithDefaultPrettyPrinter()
-                        .writeValue(sharedMORFile, mobileSharedOR);
-                mobileSharedOR.setSaved(true);
-            }
-            
-            // === PROJECT ORs (YAML or XML based on format) ===
+
             if (useYamlFormat) {
-                // Save in YAML format
-                if (webProjectOR != null && !webProjectOR.isSaved()) {
-                    File orRepLocation = new File(getORRepLocation());
-                    yamlWriter.writeWebOR(webProjectOR, orRepLocation);
-                    webProjectOR.setSaved(true);
+                File sharedRoot = new File(getSharedORRepLocation());
+                if (webSharedOR != null && (!webSharedOR.isSaved() || webProjectsChanged)) {
+                    yamlWriter.writeWebOR(webSharedOR, sharedRoot);
+                    if (webSharedOR.getSharedProjects() != null &&
+                        !webSharedOR.getSharedProjects().isEmpty()) {
+                        yamlWriter.writeSharedMetadata(webSharedOR,sharedRoot);
+                    }
+                    webSharedOR.setSaved(true);
                 }
-                if (mobileProjectOR != null && !mobileProjectOR.isSaved()) {
-                    File morRepLocation = new File(getMORRepLocation());
-                    yamlWriter.writeMobileOR(mobileProjectOR, morRepLocation);
-                    mobileProjectOR.setSaved(true);
+
+                if (mobileSharedOR != null && (!mobileSharedOR.isSaved() || mobileProjectsChanged)) {
+                    yamlWriter.writeMobileOR(mobileSharedOR, sharedRoot);
+                    if (mobileSharedOR.getSharedProjects() != null &&
+                        !mobileSharedOR.getSharedProjects().isEmpty()) {
+                        yamlWriter.writeSharedMetadata(mobileSharedOR,sharedRoot);
+                    }
+                    mobileSharedOR.setSaved(true);
                 }
-                if (structuredDataProjectOR != null && !structuredDataProjectOR.isSaved()) {
-                    File structuredDataRepLocation = new File(getStructuredDataORRepLocation());
-                    yamlWriter.writeStructuredDataOR(structuredDataProjectOR, structuredDataRepLocation);
-                    structuredDataProjectOR.setSaved(true);
-                }
+                saveAsYaml();
                 LOG.info("Saved project ORs in YAML format");
-            } else {
-                // Save in XML format (legacy)
-                if (webProjectOR != null && !webProjectOR.isSaved()) {
-                    File orFile = new File(getORLocation());
-                    orFile.getParentFile().mkdirs();
-                    XML_MAPPER.writerWithDefaultPrettyPrinter()
-                        .writeValue(orFile, webProjectOR);
-                    webProjectOR.setSaved(true);
-                }
-                if (mobileProjectOR != null && !mobileProjectOR.isSaved()) {
-                    File morFile = new File(getMORLocation());
-                    morFile.getParentFile().mkdirs();
-                    XML_MAPPER.writerWithDefaultPrettyPrinter()
-                            .writeValue(morFile, mobileProjectOR);
-                    mobileProjectOR.setSaved(true);
-                }
-                if (structuredDataProjectOR != null && !structuredDataProjectOR.isSaved()) {
-                    File structuredDataORFile = new File(getStructuredDataORLocation());
-                    structuredDataORFile.getParentFile().mkdirs();
-                    XML_MAPPER.writerWithDefaultPrettyPrinter()
-                            .writeValue(structuredDataORFile, structuredDataProjectOR);
-                    structuredDataProjectOR.setSaved(true);
-                }
-                LOG.info("Saved project ORs in XML format");
             }
         } catch (IOException ex) {
-            Logger.getLogger(ObjectRepository.class.getName()).log(Level.SEVERE, null, ex);
+            Logger.getLogger(ObjectRepository.class.getName())
+                  .log(Level.SEVERE, "Failed to save Object Repository", ex);
         }
     }
-    
+
     /**
      * Save Object Repository in YAML format.
-     * Creates page-per-file structure under ObjectRepository/Web/pages/, ObjectRepository/Mobile/pages/, and ObjectRepository/API/pages/
+     * Creates page-per-file structure under ObjectRepository/Web/, ObjectRepository/Mobile/, and ObjectRepository/API/
      */
     public void saveAsYaml() {
         try {
@@ -434,33 +268,264 @@ public class ObjectRepository {
             yamlWriter.writeMobileOR(mobileProjectOR, orRepLocation);
             yamlWriter.writeStructuredDataOR(structuredDataProjectOR, orRepLocation);
             webProjectOR.setSaved(true);
+            mobileProjectOR.setSaved(true);
+            structuredDataProjectOR.setSaved(true);
             useYamlFormat = true;
             LOG.info("Saved Object Repository in YAML format");
         } catch (IOException ex) {
             LOG.log(Level.SEVERE, "Error saving Object Repository as YAML", ex);
         }
     }
-    
-    /**
-     * Convert existing XML-based OR to YAML format.
-     * This creates YAML files while preserving the original XML files.
-     */
-    public void convertToYaml() {
-        try {
-            File orRepLocation = new File(getORRepLocation());
-            yamlWriter.convertFromXml(webProjectOR, mobileProjectOR, orRepLocation);
-            useYamlFormat = true;
-            LOG.info("Converted Object Repository to YAML format");
-        } catch (IOException ex) {
-            LOG.log(Level.SEVERE, "Error converting Object Repository to YAML", ex);
-        }
+
+    private boolean hasProjectXmlOR() {
+        return new File(getORLocation()).exists() || new File(getMORLocation()).exists();
+    }
+
+    private boolean hasSharedXmlOR() {
+        return new File(getSharedORLocation()).exists() || new File(getSharedMORLocation()).exists();
+    }
+
+    private boolean hasAnyXmlOR() {
+        return hasProjectXmlOR() || hasSharedXmlOR();
+    }
+
+    private boolean hasYamlOR() {
+        File webPages = new File(getORRepLocation(), "Web");
+        File mobilePages = new File(getORRepLocation(), "Mobile");
+        File structuredDataPages = new File(getORRepLocation(), "StructuredData");
+        return (webPages.exists() && webPages.isDirectory()) || (mobilePages.exists() && mobilePages.isDirectory()) || (structuredDataPages.exists() && structuredDataPages.isDirectory());
+    }
+
+    private boolean hasSharedYamlOR() {
+        File sharedWeb = new File(getSharedORRepLocation(), "Web");
+        File sharedMobile = new File(getSharedORRepLocation(), "Mobile");
+        File sharedStructuredDataPages = new File(getORRepLocation(), "StructuredData");
+        return (sharedWeb.exists() && sharedWeb.isDirectory()) || (sharedMobile.exists() && sharedMobile.isDirectory()) || (sharedStructuredDataPages.exists() && sharedStructuredDataPages.isDirectory());
     }
     
+    private void convertXmlOrsToYamlAndArchive() throws IOException {
+        LOG.info("Legacy XML ORs detected. Converting to YAML...");
+        XmlToYamlORConverter converter = new XmlToYamlORConverter(yamlWriter);
+
+        File projectYamlRoot = new File(getORRepLocation());
+        File sharedYamlRoot  = new File(getSharedORRepLocation());
+
+        converter.convertAll(
+            webProjectOR,
+            webSharedOR,
+            mobileProjectOR,
+            mobileSharedOR,
+            projectYamlRoot,
+            sharedYamlRoot
+        );
+
+        archiveProjectXmlORs();
+        archiveSharedXmlORs();
+        cleanupLegacySharedXmlFolders();
+        useYamlFormat = true;
+
+        LOG.info("XML OR migration complete. YAML is now active.");
+    }
+
+    private void archiveProjectXmlORs() {
+        File archiveDir = new File(sProject.getLocation(), "ProjectXMLOR");
+        archiveDir.mkdirs();
+        moveXmlToBak(getORLocation(), archiveDir);
+        moveXmlToBak(getMORLocation(), archiveDir);
+    }
+    
+    private void archiveSharedXmlORs() {
+        File archiveDir = new File("Shared" + File.separator + "SharedXMLOR");
+        archiveDir.mkdirs();
+        moveXmlToBak(getSharedORLocation(), archiveDir);
+        moveXmlToBak(getSharedMORLocation(), archiveDir);
+    }
+    
+    private void moveXmlToBak(String xmlPath, File targetDir) {
+        if (xmlPath == null) return;
+        File xmlFile = new File(xmlPath);
+        if (!xmlFile.exists()) return;
+        File bakFile = new File(targetDir, xmlFile.getName() + ".bak");
+        if (xmlFile.renameTo(bakFile)) {
+            LOG.info(() -> "Archived XML OR: " + bakFile.getAbsolutePath());
+        } else {
+            LOG.warning(() -> "Failed to archive XML OR: " + xmlFile.getAbsolutePath());
+        }
+    }
+
+    private void deleteDirectoryRecursively(File dir) {
+        if (dir == null || !dir.exists()) {
+            return;
+        }
+        File[] contents = dir.listFiles();
+        if (contents != null) {
+            for (File file : contents) {
+                if (file.isDirectory()) {
+                    deleteDirectoryRecursively(file);
+                } else {
+                    file.delete();
+                }
+            }
+        }
+        boolean deleted = dir.delete();
+        if (deleted) {
+            LOG.info(() -> "Deleted legacy XML directory: " + dir.getAbsolutePath());
+        } else {
+            LOG.warning(() -> "Failed to delete legacy XML directory: " + dir.getAbsolutePath());
+        }
+    }
+
+    private void cleanupLegacySharedXmlFolders() {
+        File sharedWebXmlDir = new File("Shared" + File.separator + "SharedWebObjects");
+        File sharedMobileXmlDir = new File("Shared" + File.separator + "SharedMobileObjects");
+        deleteDirectoryRecursively(sharedWebXmlDir);
+        deleteDirectoryRecursively(sharedMobileXmlDir);
+    }
+
+    private void loadYamlObjectRepositories() throws IOException {
+        File projectRoot = new File(getORRepLocation());
+        
+        webProjectOR = yamlReader.readWebOR(projectRoot);
+        if (webProjectOR != null) {
+            webProjectOR.setObjectRepository(this);
+            webProjectOR.setScope(WebOR.ORScope.PROJECT);
+            webProjectOR.setName(sProject.getName());
+            normalizeWebOR(webProjectOR);
+        }
+
+        mobileProjectOR = yamlReader.readMobileOR(projectRoot);
+        if (mobileProjectOR != null) {
+            mobileProjectOR.setObjectRepository(this);
+            mobileProjectOR.setScope(MobileOR.ORScope.PROJECT);
+            mobileProjectOR.setName(sProject.getName());
+            normalizeMobileOR(mobileProjectOR);
+        }
+
+        structuredDataProjectOR = yamlReader.readStructuredDataOR(projectRoot);
+        if (structuredDataProjectOR != null) {
+            structuredDataProjectOR.setObjectRepository(this);
+            structuredDataProjectOR.setName(sProject.getName());
+            normalizestructuredDataOR(structuredDataProjectOR);
+        }
+
+        File sharedRoot = new File(getSharedORRepLocation());
+        
+        if (sharedRoot.exists() && sharedRoot.isDirectory()) {
+
+            webSharedOR = yamlReader.readWebOR(sharedRoot);
+            if (webSharedOR != null) {
+                webSharedOR.setObjectRepository(this);
+                webSharedOR.setScope(WebOR.ORScope.SHARED);
+                webSharedOR.setName("Shared Web Objects");
+                normalizeWebOR(webSharedOR);
+            }
+
+            mobileSharedOR = yamlReader.readMobileOR(sharedRoot);
+            if (mobileSharedOR != null) {
+                mobileSharedOR.setObjectRepository(this);
+                mobileSharedOR.setScope(MobileOR.ORScope.SHARED);
+                mobileSharedOR.setName("Shared Mobile Objects");
+                normalizeMobileOR(mobileSharedOR);
+            }
+        }
+    }
+
     /**
-     * Set whether to use YAML format for saving.
-     */
-    public void setUsingYamlFormat(boolean useYaml) {
-        this.useYamlFormat = useYaml;
+    * Loads legacy XML-based Object Repositories into memory.
+    *
+    * This method is ONLY used during XML → YAML migration.
+    * It must NOT be called once YAML ORs exist.
+    */
+   private void loadXmlObjectRepositories() throws IOException {
+       LOG.info("Loading legacy XML Object Repositories for migration...");
+       File projectWebXml = new File(getORLocation());
+       if (projectWebXml.exists()) {
+           webProjectOR = XML_MAPPER.readValue(projectWebXml, WebOR.class);
+           webProjectOR.setObjectRepository(this);
+           LOG.info("Loaded PROJECT Web XML OR");
+       }
+
+       File projectMobileXml = new File(getMORLocation());
+       if (projectMobileXml.exists()) {
+           mobileProjectOR = XML_MAPPER.readValue(projectMobileXml, MobileOR.class);
+           mobileProjectOR.setObjectRepository(this);
+           LOG.info("Loaded PROJECT Mobile XML OR");
+       }
+
+       File sharedWebXml = new File(getSharedORLocation());
+       if (sharedWebXml.exists()) {
+           webSharedOR = XML_MAPPER.readValue(sharedWebXml, WebOR.class);
+           webSharedOR.setObjectRepository(this);
+           webSharedOR.setScope(WebOR.ORScope.SHARED);
+           LOG.info("Loaded SHARED Web XML OR");
+       }
+
+       File sharedMobileXml = new File(getSharedMORLocation());
+       if (sharedMobileXml.exists()) {
+           mobileSharedOR = XML_MAPPER.readValue(sharedMobileXml, MobileOR.class);
+           mobileSharedOR.setObjectRepository(this);
+           mobileSharedOR.setScope(MobileOR.ORScope.SHARED);
+           LOG.info("Loaded SHARED Mobile XML OR");
+       }
+
+       if (webSharedOR != null && webSharedOR.getSharedProjects() != null) {
+            webSharedProjectsFromXml = new ArrayList<>(webSharedOR.getSharedProjects());
+        }
+
+        if (mobileSharedOR != null && mobileSharedOR.getSharedProjects() != null) {
+            mobileSharedProjectsFromXml = new ArrayList<>(mobileSharedOR.getSharedProjects());
+        }
+   }
+
+   private void normalizeWebOR(WebOR webOR) {
+        if (webOR == null) return;
+
+        for (WebORPage page : webOR.getPages()) {
+            page.setRoot(webOR);
+
+            for (ObjectGroup<WebORObject> group : page.getObjectGroups()) {
+                group.setParent(page);
+
+                for (WebORObject obj : group.getObjects()) {
+                    obj.setParent(group);
+                }
+            }
+        }
+        webOR.setSaved(true);
+    }
+   
+   private void normalizeMobileOR(MobileOR mobileOR) {
+        if (mobileOR == null) return;
+
+        for (MobileORPage page : mobileOR.getPages()) {
+            page.setRoot(mobileOR);
+
+            for (ObjectGroup<MobileORObject> group : page.getObjectGroups()) {
+                group.setParent(page);
+
+                for (MobileORObject obj : group.getObjects()) {
+                    obj.setParent(group);
+                }
+            }
+        }
+        mobileOR.setSaved(true);
+    }
+   
+   private void normalizestructuredDataOR(StructuredDataOR apiOR) {
+        if (apiOR == null) return;
+
+        for (StructuredDataORPage page : apiOR.getPages()) {
+            page.setRoot(apiOR);
+
+            for (ObjectGroup<StructuredDataORObject> group : page.getObjectGroups()) {
+                group.setParent(page);
+
+                for (StructuredDataORObject obj : group.getObjects()) {
+                    obj.setParent(group);
+                }
+            }
+        }
+        apiOR.setSaved(true);
     }
 
     /**
@@ -485,25 +550,74 @@ public class ObjectRepository {
      * @param group   object group containing the object
      * @param newName new object name
      */
-    public void renameObject(ObjectGroup<WebORObject> group, String newName) {
+    public void renameObject(ObjectGroup group, String newName) {
         if (group == null || newName == null || newName.isBlank()) return;
+
         var parentPage = group.getParent();
         if (parentPage == null) return;
+
         String oldName = group.getName();
         if (oldName.equals(newName)) return;
-        boolean inProject = (webProjectOR != null) &&
-            (webProjectOR.getPageByName(parentPage.getName()) == parentPage);
-        boolean inShared  = !inProject && (webSharedOR != null) &&
-            (webSharedOR.getPageByName(parentPage.getName()) == parentPage);
-        if (inProject && webProjectOR != null) {
+
+        boolean webProject =
+            webProjectOR != null &&
+            webProjectOR.getPageByName(parentPage.getName()) == parentPage;
+
+        boolean webShared =
+            webSharedOR != null &&
+            webSharedOR.getPageByName(parentPage.getName()) == parentPage;
+
+        if (webProject) {
             webProjectOR.setSaved(false);
-            sProject.refactorObjectName(WebOR.ORScope.PROJECT, parentPage.getName(), oldName, newName);
-        } else if (inShared && webSharedOR != null) {
+            sProject.refactorObjectName(
+                WebOR.ORScope.PROJECT,
+                parentPage.getName(),
+                oldName,
+                newName
+            );
+            return;
+        }
+
+        if (webShared) {
             webSharedOR.setSaved(false);
-            markSharedUsage();
-            sProject.refactorObjectName(WebOR.ORScope.SHARED, parentPage.getName(), oldName, newName);
-        } else {
-            sProject.refactorObjectName(parentPage.getName(), oldName, newName);
+            markSharedUsage("WebOR");
+            sProject.refactorObjectName(
+                WebOR.ORScope.SHARED,
+                parentPage.getName(),
+                oldName,
+                newName
+            );
+            return;
+        }
+
+        boolean mobileProject =
+            mobileProjectOR != null &&
+            mobileProjectOR.getPageByName(parentPage.getName()) == parentPage;
+
+        boolean mobileShared =
+            mobileSharedOR != null &&
+            mobileSharedOR.getPageByName(parentPage.getName()) == parentPage;
+
+        if (mobileProject) {
+            mobileProjectOR.setSaved(false);
+            sProject.refactorMobileObjectName(
+                MobileOR.ORScope.PROJECT,
+                parentPage.getName(),
+                oldName,
+                newName
+            );
+            return;
+        }
+
+        if (mobileShared) {
+            mobileSharedOR.setSaved(false);
+            markSharedUsage("MobileOR");
+            sProject.refactorMobileObjectName(
+                MobileOR.ORScope.SHARED,
+                parentPage.getName(),
+                oldName,
+                newName
+            );
         }
     }
     
@@ -516,10 +630,13 @@ public class ObjectRepository {
      */
     public void renamePage(ORPageInf page, String newName) {
         if (page == null || newName == null || newName.isBlank()) return;
+
         String oldName = page.getName();
         if (oldName.equals(newName)) return;
+
         boolean renamed = false;
         ORScope scopeRenamed = null;
+
         if (webProjectOR != null) {
             var p = webProjectOR.getPageByName(oldName);
             if (p == page) {
@@ -531,8 +648,13 @@ public class ObjectRepository {
                 webProjectOR.setSaved(false);
                 renamed = true;
                 scopeRenamed = ORScope.PROJECT;
+
+                if (useYamlFormat) {
+                    renameWebPageYaml(oldName, newName, scopeRenamed);
+                }
             }
         }
+
         if (!renamed && webSharedOR != null) {
             var s = webSharedOR.getPageByName(oldName);
             if (s == page) {
@@ -544,8 +666,13 @@ public class ObjectRepository {
                 webSharedOR.setSaved(false);
                 renamed = true;
                 scopeRenamed = ORScope.SHARED;
+
+                if (useYamlFormat) {
+                    renameWebPageYaml(oldName, newName, scopeRenamed);
+                }
             }
         }
+
         if (renamed) {
             sProject.refactorPageName(scopeRenamed, oldName, newName);
         } else {
@@ -553,38 +680,55 @@ public class ObjectRepository {
         }
     }
 
-    public void renamePage(com.ing.datalib.or.mobile.MobileORPage page, String newName) {
+    public void renamePage(MobileORPage page, String newName) {
         if (page == null || newName == null || newName.isBlank()) return;
+
         String oldName = page.getName();
         if (oldName.equals(newName)) return;
+
         boolean renamed = false;
-        com.ing.datalib.or.mobile.MobileOR.ORScope mScope = null;
+        MobileOR.ORScope mScope = null;
+
         if (mobileProjectOR != null) {
             var p = mobileProjectOR.getPageByName(oldName);
             if (p == page) {
                 var existsSameScope = mobileProjectOR.getPageByName(newName);
                 if (existsSameScope != null && existsSameScope != page) return;
+
                 p.setName(newName);
                 mobileProjectOR.setSaved(false);
                 renamed = true;
-                mScope = com.ing.datalib.or.mobile.MobileOR.ORScope.PROJECT;
+                mScope = MobileOR.ORScope.PROJECT;
+
+                if (useYamlFormat) {
+                    renameMobilePageYaml(oldName, newName, mScope);
+                }
             }
         }
+
         if (!renamed && mobileSharedOR != null) {
             var s = mobileSharedOR.getPageByName(oldName);
             if (s == page) {
                 var existsSameScope = mobileSharedOR.getPageByName(newName);
                 if (existsSameScope != null && existsSameScope != page) return;
+
                 s.setName(newName);
                 mobileSharedOR.setSaved(false);
                 renamed = true;
-                mScope = com.ing.datalib.or.mobile.MobileOR.ORScope.SHARED;
+                mScope = MobileOR.ORScope.SHARED;
+
+                if (useYamlFormat) {
+                    renameMobilePageYaml(oldName, newName, mScope);
+                }
             }
         }
+
         if (renamed) {
-            var webLikeScope = (mScope == com.ing.datalib.or.mobile.MobileOR.ORScope.PROJECT)
-                    ? com.ing.datalib.or.web.WebOR.ORScope.PROJECT
-                    : com.ing.datalib.or.web.WebOR.ORScope.SHARED;
+            var webLikeScope =
+                (mScope == MobileOR.ORScope.PROJECT)
+                    ? WebOR.ORScope.PROJECT
+                    : WebOR.ORScope.SHARED;
+
             sProject.refactorPageName(webLikeScope, oldName, newName);
         } else {
             sProject.refactorPageName(oldName, newName);
@@ -595,59 +739,46 @@ public class ObjectRepository {
      * Resolves a WebOR object from a scoped PageRef and object name, returning a
      * ResolvedWebObject containing scope, page, object name, and object group.
      */
-    public ResolvedWebObject resolveWebObject(ResolvedWebObject.PageRef pageRef, String objectName) {
+    public ResolvedWebObject resolveWebObject(ResolvedWebObject.PageRef pageRef,String objectName) {
         if (pageRef == null || objectName == null) return null;
-        if (pageRef.scope == WebOR.ORScope.PROJECT) {
-            var g = getFrom(webProjectOR, pageRef.name, objectName);
-            if (g != null) {
-                String actualPageName = g.getParent() != null ? g.getParent().getName() : pageRef.name;
-                return new ResolvedWebObject(WebOR.ORScope.PROJECT, actualPageName, objectName, g);
-            }
-            return null;
+        if (pageRef.scope != null) {
+            return resolveWebObjectInScope(pageRef.scope,pageRef.name,objectName);
         }
-        if (pageRef.scope == WebOR.ORScope.SHARED) {
-            var g = getFrom(webSharedOR, pageRef.name, objectName);
-            if (g != null) {
-                markSharedUsage();
-                String actualPageName = g.getParent() != null ? g.getParent().getName() : pageRef.name;
-                return new ResolvedWebObject(WebOR.ORScope.SHARED, actualPageName, objectName, g);
-            }
-            return null;
+        return resolveWebObjectWithScope(pageRef.name, objectName);
+    }
+    
+    private ResolvedWebObject resolveWebObjectInScope(ORScope scope,String pageName,String objectName) {
+        WebOR or = (scope == ORScope.PROJECT) ? webProjectOR : webSharedOR;
+        ObjectGroup g = getFrom(or, pageName, objectName);
+        if (g == null) return null;
+        if (scope == ORScope.SHARED) {
+            markSharedUsage("WebOR");
         }
-        var proj = getFrom(webProjectOR, pageRef.name, objectName);
-        if (proj != null) {
-            String actualPageName = proj.getParent() != null ? proj.getParent().getName() : pageRef.name;
-            return new ResolvedWebObject(WebOR.ORScope.PROJECT, actualPageName, objectName, proj);
-        }
-        var shared = getFrom(webSharedOR, pageRef.name, objectName);
-        if (shared != null) {
-            markSharedUsage();
-            String actualPageName = shared.getParent() != null ? shared.getParent().getName() : pageRef.name;
-            return new ResolvedWebObject(WebOR.ORScope.SHARED, actualPageName, objectName, shared);
-        }
-        return null;
+        String actualPage = g.getParent() != null ? g.getParent().getName() : pageName;
+        return new ResolvedWebObject(scope, actualPage, objectName, g);
     }
 
-    public ResolvedMobileObject resolveMobileObject(ResolvedMobileObject.PageRef pageRef, String objectName) {
+    public ResolvedMobileObject resolveMobileObject(ResolvedMobileObject.PageRef pageRef,String objectName) {
         if (pageRef == null || objectName == null) return null;
-        if (pageRef.scope == ORScope.PROJECT) {
-            var g = getFrom(mobileProjectOR, pageRef.name, objectName);
-            if (g != null) {
-                String actualPageName = g.getParent() != null ? g.getParent().getName() : pageRef.name;
-                return new ResolvedMobileObject(ORScope.PROJECT, actualPageName, objectName, g);
-            }
-            return null;
-        }
-        if (pageRef.scope == ORScope.SHARED) {
-            var g = getFrom(mobileSharedOR, pageRef.name, objectName);
-            if (g != null) {
-                markSharedUsage();
-                String actualPageName = g.getParent() != null ? g.getParent().getName() : pageRef.name;
-                return new ResolvedMobileObject(ORScope.SHARED, actualPageName, objectName, g);
-            }
-            return null;
+        if (pageRef.scope != null) {
+            return resolveMobileObjectInScope(
+                    pageRef.scope,
+                    pageRef.name,
+                    objectName
+            );
         }
         return resolveMobileObjectWithScope(pageRef.name, objectName);
+    }
+    
+    private ResolvedMobileObject resolveMobileObjectInScope(ORScope scope,String pageName,String objectName) {
+        MobileOR or = (scope == ORScope.PROJECT) ? mobileProjectOR : mobileSharedOR;
+        ObjectGroup g = getFrom(or, pageName, objectName);
+        if (g == null) return null;
+        if (scope == ORScope.SHARED) {
+            markSharedUsage("MobileOR");
+        }
+        String actualPage = g.getParent() != null ? g.getParent().getName() : pageName;
+        return new ResolvedMobileObject(scope, actualPage, objectName, g);
     }
     
     public ResolvedStructuredDataObject resolveStructuredDataObject(ResolvedStructuredDataObject.PageRef pageRef, String objectName) {
@@ -663,7 +794,7 @@ public class ObjectRepository {
         if (pageRef.scope == ORScope.SHARED) {
             var g = getFrom(structuredDataSharedOR, pageRef.name, objectName);
             if (g != null) {
-                markSharedUsage();
+                markSharedUsage("StructuredDataOR");
                 String actualPageName = g.getParent() != null ? g.getParent().getName() : pageRef.name;
                 return new ResolvedStructuredDataObject(ORScope.SHARED, actualPageName, objectName, g);
             }
@@ -679,17 +810,25 @@ public class ObjectRepository {
      * @param objectName object group name
      * @return resolved WebOR object with scope metadata
      */
-    public ResolvedWebObject resolveWebObjectWithScope(String pageName, String objectName) {
+    public ResolvedWebObject resolveWebObjectWithScope(String pageName,String objectName) {
+        ResolvedWebObject proj = resolveWebObjectInScope(ORScope.PROJECT, pageName, objectName);
+        if (proj != null) return proj;
+        return resolveWebObjectInScope(ORScope.SHARED, pageName, objectName);
+    }
+
+    public ResolvedWebObject resolveWebObjectWithScope(String pageName, String objectName,TestStep step) {
         var proj = getFrom(webProjectOR, pageName, objectName);
         if (proj != null) {
-            String actualPageName = proj.getParent() != null ? proj.getParent().getName() : pageName;
-            return new ResolvedWebObject(ORScope.PROJECT, actualPageName, objectName, proj);
+            return new ResolvedWebObject(PROJECT, pageName, objectName, proj);
         }
         var shared = getFrom(webSharedOR, pageName, objectName);
         if (shared != null) {
-            markSharedUsage();
-            String actualPageName = shared.getParent() != null ? shared.getParent().getName() : pageName;
-            return new ResolvedWebObject(ORScope.SHARED, actualPageName, objectName, shared);
+            if (step != null &&
+                step.getReference().startsWith("[Project] ")) {
+                step.setReference("[Shared] " + pageName);
+                step.getTestCase().setSaved(false);
+            }
+            return new ResolvedWebObject(SHARED, pageName, objectName, shared);
         }
         return null;
     }
@@ -701,20 +840,11 @@ public class ObjectRepository {
     * @param objectName object group name
     * @return resolved MobileOR object with scope metadata
     */
-   public ResolvedMobileObject resolveMobileObjectWithScope(String pageName, String objectName) {
-       var proj = getFrom(mobileProjectOR, pageName, objectName);
-       if (proj != null) {
-           String actualPageName = proj.getParent() != null ? proj.getParent().getName() : pageName;
-           return new ResolvedMobileObject(ORScope.PROJECT, actualPageName, objectName, proj);
-       }
-       var shared = getFrom(mobileSharedOR, pageName, objectName);
-       if (shared != null) {
-           markSharedUsage();
-           String actualPageName = shared.getParent() != null ? shared.getParent().getName() : pageName;
-           return new ResolvedMobileObject(ORScope.SHARED, actualPageName, objectName, shared);
-       }
-       return null;
-   }
+    public ResolvedMobileObject resolveMobileObjectWithScope(String pageName, String objectName) {
+        ResolvedMobileObject proj = resolveMobileObjectInScope(ORScope.PROJECT, pageName, objectName);
+        if (proj != null) return proj;
+        return resolveMobileObjectInScope(ORScope.SHARED, pageName, objectName);
+    }
    
    /**
     * Resolves a StructuredDataOR object by searching project scope first, then shared scope.
@@ -731,12 +861,13 @@ public class ObjectRepository {
        }
        var shared = getFrom(structuredDataSharedOR, pageName, objectName);
        if (shared != null) {
-           markSharedUsage();
+           markSharedUsage("StructuredDataOR");
            String actualPageName = shared.getParent() != null ? shared.getParent().getName() : pageName;
            return new ResolvedStructuredDataObject(ORScope.SHARED, actualPageName, objectName, shared);
        }
        return null;
    }
+
 
     private ObjectGroup<WebORObject> getFrom(WebOR or, String page, String obj) {
         if (or == null) return null;
@@ -750,7 +881,7 @@ public class ObjectRepository {
         return (p == null) ? null : p.getObjectGroupByName(obj);
     }
     
-    private ObjectGroup<StructuredDataORObject> getFrom(StructuredData or, String page, String obj) {
+    private ObjectGroup<StructuredDataORObject> getFrom(StructuredDataOR or, String page, String obj) {
         if (or == null) return null;
         StructuredDataORPage p = or.getPageByName(page);
         return (p == null) ? null : p.getObjectGroupByName(obj);
@@ -849,6 +980,9 @@ public class ObjectRepository {
         WebORPage targetPage = getOrCreatePage(sharedOR, uniqueTargetName);
         copyAllGroups(sourcePage, targetPage);
         sharedOR.setSaved(false);
+        if (useYamlFormat) {
+            saveWebPageNow(targetPage);
+        }
         LOG.info(() -> "Copied Web Page '" + sourcePageName + "' to SHARED page '" + uniqueTargetName + "' successfully.");
         return uniqueTargetName;
     }
@@ -869,13 +1003,57 @@ public class ObjectRepository {
         if (targetPage == null) return null;
         ObjectGroup<WebORObject> originalGroup = source.getGroup();
         if (originalGroup == null) return null;
-        String baseName   = originalGroup.getName();
-        String uniqueName = generateUniqueGroupName(targetPage, baseName);
+        String originalName = originalGroup.getName();
+        String baseName = originalName.replaceAll("_Copy_\\d+$", "");
+        String uniqueName;
+        int index = 1;
+        do {
+            uniqueName = baseName + "_Copy_" + index++;
+        } while (targetPage.getObjectGroupByName(uniqueName) != null);
         ObjectGroup<WebORObject> newGroup = cloneGroupIntoPage(originalGroup, targetPage, uniqueName);
         targetPage.getObjectGroups().add(newGroup);
         sharedOR.setSaved(false);
-        LOG.info(() -> "Copied Web Object '" + baseName + "' to SHARED as '" + uniqueName + "'");
+        if (useYamlFormat) {
+            saveWebPageNow(targetPage);
+        }
+        LOG.info(
+            "Copied Web Object '" + originalName +
+            "' to SHARED as '" + uniqueName + "'"
+        );
         return uniqueName;
+    }
+
+    public String moveWebObject(ResolvedWebObject source, String targetPageName) {
+        if (source == null) return null;
+        WebOR sharedOR = getWebSharedOR();
+        if (sharedOR == null) return null;
+        WebORPage targetPage = getOrCreatePage(sharedOR, targetPageName);
+        if (targetPage == null) return null;
+        ObjectGroup<WebORObject> originalGroup = source.getGroup();
+        if (originalGroup == null) return null;
+        String originalName = originalGroup.getName();
+        if (targetPage.getObjectGroupByName(originalName) != null) {
+            return null;
+        }
+        ORPageInf sourcePage = originalGroup.getParent();
+        if (sourcePage != null) {
+            sourcePage.getObjectGroups().remove(originalGroup);
+            sourcePage.getRoot().setSaved(false);
+            if (useYamlFormat && sourcePage instanceof WebORPage) {
+                saveWebPageNow((WebORPage) sourcePage);
+            }
+        }
+        originalGroup.setParent(targetPage);
+        targetPage.getObjectGroups().add(originalGroup);
+        sharedOR.setSaved(false);
+        if (useYamlFormat) {
+            saveWebPageNow(targetPage);
+        }
+        LOG.info(
+            "Moved Web Object '" + originalName +
+            "' to SHARED page '" + targetPageName + "'"
+        );
+        return originalName;
     }
 
     /**
@@ -894,8 +1072,10 @@ public class ObjectRepository {
         MobileORPage targetPage = getOrCreateMobilePage(sharedMOR, uniqueTargetName);
         copyAllMobileGroups(sourcePage, targetPage);
         sharedMOR.setSaved(false);
-        LOG.info(() -> "Copied Mobile Page '" + sourcePageName
-                + "' to SHARED page '" + uniqueTargetName + "' successfully.");
+        if (useYamlFormat) {
+            saveMobilePageNow(targetPage);
+        }
+        LOG.info(() -> "Copied Mobile Page '" + sourcePageName + "' to SHARED page '" + uniqueTargetName + "' successfully.");
         return uniqueTargetName;
     }
 
@@ -914,13 +1094,58 @@ public class ObjectRepository {
         if (targetPage == null) return null;
         ObjectGroup<MobileORObject> originalGroup = source.getGroup();
         if (originalGroup == null) return null;
-        String baseName   = originalGroup.getName();
-        String uniqueName = generateUniqueMobileGroupName(targetPage, baseName);
+        String originalName = originalGroup.getName();
+        String baseName = originalName.replaceAll("_Copy_\\d+$", "");
+        String uniqueName;
+        int index = 1;
+        do {
+            uniqueName = baseName + "_Copy_" + index++;
+        } while (targetPage.getObjectGroupByName(uniqueName) != null);
         ObjectGroup<MobileORObject> newGroup = cloneMobileGroupIntoPage(originalGroup, targetPage, uniqueName);
         targetPage.getObjectGroups().add(newGroup);
         sharedMOR.setSaved(false);
-        LOG.info(() -> "Copied Mobile Object '" + baseName + "' to SHARED as '" + uniqueName + "'");
+        if (useYamlFormat) {
+            saveMobilePageNow(targetPage);
+        }
+        LOG.info(
+            "Copied Mobile Object '" + originalName +
+            "' to SHARED as '" + uniqueName + "'"
+        );
         return uniqueName;
+    }
+    
+    public String moveMobileObject(ResolvedMobileObject source, String targetPageName) {
+        if (source == null) return null;
+        MobileOR sharedOR = getMobileSharedOR();
+        if (sharedOR == null) return null;
+        MobileORPage targetPage = getOrCreateMobilePage(sharedOR, targetPageName);
+        if (targetPage == null) return null;
+        ObjectGroup<MobileORObject> originalGroup = source.getGroup();
+        if (originalGroup == null) return null;
+        String originalName = originalGroup.getName();
+        if (targetPage.getObjectGroupByName(originalName) != null) {
+            return null;
+        }
+        ORPageInf sourcePage = originalGroup.getParent();
+        if (sourcePage != null) {
+            sourcePage.getObjectGroups().remove(originalGroup);
+            sourcePage.getRoot().setSaved(false);
+
+            if (useYamlFormat && sourcePage instanceof MobileORPage) {
+                saveMobilePageNow((MobileORPage) sourcePage);
+            }
+        }
+        originalGroup.setParent(targetPage);
+        targetPage.getObjectGroups().add(originalGroup);
+        sharedOR.setSaved(false);
+        if (useYamlFormat) {
+            saveMobilePageNow(targetPage);
+        }
+        LOG.info(
+            "Moved Mobile Object Group '" + originalName +
+            "' to SHARED page '" + targetPageName + "'"
+        );
+        return originalName;
     }
 
     private String generateUniquePageName(MobileOR mor, String baseName) {
@@ -964,14 +1189,17 @@ public class ObjectRepository {
      * Marks that the current project has used a shared object,
      * updating shared OR metadata.
      */
-    private void markSharedUsage() {
-        if (sProject != null && sProject.getName() != null && !sProject.getName().isBlank()) {
-            sharedUsageProjects.add(sProject.getName());
+    private void markSharedUsage(String orType) {
+        if (sProject == null || sProject.getName() == null) {
+            return;
+        }
+
+        if ("WebOR".equals(orType)) {
+            webSharedUsageProjects.add(sProject.getName());
+        } else if ("MobileOR".equals(orType)) {
+            mobileSharedUsageProjects.add(sProject.getName());
         }
     }
-    
-    // ============ YAML-related stub methods for backward compatibility ============
-    // These methods are placeholders for future YAML OR support integration
 
     /**
      * Check if using YAML format.
@@ -988,7 +1216,7 @@ public class ObjectRepository {
     public void setUseYamlFormat(boolean useYaml) {
         this.useYamlFormat = useYaml;
         if (useYaml && yamlReader == null) {
-            yamlReader = new YamlORReader();
+            yamlReader = new YamlORReader(this);
             yamlWriter = new YamlORWriter();
         }
     }
@@ -1000,19 +1228,25 @@ public class ObjectRepository {
      * @param page the page to save
      */
     public void saveWebPageNow(WebORPage page) {
-        if (useYamlFormat && yamlWriter != null) {
-            try {
-                File orRepLocation = new File(getORRepLocation());
-                File webPagesDir = new File(orRepLocation, "Web/pages");
-                if (!webPagesDir.exists()) {
-                    webPagesDir.mkdirs();
-                }
-                yamlWriter.writeWebPage(page, webPagesDir);
-            } catch (IOException e) {
-                LOG.log(Level.SEVERE, "Failed to save Web page: " + page.getName(), e);
+        if (!useYamlFormat || yamlWriter == null || page == null) return;
+        try {
+            File repoRoot =
+                (page.getRoot().getScope() == WebOR.ORScope.SHARED)
+                    ? new File(getSharedORRepLocation())
+                    : new File(getORRepLocation());
+            File webPagesDir = new File(repoRoot, "Web");
+            if (!webPagesDir.exists()) {
+                webPagesDir.mkdirs();
             }
+            yamlWriter.writeWebPage(page, webPagesDir);
+            page.getRoot().setSaved(true);
+        } catch (IOException e) {
+            LOG.log(
+                Level.SEVERE,
+                "Failed to save Web page: " + page.getName(),
+                e
+            );
         }
-        // XML format doesn't need per-page saves
     }
     
     /**
@@ -1022,19 +1256,25 @@ public class ObjectRepository {
      * @param page the page to save
      */
     public void saveMobilePageNow(MobileORPage page) {
-        if (useYamlFormat && yamlWriter != null) {
-            try {
-                File morRepLocation = new File(getMORRepLocation());
-                File mobilePagesDir = new File(morRepLocation, "Mobile/pages");
-                if (!mobilePagesDir.exists()) {
-                    mobilePagesDir.mkdirs();
-                }
-                yamlWriter.writeMobilePage(page, mobilePagesDir);
-            } catch (IOException e) {
-                LOG.log(Level.SEVERE, "Failed to save Mobile page: " + page.getName(), e);
+        if (!useYamlFormat || yamlWriter == null || page == null) return;
+        try {
+            File repoRoot =
+                (page.getRoot().getScope() == MobileOR.ORScope.SHARED)
+                    ? new File(getSharedORRepLocation())
+                    : new File(getORRepLocation());
+            File mobilePagesDir = new File(repoRoot, "Mobile");
+            if (!mobilePagesDir.exists()) {
+                mobilePagesDir.mkdirs();
             }
+            yamlWriter.writeMobilePage(page, mobilePagesDir);
+            page.getRoot().setSaved(true);
+        } catch (IOException e) {
+            LOG.log(
+                Level.SEVERE,
+                "Failed to save Mobile page: " + page.getName(),
+                e
+            );
         }
-        // XML format doesn't need per-page saves
     }
     
     /**
@@ -1047,7 +1287,7 @@ public class ObjectRepository {
         if (useYamlFormat && yamlWriter != null) {
             try {
                 File structuredDataOrRepLocation = new File(getStructuredDataORRepLocation());
-                File structuredDataPagesDir = new File(structuredDataOrRepLocation, "StructuredData/pages");
+                File structuredDataPagesDir = new File(structuredDataOrRepLocation, "StructuredData");
                 if (!structuredDataPagesDir.exists()) {
                     structuredDataPagesDir.mkdirs();
                 }
@@ -1066,15 +1306,24 @@ public class ObjectRepository {
      * @param newName new page name
      * @return true if renamed successfully, false otherwise
      */
-    public boolean renameWebPageYaml(String oldName, String newName) {
+    public boolean renameWebPageYaml(String oldName, String newName, WebOR.ORScope scope) {
         if (!useYamlFormat || yamlWriter == null) {
-            return true; // XML mode - no-op
+            return true;
+        }
+        if (oldName == null || newName == null || oldName.equals(newName)) {
+            return true;
         }
         try {
-            File orRepLocation = new File(getORRepLocation());
-            return yamlWriter.renameWebPage(oldName, newName, orRepLocation);
+            File repoRoot =
+                (scope == WebOR.ORScope.SHARED)
+                    ? new File(getSharedORRepLocation())
+                    : new File(getORRepLocation());
+            return yamlWriter.renameWebPage(oldName, newName, repoRoot);
+
         } catch (Exception e) {
-            LOG.log(Level.SEVERE, "Failed to rename Web page from " + oldName + " to " + newName, e);
+            LOG.log(Level.SEVERE,
+                "Failed to rename Web page [" + scope + "] from " +
+                oldName + " to " + newName, e);
             return false;
         }
     }
@@ -1086,12 +1335,18 @@ public class ObjectRepository {
      * @param newName new page name
      * @return true if renamed successfully, false otherwise
      */
-    public boolean renameMobilePageYaml(String oldName, String newName) {
+    public boolean renameMobilePageYaml(String oldName, String newName, MobileOR.ORScope scope) {
         if (!useYamlFormat || yamlWriter == null) {
             return true; // XML mode - no-op
         }
+        if (oldName == null || newName == null || oldName.equals(newName)) {
+            return true;
+        }
         try {
-            File morRepLocation = new File(getMORRepLocation());
+            File morRepLocation =
+                (scope == MobileOR.ORScope.SHARED)
+                    ? new File(getSharedORRepLocation())
+                    : new File(getORRepLocation());
             return yamlWriter.renameMobilePage(oldName, newName, morRepLocation);
         } catch (Exception e) {
             LOG.log(Level.SEVERE, "Failed to rename Mobile page from " + oldName + " to " + newName, e);
@@ -1110,11 +1365,62 @@ public class ObjectRepository {
         if (!useYamlFormat || yamlWriter == null) {
             return true; // XML mode - no-op
         }
+        if (oldName == null || newName == null || oldName.equals(newName)) {
+            return true;
+        }
         try {
             File structuredDataRepLocation = new File(getStructuredDataORRepLocation());
             return yamlWriter.renameStructuredDataPage(oldName, newName, structuredDataRepLocation);
         } catch (Exception e) {
             LOG.log(Level.SEVERE, "Failed to rename Structured Data page from " + oldName + " to " + newName, e);
+            return false;
+        }
+    }
+    
+    public boolean deleteWebPageYaml(String pageName) {
+        if (!useYamlFormat || yamlWriter == null) {
+            return true; // XML mode - no-op
+        }
+        if (pageName == null || pageName.isBlank()) {
+            return true;
+        }
+        try {
+            File orRepLocation = new File(getORRepLocation());
+            return yamlWriter.deleteWebPage(pageName, orRepLocation);
+        } catch (Exception e) {
+            LOG.log(Level.SEVERE, "Failed to delete Web page YAML: " + pageName, e);
+            return false;
+        }
+    }
+    
+    public boolean deleteMobilePageYaml(String pageName) {
+        if (!useYamlFormat || yamlWriter == null) {
+            return true; // XML mode - no-op
+        }
+        if (pageName == null || pageName.isBlank()) {
+            return true;
+        }
+        try {
+            File morRepLocation = new File(getORRepLocation());
+            return yamlWriter.deleteMobilePage(pageName, morRepLocation);
+        } catch (Exception e) {
+            LOG.log(Level.SEVERE, "Failed to delete Mobile page YAML: " + pageName, e);
+            return false;
+        }
+    }
+    
+    public boolean deleteStructuredDataPageYaml(String pageName) {
+        if (!useYamlFormat || yamlWriter == null) {
+            return true; // XML mode - no-op
+        }
+        if (pageName == null || pageName.isBlank()) {
+            return true;
+        }
+        try {
+            File apiorRepLocation = new File(getORRepLocation());
+            return yamlWriter.deleteStructuredDataPage(pageName, apiorRepLocation);
+        } catch (Exception e) {
+            LOG.log(Level.SEVERE, "Failed to delete Structured Data page YAML: " + pageName, e);
             return false;
         }
     }

--- a/Datalib/src/main/java/com/ing/datalib/or/XmlToYamlORConverter.java
+++ b/Datalib/src/main/java/com/ing/datalib/or/XmlToYamlORConverter.java
@@ -1,0 +1,109 @@
+package com.ing.datalib.or;
+
+import com.ing.datalib.or.mobile.MobileOR;
+import com.ing.datalib.or.mobile.MobileORPage;
+import com.ing.datalib.or.web.WebOR;
+import com.ing.datalib.or.web.WebORPage;
+import com.ing.datalib.or.yaml.YamlORWriter;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.logging.Logger;
+
+/**
+ * Converts in-memory XML Object Repositories to YAML.
+ *
+ * Scope is determined by WHICH OR is passed:
+ * - Project OR → ObjectRepository
+ * - Shared OR  → Shared
+ *
+ * Pages do not carry scope.
+ */
+public class XmlToYamlORConverter {
+
+    private static final Logger LOG = Logger.getLogger(XmlToYamlORConverter.class.getName());
+
+    private final YamlORWriter yamlWriter;
+
+    public XmlToYamlORConverter(YamlORWriter yamlWriter) {
+        this.yamlWriter = yamlWriter;
+    }
+
+    /**
+     * Convert all ORs to YAML with correct folder separation.
+     */
+    public void convertAll(
+            WebOR projectWeb,
+            WebOR sharedWeb,
+            MobileOR projectMobile,
+            MobileOR sharedMobile,
+            File projectRoot,
+            File sharedRoot) throws IOException {
+
+        writeProjectWeb(projectWeb, projectRoot);
+        writeSharedWeb(sharedWeb, sharedRoot);
+
+        writeProjectMobile(projectMobile, projectRoot);
+        writeSharedMobile(sharedMobile, sharedRoot);
+    }
+
+    private void writeProjectWeb(WebOR projectOR, File projectRoot)
+            throws IOException {
+
+        if (projectOR == null) return;
+
+        File pagesDir = new File(projectRoot, "Web");
+        pagesDir.mkdirs();
+
+        LOG.info("Writing PROJECT Web OR to " + pagesDir.getAbsolutePath());
+
+        for (WebORPage page : projectOR.getPages()) {
+            yamlWriter.writeWebPage(page, pagesDir);
+        }
+    }
+
+    private void writeProjectMobile(MobileOR projectOR, File projectRoot)
+            throws IOException {
+
+        if (projectOR == null) return;
+
+        File pagesDir = new File(projectRoot, "Mobile");
+        pagesDir.mkdirs();
+
+        LOG.info("Writing PROJECT Mobile OR to " + pagesDir.getAbsolutePath());
+
+        for (MobileORPage page : projectOR.getPages()) {
+            yamlWriter.writeMobilePage(page, pagesDir);
+        }
+    }
+
+    private void writeSharedWeb(WebOR sharedOR, File sharedRoot)
+            throws IOException {
+
+        if (sharedOR == null) return;
+
+        File pagesDir = new File(sharedRoot, "Web");
+        pagesDir.mkdirs();
+
+        LOG.info("Writing SHARED Web OR to " + pagesDir.getAbsolutePath());
+
+        for (WebORPage page : sharedOR.getPages()) {
+            yamlWriter.writeWebPage(page, pagesDir);
+        }
+    }
+
+    private void writeSharedMobile(MobileOR sharedOR, File sharedRoot)
+            throws IOException {
+
+        if (sharedOR == null) return;
+
+        File pagesDir = new File(sharedRoot, "Mobile");
+        pagesDir.mkdirs();
+
+        LOG.info("Writing SHARED Mobile OR to " + pagesDir.getAbsolutePath());
+
+        for (MobileORPage page : sharedOR.getPages()) {
+            yamlWriter.writeMobilePage(page, pagesDir);
+        }
+    }
+}

--- a/Datalib/src/main/java/com/ing/datalib/or/mobile/MobileOR.java
+++ b/Datalib/src/main/java/com/ing/datalib/or/mobile/MobileOR.java
@@ -103,6 +103,9 @@ public class MobileOR implements ORRootInf<MobileORPage> {
         this.pages = pages;
         for (MobileORPage page : pages) {
             page.setRoot(this);
+            if (page.getSource() == null) {
+                page.setSource(isShared() ? ORScope.SHARED : ORScope.PROJECT);
+            }
         }
     }
 
@@ -250,7 +253,7 @@ public class MobileOR implements ORRootInf<MobileORPage> {
     public String getRepLocation() {
         return repLocationOverride != null
                 ? repLocationOverride
-                : getObjectRepository().getMORRepLocation();
+                : getObjectRepository().getORRepLocation();
     }
 
     @JsonIgnore
@@ -282,6 +285,6 @@ public class MobileOR implements ORRootInf<MobileORPage> {
     }
     
     public void setSharedProjects(List<String> projects) {
-        this.projects = (projects == null) ? new ArrayList<>() : projects;
+        this.projects = projects;
     }
 }

--- a/Datalib/src/main/java/com/ing/datalib/or/mobile/MobileORObject.java
+++ b/Datalib/src/main/java/com/ing/datalib/or/mobile/MobileORObject.java
@@ -76,10 +76,11 @@ public class MobileORObject extends UndoRedoModel implements ORObjectInf {
         changeSave();
         if (group.getObjects().size() == 1) {
             group.removeFromParent();
-        } else {
-            group.getObjects().remove(this);
-            FileUtils.deleteFile(getRepLocation());
         }
+        group.getObjects().remove(this);
+        if (!group.getParent().getRoot().getObjectRepository().isUsingYamlFormat()) {
+            FileUtils.deleteFile(getRepLocation());
+        } 
     }
 
     @Override
@@ -311,30 +312,21 @@ public class MobileORObject extends UndoRedoModel implements ORObjectInf {
         return String.class;
     }
 
+    @JsonIgnore
     @Override
     public Boolean rename(String newName) {
-        Boolean flag = true;
         if (getParent().getChildCount() == 1) {
-            flag = getParent().rename(newName);
+            getParent().rename(newName);
         }
-        if (flag && getParent().getObjectByName(newName) == null) {
-            // Check if using YAML format
-            if (getParent().getParent().getRoot().getObjectRepository().isUsingYamlFormat()) {
-                // For YAML format, objects are stored within the page YAML file
-                // Just update the name and mark as needing save
-                setName(newName);
-                changeSave();
-                return true;
-            } else {
-                // Use original XML folder-based rename
-                if (FileUtils.renameFile(getRepLocation(), newName)) {
-                    setName(newName);
-                    changeSave();
-                    return true;
-                }
-            }
+        if (newName == null || newName.isBlank()) {
+            return false;
         }
-        return false;
+        if (getParent().getObjectByName(newName) != null) {
+            return false;
+        }
+        setName(newName);
+        changeSave();
+        return true;
     }
 
     @JsonIgnore

--- a/Datalib/src/main/java/com/ing/datalib/or/mobile/MobileORPage.java
+++ b/Datalib/src/main/java/com/ing/datalib/or/mobile/MobileORPage.java
@@ -90,7 +90,11 @@ public class MobileORPage implements ORPageInf<MobileORObject, MobileOR> {
     public void removeFromParent() {
         root.setSaved(false);
         root.getPages().remove(this);
-        FileUtils.deleteFile(getRepLocation());
+        if (root.getObjectRepository().isUsingYamlFormat()) {
+            root.getObjectRepository().deleteMobilePageYaml(getName());
+        } else {
+            FileUtils.deleteFile(getRepLocation());
+        }
     }
 
     @JsonIgnore
@@ -256,28 +260,10 @@ public class MobileORPage implements ORPageInf<MobileORObject, MobileOR> {
 
     @Override
     public Boolean rename(String newName) {
-        if (getParent().getPageByName(newName) == null) {
-            String oldName = getName();
-            // Check if using YAML format
-            if (getRoot().getObjectRepository().isUsingYamlFormat()) {
-                // Rename the YAML file
-                if (getRoot().getObjectRepository().renameMobilePageYaml(oldName, newName)) {
-                    getRoot().getObjectRepository().renamePage(this, newName);
-                    setName(newName);
-                    getParent().setSaved(false);
-                    return true;
-                }
-            } else {
-                // Use original XML folder-based rename
-                if (FileUtils.renameFile(getRepLocation(), newName)) {
-                    getRoot().getObjectRepository().renamePage(this, newName);
-                    setName(newName);
-                    getParent().setSaved(false);
-                    return true;
-                }
-            }
-        }
-        return false;
+        getRoot()
+            .getObjectRepository()
+            .renamePage(this, newName);
+        return true;
     }
 
     @JsonIgnore

--- a/Datalib/src/main/java/com/ing/datalib/or/structureddata/ResolvedStructuredDataObject.java
+++ b/Datalib/src/main/java/com/ing/datalib/or/structureddata/ResolvedStructuredDataObject.java
@@ -1,0 +1,112 @@
+package com.ing.datalib.or.structureddata;
+
+import com.ing.datalib.or.common.ObjectGroup;
+import com.ing.datalib.or.web.WebOR.ORScope;
+
+/**
+ * Represents a resolved Strucutured Data object within the Object Repository, including its scope,
+ * page name, object name, and resolved object group.
+ *
+ */
+public class ResolvedStructuredDataObject {
+
+    private final ORScope scope;
+    private final String pageName;
+    private final String objectName;
+    private final ObjectGroup<StructuredDataORObject> group;
+
+    public ResolvedStructuredDataObject(ORScope scope, String pageName, String objectName, ObjectGroup<StructuredDataORObject> group) {
+        this.scope = scope;
+        this.pageName = pageName;
+        this.objectName = objectName;
+        this.group = group;
+    }
+
+    public ORScope getScope() { 
+        return scope; 
+    }
+    
+    public String getPageName() { 
+        return pageName; 
+    }
+    
+    public String getObjectName() { 
+        return objectName; 
+    }
+    
+    public ObjectGroup<StructuredDataORObject> getGroup() { 
+        return group; 
+    }
+
+    /**
+     * Returns the first resolved StructuredDataORObject from the group, or null if none exist.
+     */
+    public StructuredDataORObject getObject() {
+        return (group != null && !group.getObjects().isEmpty()) ? group.getObjects().get(0) : null;
+    }
+
+    public boolean isFromProject() { 
+        return scope == ORScope.PROJECT; 
+    }
+    
+    public boolean isFromShared()  { 
+        return scope == ORScope.SHARED; 
+    }
+
+    public boolean isPresent() {
+        return group != null && !group.getObjects().isEmpty();
+    }
+
+    public String debugString() {
+        return "ResolvedStructuredDataObject{scope=" + scope
+                + ", page='" + pageName + '\''
+                + ", object='" + objectName + '\''
+                + ", objectCount=" + (group == null ? 0 : group.getObjects().size())
+                + '}';
+    }
+
+    /**
+     * Optional: reuse the same PageRef concept as web if you want scoped tokens like:
+     * "[Shared] Login" / "[Project] Home"
+     *
+     * If you already want Structured Data page tokens to behave the same way, you can keep this.
+     */
+    public static final class PageRef {
+        public final String name;
+        public final ORScope scope;
+
+        public PageRef(String name, ORScope scope) {
+            this.name = name;
+            this.scope = scope;
+        }
+
+        public String qualified() {
+            if (scope == null) return name;
+            switch (scope) {
+                case PROJECT: return "[Project] " + name;
+                case SHARED:  return "[Shared] " + name;
+                default:      return name;
+            }
+        }
+
+        public static PageRef parse(String token) {
+            String s = token == null ? "" : token.trim();
+            if (s.isEmpty()) return new PageRef("", ORScope.PROJECT);
+
+            if (s.startsWith("[") && s.contains("]")) {
+                int end = s.indexOf(']');
+                String scopeText = s.substring(1, end).trim().toUpperCase();
+                String base = s.substring(end + 1).trim();
+                ORScope sc;
+                switch (scopeText) {
+                    case "PROJECT": sc = ORScope.PROJECT; break;
+                    case "SHARED":  sc = ORScope.SHARED;  break;
+                    default:        sc = ORScope.PROJECT;
+                }
+                return new PageRef(base, sc);
+            }
+
+            return new PageRef(s, ORScope.PROJECT);
+        }
+    }
+}

--- a/Datalib/src/main/java/com/ing/datalib/or/structureddata/StructuredData.java
+++ b/Datalib/src/main/java/com/ing/datalib/or/structureddata/StructuredData.java
@@ -1,4 +1,4 @@
-package com.ing.datalib.or.api;
+package com.ing.datalib.or.structureddata;
 
 import com.ing.datalib.or.ObjectRepository;
 import com.ing.datalib.or.common.ORRootInf;
@@ -8,7 +8,6 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
-import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -22,7 +21,7 @@ import javax.swing.tree.TreeNode;
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JacksonXmlRootElement(localName = "Root")
-public class APIOR implements ORRootInf<APIORPage> {
+public class StructuredData implements ORRootInf<StructuredDataORPage> {
 
     public final static List<String> OBJECT_PROPS
             = new ArrayList<>(Arrays.asList(
@@ -34,7 +33,7 @@ public class APIOR implements ORRootInf<APIORPage> {
 
     @JacksonXmlProperty(localName = "Page")
     @JacksonXmlElementWrapper(useWrapping = false, localName = "Page")
-    private List<APIORPage> pages;
+    private List<StructuredDataORPage> pages;
 
     @JacksonXmlProperty(isAttribute = true)
     private String type;
@@ -45,13 +44,13 @@ public class APIOR implements ORRootInf<APIORPage> {
     @JsonIgnore
     private Boolean saved = true;
 
-    public APIOR() {
+    public StructuredData() {
         this.pages = new ArrayList<>();
     }
 
-    public APIOR(String name) {
+    public StructuredData(String name) {
         this.name = name;
-        this.type = "APIOR";
+        this.type = "StructuredDataOR";
         this.pages = new ArrayList<>();
     }
 
@@ -66,14 +65,14 @@ public class APIOR implements ORRootInf<APIORPage> {
     }
 
     @Override 
-    public List<APIORPage> getPages() {
+    public List<StructuredDataORPage> getPages() {
         return pages;
     }
 
     @Override
-    public void setPages(List<APIORPage> pages) {
+    public void setPages(List<StructuredDataORPage> pages) {
         this.pages = pages;
-        for (APIORPage page : pages) {
+        for (StructuredDataORPage page : pages) {
             page.setRoot(this);
         }
     }
@@ -88,8 +87,8 @@ public class APIOR implements ORRootInf<APIORPage> {
 
     @JsonIgnore
     @Override
-    public APIORPage getPageByName(String pageName) {
-        for (APIORPage page : pages) {
+    public StructuredDataORPage getPageByName(String pageName) {
+        for (StructuredDataORPage page : pages) {
             if (page.getName().equalsIgnoreCase(pageName)) {
                 return page;
             }
@@ -98,8 +97,8 @@ public class APIOR implements ORRootInf<APIORPage> {
     }
 
     @JsonIgnore
-    public APIORPage getPageByTitle(String title) {
-        for (APIORPage page : pages) {
+    public StructuredDataORPage getPageByTitle(String title) {
+        for (StructuredDataORPage page : pages) {
             if (page.getTitle().equals(title)) {
                 return page;
             }
@@ -109,8 +108,8 @@ public class APIOR implements ORRootInf<APIORPage> {
 
     @JsonIgnore
     @Override
-    public APIORPage addPage() {
-        String pName = "APIPage";
+    public StructuredDataORPage addPage() {
+        String pName = "StructuredDataPage";
         int i = 0;
         String pageName;
         do {
@@ -122,16 +121,16 @@ public class APIOR implements ORRootInf<APIORPage> {
 
     @JsonIgnore
     @Override
-    public APIORPage addPage(String pageName) {
+    public StructuredDataORPage addPage(String pageName) {
         if (getPageByName(pageName) == null) {
-            APIORPage page = new APIORPage(pageName, this);
+            StructuredDataORPage page = new StructuredDataORPage(pageName, this);
             pages.add(page);
-            // API OR uses YAML format - no folder creation needed
+            // Structured Data OR uses YAML format - no folder creation needed
             setSaved(false);
             
             // Auto-save for YAML format
             if (objectRepository != null && objectRepository.isUsingYamlFormat()) {
-                objectRepository.saveAPIPageNow(page);
+                objectRepository.saveStructuredDataPageNow(page);
             }
             return page;
         }
@@ -141,7 +140,7 @@ public class APIOR implements ORRootInf<APIORPage> {
     @JsonIgnore
     @Override
     public void deletePage(String pageName) {
-        APIORPage page = getPageByName(pageName);
+        StructuredDataORPage page = getPageByName(pageName);
         if (page != null) {
             pages.remove(page);
             setSaved(false);

--- a/Datalib/src/main/java/com/ing/datalib/or/structureddata/StructuredDataAttribute.java
+++ b/Datalib/src/main/java/com/ing/datalib/or/structureddata/StructuredDataAttribute.java
@@ -1,0 +1,65 @@
+
+package com.ing.datalib.or.structureddata;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+
+@JsonInclude(JsonInclude.Include.NON_DEFAULT)
+public class StructuredDataAttribute {
+
+    @JacksonXmlProperty(isAttribute = true, localName = "ref")
+    private String name;
+
+    @JacksonXmlProperty(isAttribute = true)
+    private String value;
+
+    @JacksonXmlProperty(isAttribute = true, localName = "pref")
+    private String preference;
+    
+    public StructuredDataAttribute() {
+    }
+
+    public StructuredDataAttribute(String name, int preference) {
+        this.name = name;
+        this.value = "";
+        this.preference = String.valueOf(preference);
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+    public String getPreference() {
+        return preference;
+    }
+
+    public void setPreference(String preference) {
+        this.preference = preference;
+    }
+
+    @Override
+    public String toString() {
+        return "ClassPojo [ref = " + name + ", value = " + value + "]";
+    }
+
+    @JsonIgnore
+    public StructuredDataAttribute cloneAs() {
+        StructuredDataAttribute attribute = new StructuredDataAttribute();
+        attribute.setName(name);
+        attribute.setValue(value);
+        return attribute;
+    }
+}

--- a/Datalib/src/main/java/com/ing/datalib/or/structureddata/StructuredDataOR.java
+++ b/Datalib/src/main/java/com/ing/datalib/or/structureddata/StructuredDataOR.java
@@ -21,7 +21,7 @@ import javax.swing.tree.TreeNode;
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JacksonXmlRootElement(localName = "Root")
-public class StructuredData implements ORRootInf<StructuredDataORPage> {
+public class StructuredDataOR implements ORRootInf<StructuredDataORPage> {
 
     public final static List<String> OBJECT_PROPS
             = new ArrayList<>(Arrays.asList(
@@ -44,11 +44,11 @@ public class StructuredData implements ORRootInf<StructuredDataORPage> {
     @JsonIgnore
     private Boolean saved = true;
 
-    public StructuredData() {
+    public StructuredDataOR() {
         this.pages = new ArrayList<>();
     }
 
-    public StructuredData(String name) {
+    public StructuredDataOR(String name) {
         this.name = name;
         this.type = "StructuredDataOR";
         this.pages = new ArrayList<>();

--- a/Datalib/src/main/java/com/ing/datalib/or/structureddata/StructuredDataORObject.java
+++ b/Datalib/src/main/java/com/ing/datalib/or/structureddata/StructuredDataORObject.java
@@ -1,7 +1,6 @@
-package com.ing.datalib.or.api;
+package com.ing.datalib.or.structureddata;
 
 import com.ing.datalib.component.utils.FileUtils;
-import com.ing.datalib.or.common.ORAttribute;
 import com.ing.datalib.or.common.ORObjectInf;
 import com.ing.datalib.or.common.ORUtils;
 import com.ing.datalib.or.common.ObjectGroup;
@@ -28,36 +27,35 @@ import javax.swing.tree.TreePath;
  * Supports only JsonPath and Xpath as locator attributes.
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public class APIORObject extends UndoRedoModel implements ORObjectInf {
+public class StructuredDataORObject extends UndoRedoModel implements ORObjectInf {
 
     @JacksonXmlProperty(isAttribute = true, localName = "ref")
     private String name;
 
     @JacksonXmlProperty(localName = "Property")
     @JacksonXmlElementWrapper(useWrapping = false, localName = "Property")
-    private List<ORAttribute> attributes;
+    private List<StructuredDataAttribute> attributes;
 
     @JsonIgnore
-    private ObjectGroup<APIORObject> group;
+    private ObjectGroup<StructuredDataORObject> group;
 
-    public APIORObject() {
-        setDefaultORAttributes();
+    public StructuredDataORObject() {
+        setDefaultStructuredDataAttributes();
     }
 
-    public APIORObject(String name, ObjectGroup group) {
+    public StructuredDataORObject(String name, ObjectGroup group) {
         this.name = name;
         this.group = group;
-        setDefaultORAttributes();
+        setDefaultStructuredDataAttributes();
     }
 
     @JsonIgnore
-    public final void setDefaultORAttributes() {
+    public final void setDefaultStructuredDataAttributes() {
         attributes = new ArrayList<>();
-        for (int i = 0; i < APIOR.OBJECT_PROPS.size(); i++) {
-            ORAttribute attr = new ORAttribute();
-            attr.setName(APIOR.OBJECT_PROPS.get(i));
+        for (int i = 0; i < StructuredData.OBJECT_PROPS.size(); i++) {
+            StructuredDataAttribute attr = new StructuredDataAttribute();
+            attr.setName(StructuredData.OBJECT_PROPS.get(i));
             attr.setValue("");
-            attr.setPreference("" + (i + 1));
             attributes.add(attr);
         }
     }
@@ -72,11 +70,11 @@ public class APIORObject extends UndoRedoModel implements ORObjectInf {
         this.name = name;
     }
 
-    public List<ORAttribute> getAttributes() {
+    public List<StructuredDataAttribute> getAttributes() {
         return attributes;
     }
 
-    public void setAttributes(List<ORAttribute> attributes) {
+    public void setAttributes(List<StructuredDataAttribute> attributes) {
         this.attributes = attributes;
     }
 
@@ -105,7 +103,7 @@ public class APIORObject extends UndoRedoModel implements ORObjectInf {
 
     @JsonIgnore
     @Override
-    public ObjectGroup<APIORObject> getParent() {
+    public ObjectGroup<StructuredDataORObject> getParent() {
         return group;
     }
 
@@ -170,7 +168,7 @@ public class APIORObject extends UndoRedoModel implements ORObjectInf {
     @JsonIgnore
     @Override
     public void setValueAt(Object value, int rowIndex, int columnIndex) {
-        ORAttribute attr = attributes.get(rowIndex);
+        StructuredDataAttribute attr = attributes.get(rowIndex);
         if (columnIndex == 0) {
             if (isNotDefault(rowIndex) && getAttribute(value.toString()) == null) {
                 super.setValueAt(value, rowIndex, columnIndex);
@@ -189,7 +187,7 @@ public class APIORObject extends UndoRedoModel implements ORObjectInf {
     @JsonIgnore
     private Boolean isNotDefault(int rowIndex) {
         String value = getValueAt(rowIndex, 0).toString();
-        return APIOR.OBJECT_PROPS.indexOf(value) == -1;
+        return StructuredData.OBJECT_PROPS.indexOf(value) == -1;
     }
 
     @JsonIgnore
@@ -212,13 +210,13 @@ public class APIORObject extends UndoRedoModel implements ORObjectInf {
     @JsonIgnore
     private void changeSave() {
         if (group != null) {
-            APIORPage page = (APIORPage) group.getParent();
+            StructuredDataORPage page = (StructuredDataORPage) group.getParent();
             page.getRoot().setSaved(false);
             
             // Auto-save for YAML format
             if (page.getRoot().getObjectRepository() != null 
                 && page.getRoot().getObjectRepository().isUsingYamlFormat()) {
-                page.getRoot().getObjectRepository().saveAPIPageNow(page);
+                page.getRoot().getObjectRepository().saveStructuredDataPageNow(page);
             }
         }
     }
@@ -279,8 +277,8 @@ public class APIORObject extends UndoRedoModel implements ORObjectInf {
 
     @JsonIgnore
     @Override
-    public APIORPage getPage() {
-        return (APIORPage) group.getParent();
+    public StructuredDataORPage getPage() {
+        return (StructuredDataORPage) group.getParent();
     }
 
     @JsonIgnore
@@ -314,6 +312,8 @@ public class APIORObject extends UndoRedoModel implements ORObjectInf {
         if (getParent().getChildCount() == 1) {
             flag = getParent().rename(newName);
         }
+        ObjectGroup<StructuredDataORObject> parent = getParent();
+        String parentName = parent.getName();
         if (flag && getParent().getObjectByName(newName) == null) {
             // Check if using YAML format
             if (getParent().getParent().getRoot().getObjectRepository().isUsingYamlFormat()) {
@@ -342,11 +342,11 @@ public class APIORObject extends UndoRedoModel implements ORObjectInf {
 
     @JsonIgnore
     @Override
-    public APIORObject clone(ORObjectInf obj) {
-        if (obj instanceof APIORObject) {
-            APIORObject apiObj = (APIORObject) obj;
+    public StructuredDataORObject clone(ORObjectInf obj) {
+        if (obj instanceof StructuredDataORObject) {
+            StructuredDataORObject apiObj = (StructuredDataORObject) obj;
             apiObj.getAttributes().clear();
-            for (ORAttribute attribute : attributes) {
+            for (StructuredDataAttribute attribute : attributes) {
                 apiObj.getAttributes().add(attribute.cloneAs());
             }
             apiObj.changeSave();
@@ -356,8 +356,8 @@ public class APIORObject extends UndoRedoModel implements ORObjectInf {
     }
 
     @JsonIgnore
-    public ORAttribute getAttribute(String name) {
-        for (ORAttribute attribute : attributes) {
+    public StructuredDataAttribute getAttribute(String name) {
+        for (StructuredDataAttribute attribute : attributes) {
             if (attribute.getName().equalsIgnoreCase(name)) {
                 return attribute;
             }
@@ -367,7 +367,7 @@ public class APIORObject extends UndoRedoModel implements ORObjectInf {
 
     @JsonIgnore
     public String getAttributeByName(String name) {
-        for (ORAttribute attribute : attributes) {
+        for (StructuredDataAttribute attribute : attributes) {
             if (attribute.getName().equalsIgnoreCase(name)) {
                 return attribute.getValue();
             }
@@ -377,7 +377,7 @@ public class APIORObject extends UndoRedoModel implements ORObjectInf {
 
     @JsonIgnore
     public void setAttributeByName(String name, String value) {
-        for (ORAttribute attribute : attributes) {
+        for (StructuredDataAttribute attribute : attributes) {
             if (attribute.getName().equalsIgnoreCase(name)) {
                 attribute.setValue(value);
             }
@@ -386,16 +386,15 @@ public class APIORObject extends UndoRedoModel implements ORObjectInf {
 
     @JsonIgnore
     public void addOrUpdateAttribute(String name, String value) {
-        for (ORAttribute attribute : attributes) {
+        for (StructuredDataAttribute attribute : attributes) {
             if (attribute.getName().equalsIgnoreCase(name)) {
                 attribute.setValue(value);
                 return;
             }
         }
-        ORAttribute attr = new ORAttribute();
+        StructuredDataAttribute attr = new StructuredDataAttribute();
         attr.setName(name);
         attr.setValue(value);
-        attr.setPreference(String.valueOf(attributes.size() + 1));
         attributes.add(attr);
         changeSave();
     }
@@ -409,10 +408,9 @@ public class APIORObject extends UndoRedoModel implements ORObjectInf {
             name = attrName + i++;
         } while (getAttribute(name) != null);
         
-        ORAttribute attr = new ORAttribute();
+        StructuredDataAttribute attr = new StructuredDataAttribute();
         attr.setName(name);
         attr.setValue("");
-        attr.setPreference(String.valueOf(attributes.size() + 1));
         attributes.add(attr);
         changeSave();
         fireTableRowsInserted(attributes.size() - 1, attributes.size() - 1);
@@ -442,14 +440,13 @@ public class APIORObject extends UndoRedoModel implements ORObjectInf {
             return;
         }
         
-        ORAttribute attr = new ORAttribute();
+        StructuredDataAttribute attr = new StructuredDataAttribute();
         if (values != null && values.length > 0) {
             attr.setName(values[0] != null ? values[0].toString() : "");
             if (values.length > 1) {
                 attr.setValue(values[1] != null ? values[1].toString() : "");
             }
         }
-        attr.setPreference(String.valueOf(row + 1));
         
         attributes.add(row, attr);
         rowAdded(row);
@@ -459,10 +456,10 @@ public class APIORObject extends UndoRedoModel implements ORObjectInf {
     @JsonIgnore
     @Override
     public Boolean isEqualOf(ORObjectInf object) {
-        if (object == null || !(object instanceof APIORObject)) {
+        if (object == null || !(object instanceof StructuredDataORObject)) {
             return false;
         }
-        APIORObject other = (APIORObject) object;
+        StructuredDataORObject other = (StructuredDataORObject) object;
         return Objects.equals(this.name, other.name);
     }
 

--- a/Datalib/src/main/java/com/ing/datalib/or/structureddata/StructuredDataORObject.java
+++ b/Datalib/src/main/java/com/ing/datalib/or/structureddata/StructuredDataORObject.java
@@ -52,9 +52,9 @@ public class StructuredDataORObject extends UndoRedoModel implements ORObjectInf
     @JsonIgnore
     public final void setDefaultStructuredDataAttributes() {
         attributes = new ArrayList<>();
-        for (int i = 0; i < StructuredData.OBJECT_PROPS.size(); i++) {
+        for (int i = 0; i < StructuredDataOR.OBJECT_PROPS.size(); i++) {
             StructuredDataAttribute attr = new StructuredDataAttribute();
-            attr.setName(StructuredData.OBJECT_PROPS.get(i));
+            attr.setName(StructuredDataOR.OBJECT_PROPS.get(i));
             attr.setValue("");
             attributes.add(attr);
         }
@@ -86,7 +86,9 @@ public class StructuredDataORObject extends UndoRedoModel implements ORObjectInf
             group.removeFromParent();
         }
         group.getObjects().remove(this);
-        FileUtils.deleteFile(getRepLocation());
+        if (!group.getParent().getRoot().getObjectRepository().isUsingYamlFormat()) {
+            FileUtils.deleteFile(getRepLocation());
+        } 
     }
 
     @JsonIgnore
@@ -187,7 +189,7 @@ public class StructuredDataORObject extends UndoRedoModel implements ORObjectInf
     @JsonIgnore
     private Boolean isNotDefault(int rowIndex) {
         String value = getValueAt(rowIndex, 0).toString();
-        return StructuredData.OBJECT_PROPS.indexOf(value) == -1;
+        return StructuredDataOR.OBJECT_PROPS.indexOf(value) == -1;
     }
 
     @JsonIgnore

--- a/Datalib/src/main/java/com/ing/datalib/or/structureddata/StructuredDataORPage.java
+++ b/Datalib/src/main/java/com/ing/datalib/or/structureddata/StructuredDataORPage.java
@@ -1,4 +1,4 @@
-package com.ing.datalib.or.api;
+package com.ing.datalib.or.structureddata;
 
 import com.ing.datalib.component.utils.FileUtils;
 import com.ing.datalib.or.common.ORPageInf;
@@ -23,7 +23,7 @@ import javax.swing.tree.TreePath;
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties({"root"})
-public class APIORPage implements ORPageInf<APIORObject, APIOR> {
+public class StructuredDataORPage implements ORPageInf<StructuredDataORObject, StructuredData> {
 
     @JacksonXmlProperty(isAttribute = true, localName = "ref")
     private String name;
@@ -33,16 +33,16 @@ public class APIORPage implements ORPageInf<APIORObject, APIOR> {
 
     @JacksonXmlProperty(localName = "ObjectGroup")
     @JacksonXmlElementWrapper(useWrapping = false, localName = "ObjectGroup")
-    private List<ObjectGroup<APIORObject>> objectGroups;
+    private List<ObjectGroup<StructuredDataORObject>> objectGroups;
 
     @JsonIgnore
-    private APIOR root;
+    private StructuredData root;
 
-    public APIORPage() {
+    public StructuredDataORPage() {
         this.objectGroups = new ArrayList<>();
     }
 
-    public APIORPage(String name, APIOR root) {
+    public StructuredDataORPage(String name, StructuredData root) {
         this.name = name;
         this.root = root;
         this.title = "";
@@ -68,14 +68,14 @@ public class APIORPage implements ORPageInf<APIORObject, APIOR> {
     }
 
     @Override
-    public List<ObjectGroup<APIORObject>> getObjectGroups() {
+    public List<ObjectGroup<StructuredDataORObject>> getObjectGroups() {
         return objectGroups;
     }
 
     @Override
-    public void setObjectGroups(List<ObjectGroup<APIORObject>> objectGroups) {
+    public void setObjectGroups(List<ObjectGroup<StructuredDataORObject>> objectGroups) {
         this.objectGroups = objectGroups;
-        for (ObjectGroup<APIORObject> objectGroup : objectGroups) {
+        for (ObjectGroup<StructuredDataORObject> objectGroup : objectGroups) {
             objectGroup.setParent(this);
         }
     }
@@ -90,8 +90,8 @@ public class APIORPage implements ORPageInf<APIORObject, APIOR> {
 
     @JsonIgnore
     @Override
-    public ObjectGroup<APIORObject> getObjectGroupByName(String groupName) {
-        for (ObjectGroup<APIORObject> group : objectGroups) {
+    public ObjectGroup<StructuredDataORObject> getObjectGroupByName(String groupName) {
+        for (ObjectGroup<StructuredDataORObject> group : objectGroups) {
             if (group.getName().equalsIgnoreCase(groupName)) {
                 return group;
             }
@@ -101,8 +101,8 @@ public class APIORPage implements ORPageInf<APIORObject, APIOR> {
 
     @JsonIgnore
     @Override
-    public ObjectGroup<APIORObject> addObjectGroup() {
-        String oName = "APIObjectGroup";
+    public ObjectGroup<StructuredDataORObject> addObjectGroup() {
+        String oName = "StructuredDataObjectGroup";
         int i = 0;
         String objectName;
         do {
@@ -114,18 +114,18 @@ public class APIORPage implements ORPageInf<APIORObject, APIOR> {
 
     @JsonIgnore
     @Override
-    public ObjectGroup<APIORObject> addObjectGroup(String groupName) {
+    public ObjectGroup<StructuredDataORObject> addObjectGroup(String groupName) {
         if (getObjectGroupByName(groupName) == null) {
-            ObjectGroup<APIORObject> group = new ObjectGroup<>(groupName, this);
+            ObjectGroup<StructuredDataORObject> group = new ObjectGroup<>(groupName, this);
             objectGroups.add(group);
-            // API OR uses YAML format - no folder creation needed
+            // Structured Data OR uses YAML format - no folder creation needed
             group.addObject(groupName);
             root.setSaved(false);
             
             // Auto-save for YAML format
             if (root.getObjectRepository() != null 
                 && root.getObjectRepository().isUsingYamlFormat()) {
-                root.getObjectRepository().saveAPIPageNow(this);
+                root.getObjectRepository().saveStructuredDataPageNow(this);
             }
             return group;
         }
@@ -134,14 +134,14 @@ public class APIORPage implements ORPageInf<APIORObject, APIOR> {
 
     @JsonIgnore
     @Override
-    public APIORObject getNewObject(String objectName, ObjectGroup<APIORObject> group) {
-        return new APIORObject(objectName, group);
+    public StructuredDataORObject getNewObject(String objectName, ObjectGroup<StructuredDataORObject> group) {
+        return new StructuredDataORObject(objectName, group);
     }
 
     @JsonIgnore
     @Override
-    public APIORObject addObject() {
-        String oName = "APIObject";
+    public StructuredDataORObject addObject() {
+        String oName = "SObject";
         int i = 0;
         String objectName;
         do {
@@ -152,8 +152,8 @@ public class APIORPage implements ORPageInf<APIORObject, APIOR> {
 
     @JsonIgnore
     @Override
-    public APIORObject addObject(String objectName) {
-        ObjectGroup<APIORObject> group = addObjectGroup(objectName);
+    public StructuredDataORObject addObject(String objectName) {
+        ObjectGroup<StructuredDataORObject> group = addObjectGroup(objectName);
         if (group != null) {
             return group.getObjectByName(objectName);
         }
@@ -162,20 +162,20 @@ public class APIORPage implements ORPageInf<APIORObject, APIOR> {
 
     @JsonIgnore
     @Override
-    public void setRoot(APIOR root) {
+    public void setRoot(StructuredData root) {
         this.root = root;
     }
 
     @JsonIgnore
     @Override
-    public APIOR getRoot() {
+    public StructuredData getRoot() {
         return root;
     }
 
     @JsonIgnore
     @Override
     public void deleteObjectGroup(String groupName) {
-        ObjectGroup<APIORObject> group = getObjectGroupByName(groupName);
+        ObjectGroup<StructuredDataORObject> group = getObjectGroupByName(groupName);
         if (group != null) {
             objectGroups.remove(group);
             root.setSaved(false);
@@ -262,7 +262,7 @@ public class APIORPage implements ORPageInf<APIORObject, APIOR> {
         // Check if using YAML format
         if (root.getObjectRepository().isUsingYamlFormat()) {
             // For YAML format, rename the page YAML file
-            if (root.getObjectRepository().renameAPIPageYaml(name, newName)) {
+            if (root.getObjectRepository().renameStructuredDataPageYaml(name, newName)) {
                 String oldName = name;
                 root.getObjectRepository().renamePage(this, newName);
                 setName(newName);

--- a/Datalib/src/main/java/com/ing/datalib/or/structureddata/StructuredDataORPage.java
+++ b/Datalib/src/main/java/com/ing/datalib/or/structureddata/StructuredDataORPage.java
@@ -23,7 +23,7 @@ import javax.swing.tree.TreePath;
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties({"root"})
-public class StructuredDataORPage implements ORPageInf<StructuredDataORObject, StructuredData> {
+public class StructuredDataORPage implements ORPageInf<StructuredDataORObject, StructuredDataOR> {
 
     @JacksonXmlProperty(isAttribute = true, localName = "ref")
     private String name;
@@ -36,13 +36,13 @@ public class StructuredDataORPage implements ORPageInf<StructuredDataORObject, S
     private List<ObjectGroup<StructuredDataORObject>> objectGroups;
 
     @JsonIgnore
-    private StructuredData root;
+    private StructuredDataOR root;
 
     public StructuredDataORPage() {
         this.objectGroups = new ArrayList<>();
     }
 
-    public StructuredDataORPage(String name, StructuredData root) {
+    public StructuredDataORPage(String name, StructuredDataOR root) {
         this.name = name;
         this.root = root;
         this.title = "";
@@ -85,7 +85,11 @@ public class StructuredDataORPage implements ORPageInf<StructuredDataORObject, S
     public void removeFromParent() {
         root.setSaved(false);
         root.getPages().remove(this);
-        FileUtils.deleteFile(getRepLocation());
+        if (root.getObjectRepository().isUsingYamlFormat()) {
+            root.getObjectRepository().deleteWebPageYaml(getName());
+        } else {
+            FileUtils.deleteFile(getRepLocation());
+        }
     }
 
     @JsonIgnore
@@ -162,13 +166,13 @@ public class StructuredDataORPage implements ORPageInf<StructuredDataORObject, S
 
     @JsonIgnore
     @Override
-    public void setRoot(StructuredData root) {
+    public void setRoot(StructuredDataOR root) {
         this.root = root;
     }
 
     @JsonIgnore
     @Override
-    public StructuredData getRoot() {
+    public StructuredDataOR getRoot() {
         return root;
     }
 

--- a/Datalib/src/main/java/com/ing/datalib/or/web/WebOR.java
+++ b/Datalib/src/main/java/com/ing/datalib/or/web/WebOR.java
@@ -296,6 +296,6 @@ public class WebOR implements ORRootInf<WebORPage> {
     }
 
     public void setSharedProjects(List<String> projects) {
-        this.projects = (projects == null) ? new ArrayList<>() : projects;
+        this.projects = projects;
     }
 }

--- a/Datalib/src/main/java/com/ing/datalib/or/web/WebORObject.java
+++ b/Datalib/src/main/java/com/ing/datalib/or/web/WebORObject.java
@@ -109,7 +109,9 @@ public class WebORObject extends UndoRedoModel implements ORObjectInf {
             group.removeFromParent();
         }
         group.getObjects().remove(this);
-        FileUtils.deleteFile(getRepLocation());
+        if (!group.getParent().getRoot().getObjectRepository().isUsingYamlFormat()) {
+            FileUtils.deleteFile(getRepLocation());
+        } 
     }
 
     @JsonIgnore
@@ -352,30 +354,24 @@ public class WebORObject extends UndoRedoModel implements ORObjectInf {
     @JsonIgnore
     @Override
     public Boolean rename(String newName) {
-        Boolean flag = true;
         if (getParent().getChildCount() == 1) {
-            flag = getParent().rename(newName);
+            getParent().rename(newName);
         }
-        if (flag && getParent().getObjectByName(newName) == null) {
-            // Check if using YAML format
-            if (getParent().getParent().getRoot().getObjectRepository().isUsingYamlFormat()) {
-                // For YAML format, objects are stored within the page YAML file
-                // Just update the name and mark as needing save
-                setName(newName);
-                changeSave();
-                return true;
-            } else {
-                // Use original XML folder-based rename
-                if (FileUtils.renameFile(getRepLocation(), newName)) {
-                    setName(newName);
-                    changeSave();
-                    return true;
-                }
-            }
+        if (newName == null || newName.isBlank()) {
+            return false;
         }
-        return false;
+        if (getParent().getObjectByName(newName) != null) {
+            return false;
+        }
+        setName(newName);
+        changeSave();
+        return true;
     }
-
+    
+    /**
+     * Returns filesystem path for legacy XML-based OR.
+     * MUST NOT be used in YAML mode.
+     */
     @JsonIgnore
     @Override
     public String getRepLocation() {

--- a/Datalib/src/main/java/com/ing/datalib/or/web/WebORPage.java
+++ b/Datalib/src/main/java/com/ing/datalib/or/web/WebORPage.java
@@ -90,7 +90,11 @@ public class WebORPage implements ORPageInf<WebORObject, WebOR> {
     public void removeFromParent() {
         root.setSaved(false);
         root.getPages().remove(this);
-        FileUtils.deleteFile(getRepLocation());
+        if (root.getObjectRepository().isUsingYamlFormat()) {
+            root.getObjectRepository().deleteWebPageYaml(getName());
+        } else {
+            FileUtils.deleteFile(getRepLocation());
+        }
     }
 
     @JsonIgnore
@@ -255,28 +259,10 @@ public class WebORPage implements ORPageInf<WebORObject, WebOR> {
 
     @Override
     public Boolean rename(String newName) {
-        if (getParent().getPageByName(newName) == null) {
-            String oldName = getName();
-            // Check if using YAML format
-            if (getRoot().getObjectRepository().isUsingYamlFormat()) {
-                // Rename the YAML file
-                if (getRoot().getObjectRepository().renameWebPageYaml(oldName, newName)) {
-                    getRoot().getObjectRepository().renamePage(this, newName);
-                    setName(newName);
-                    getParent().setSaved(false);
-                    return true;
-                }
-            } else {
-                // Use original XML folder-based rename
-                if (FileUtils.renameFile(getRepLocation(), newName)) {
-                    getRoot().getObjectRepository().renamePage(this, newName);
-                    setName(newName);
-                    getParent().setSaved(false);
-                    return true;
-                }
-            }
-        }
-        return false;
+        getRoot()
+            .getObjectRepository()
+            .renamePage(this, newName);
+        return true;
     }
 
     @JsonIgnore

--- a/Datalib/src/main/java/com/ing/datalib/or/yaml/YamlMobilePageDefinition.java
+++ b/Datalib/src/main/java/com/ing/datalib/or/yaml/YamlMobilePageDefinition.java
@@ -33,7 +33,7 @@ import java.util.Map;
  * </pre>
  */
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-@JsonPropertyOrder({"page", "packageName", "description", "platform", "tags", "elements"})
+@JsonPropertyOrder({"page", "scope", "packageName", "description", "platform", "tags", "elements"})
 public class YamlMobilePageDefinition {
     
     private String page;
@@ -42,6 +42,7 @@ public class YamlMobilePageDefinition {
     private String platform;     // "android" | "ios" | "both"
     private List<String> tags;
     private Map<String, YamlMobileElementDefinition> elements = new LinkedHashMap<>();
+    private MobileOR.ORScope scope;
     
     public YamlMobilePageDefinition() {
     }
@@ -58,6 +59,14 @@ public class YamlMobilePageDefinition {
 
     public void setPage(String page) {
         this.page = page;
+    }
+    
+    public MobileOR.ORScope getScope() {
+        return scope;
+    }
+
+    public void setScope(MobileOR.ORScope scope) {
+        this.scope = scope;
     }
 
     public String getPackageName() {
@@ -110,6 +119,10 @@ public class YamlMobilePageDefinition {
         yaml.setPage(page.getName());
         yaml.setPackageName(page.getPackageName());
         
+        if (page.getRoot() != null) {
+            yaml.setScope(page.getRoot().getScope());
+        }
+
         // Iterate through object groups and objects using Lists
         for (ObjectGroup<MobileORObject> group : page.getObjectGroups()) {
             for (MobileORObject obj : group.getObjects()) {
@@ -127,6 +140,11 @@ public class YamlMobilePageDefinition {
      */
     public MobileORPage toMobileORPage(MobileOR root) {
         MobileORPage page = new MobileORPage(this.page, root);
+       
+        if (this.scope != null && root != null && this.scope != root.getScope()) { 
+            throw new IllegalStateException("Scope mismatch: YAML mobile page '" + page + "' declares scope " + scope + " but is loaded under OR scope " + root.getScope());
+        }
+
         if (this.packageName != null && !this.packageName.isEmpty()) {
             page.setPackageName(this.packageName);
         }

--- a/Datalib/src/main/java/com/ing/datalib/or/yaml/YamlORReader.java
+++ b/Datalib/src/main/java/com/ing/datalib/or/yaml/YamlORReader.java
@@ -1,7 +1,7 @@
 package com.ing.datalib.or.yaml;
 
-import com.ing.datalib.or.api.APIOR;
-import com.ing.datalib.or.api.APIORPage;
+import com.ing.datalib.or.structureddata.StructuredData;
+import com.ing.datalib.or.structureddata.StructuredDataORPage;
 import com.ing.datalib.or.mobile.MobileOR;
 import com.ing.datalib.or.mobile.MobileORPage;
 import com.ing.datalib.or.web.WebOR;
@@ -69,11 +69,11 @@ public class YamlORReader {
     }
     
     /**
-     * Check if a YAML-based API OR exists.
+     * Check if a YAML-based Structured Data OR exists.
      */
-    public boolean apiORExists(File orLocation) {
-        File apiPagesDir = new File(orLocation, "API/pages");
-        return apiPagesDir.exists() && apiPagesDir.isDirectory();
+    public boolean structuredDataORExists(File orLocation) {
+        File structuredDataPagesDir = new File(orLocation, "StructuredData/pages");
+        return structuredDataPagesDir.exists() && structuredDataPagesDir.isDirectory();
     }
     
     /**
@@ -157,43 +157,43 @@ public class YamlORReader {
     }
     
     /**
-     * Read API OR from YAML files.
+     * Read Structured Data OR from YAML files.
      * 
      * @param orLocation The ObjectRepository directory
-     * @return APIOR populated with pages from YAML files
+     * @return StructuredDataOR populated with pages from YAML files
      */
-    public APIOR readAPIOR(File orLocation) throws IOException {
-        APIOR apiOR = new APIOR();
-        File apiPagesDir = new File(orLocation, "API/pages");
+    public StructuredData readStructuredDataOR(File orLocation) throws IOException {
+        StructuredData structuredDataOR = new StructuredData();
+        File StructuredDataPagesDir = new File(orLocation, "StructuredData/pages");
         
-        if (!apiPagesDir.exists()) {
-            LOGGER.info("No API OR YAML directory found at: " + apiPagesDir.getAbsolutePath());
-            return apiOR;
+        if (!StructuredDataPagesDir.exists()) {
+            LOGGER.info("No Structured Data OR YAML directory found at: " + StructuredDataPagesDir.getAbsolutePath());
+            return structuredDataOR;
         }
         
-        List<File> yamlFiles = listYamlFiles(apiPagesDir);
-        LOGGER.info("Found " + yamlFiles.size() + " API OR YAML files");
+        List<File> yamlFiles = listYamlFiles(StructuredDataPagesDir);
+        LOGGER.info("Found " + yamlFiles.size() + " Structured Data OR YAML files");
         
         for (File yamlFile : yamlFiles) {
             try {
-                YamlAPIPageDefinition pageDef = yamlMapper.readValue(yamlFile, YamlAPIPageDefinition.class);
-                APIORPage page = pageDef.toAPIORPage(apiOR);
-                apiOR.getPages().add(page);
-                LOGGER.fine("Loaded API page: " + page.getName() + " with " + pageDef.getElementCount() + " elements");
+                YamlStructuredDataPageDefinition pageDef = yamlMapper.readValue(yamlFile, YamlStructuredDataPageDefinition.class);
+                StructuredDataORPage page = pageDef.toStructuredDataORPage(structuredDataOR);
+                structuredDataOR.getPages().add(page);
+                LOGGER.fine("Loaded Structured Data page: " + page.getName() + " with " + pageDef.getElementCount() + " elements");
             } catch (IOException e) {
                 LOGGER.log(Level.WARNING, "Failed to read YAML file: " + yamlFile.getName(), e);
             }
         }
         
-        return apiOR;
+        return structuredDataOR;
     }
     
     /**
-     * Read a single API page from a YAML file.
+     * Read a single Structured Data page from a YAML file.
      */
-    public APIORPage readAPIPage(File yamlFile, APIOR root) throws IOException {
-        YamlAPIPageDefinition pageDef = yamlMapper.readValue(yamlFile, YamlAPIPageDefinition.class);
-        return pageDef.toAPIORPage(root);
+    public StructuredDataORPage readStructuredDataPage(File yamlFile, StructuredData root) throws IOException {
+        YamlStructuredDataPageDefinition pageDef = yamlMapper.readValue(yamlFile, YamlStructuredDataPageDefinition.class);
+        return pageDef.toStructuredDataORPage(root);
     }
     
     /**

--- a/Datalib/src/main/java/com/ing/datalib/or/yaml/YamlORReader.java
+++ b/Datalib/src/main/java/com/ing/datalib/or/yaml/YamlORReader.java
@@ -1,6 +1,6 @@
 package com.ing.datalib.or.yaml;
 
-import com.ing.datalib.or.structureddata.StructuredData;
+import com.ing.datalib.or.structureddata.StructuredDataOR;
 import com.ing.datalib.or.structureddata.StructuredDataORPage;
 import com.ing.datalib.or.mobile.MobileOR;
 import com.ing.datalib.or.mobile.MobileORPage;
@@ -9,6 +9,7 @@ import com.ing.datalib.or.web.WebORPage;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
+import com.ing.datalib.or.ObjectRepository;
 
 import java.io.File;
 import java.io.IOException;
@@ -44,6 +45,8 @@ public class YamlORReader {
     
     private final ObjectMapper yamlMapper;
     
+    private ObjectRepository objectRepository;
+    
     public YamlORReader() {
         YAMLFactory factory = new YAMLFactory();
         factory.disable(YAMLGenerator.Feature.WRITE_DOC_START_MARKER);
@@ -51,12 +54,20 @@ public class YamlORReader {
         // Configure for clean YAML
         this.yamlMapper.findAndRegisterModules();
     }
+
+    public YamlORReader(ObjectRepository objectRepository) {
+        this.objectRepository = objectRepository;
+        YAMLFactory factory = new YAMLFactory();
+        factory.disable(YAMLGenerator.Feature.WRITE_DOC_START_MARKER);
+        this.yamlMapper = new ObjectMapper(factory);
+        this.yamlMapper.findAndRegisterModules();
+    }
     
     /**
      * Check if a YAML-based Web OR exists.
      */
     public boolean webORExists(File orLocation) {
-        File webPagesDir = new File(orLocation, "Web/pages");
+        File webPagesDir = new File(orLocation, "Web");
         return webPagesDir.exists() && webPagesDir.isDirectory();
     }
     
@@ -64,7 +75,7 @@ public class YamlORReader {
      * Check if a YAML-based Mobile OR exists.
      */
     public boolean mobileORExists(File orLocation) {
-        File mobilePagesDir = new File(orLocation, "Mobile/pages");
+        File mobilePagesDir = new File(orLocation, "Mobile");
         return mobilePagesDir.exists() && mobilePagesDir.isDirectory();
     }
     
@@ -84,7 +95,13 @@ public class YamlORReader {
      */
     public WebOR readWebOR(File orLocation) throws IOException {
         WebOR webOR = new WebOR();
-        File webPagesDir = new File(orLocation, "Web/pages");
+        File webPagesDir = new File(orLocation, "Web");
+        
+        if (orLocation.getPath().contains(File.separator + "Shared" + File.separator)) {
+            webOR.setScope(WebOR.ORScope.SHARED);
+        } else {
+            webOR.setScope(WebOR.ORScope.PROJECT);
+        }
         
         if (!webPagesDir.exists()) {
             LOGGER.info("No Web OR YAML directory found at: " + webPagesDir.getAbsolutePath());
@@ -116,8 +133,14 @@ public class YamlORReader {
      */
     public MobileOR readMobileOR(File orLocation) throws IOException {
         MobileOR mobileOR = new MobileOR();
-        File mobilePagesDir = new File(orLocation, "Mobile/pages");
+        File mobilePagesDir = new File(orLocation, "Mobile");
         
+        if (orLocation.getPath().contains(File.separator + "Shared" + File.separator)) {
+            mobileOR.setScope(MobileOR.ORScope.SHARED);
+        } else {
+            mobileOR.setScope(MobileOR.ORScope.PROJECT);
+        }
+
         if (!mobilePagesDir.exists()) {
             LOGGER.info("No Mobile OR YAML directory found at: " + mobilePagesDir.getAbsolutePath());
             return mobileOR;
@@ -162,8 +185,8 @@ public class YamlORReader {
      * @param orLocation The ObjectRepository directory
      * @return StructuredDataOR populated with pages from YAML files
      */
-    public StructuredData readStructuredDataOR(File orLocation) throws IOException {
-        StructuredData structuredDataOR = new StructuredData();
+    public StructuredDataOR readStructuredDataOR(File orLocation) throws IOException {
+        StructuredDataOR structuredDataOR = new StructuredDataOR();
         File StructuredDataPagesDir = new File(orLocation, "StructuredData/pages");
         
         if (!StructuredDataPagesDir.exists()) {
@@ -191,7 +214,7 @@ public class YamlORReader {
     /**
      * Read a single Structured Data page from a YAML file.
      */
-    public StructuredDataORPage readStructuredDataPage(File yamlFile, StructuredData root) throws IOException {
+    public StructuredDataORPage readStructuredDataPage(File yamlFile, StructuredDataOR root) throws IOException {
         YamlStructuredDataPageDefinition pageDef = yamlMapper.readValue(yamlFile, YamlStructuredDataPageDefinition.class);
         return pageDef.toStructuredDataORPage(root);
     }

--- a/Datalib/src/main/java/com/ing/datalib/or/yaml/YamlORWriter.java
+++ b/Datalib/src/main/java/com/ing/datalib/or/yaml/YamlORWriter.java
@@ -1,7 +1,7 @@
 package com.ing.datalib.or.yaml;
 
-import com.ing.datalib.or.api.APIOR;
-import com.ing.datalib.or.api.APIORPage;
+import com.ing.datalib.or.structureddata.StructuredData;
+import com.ing.datalib.or.structureddata.StructuredDataORPage;
 import com.ing.datalib.or.mobile.MobileOR;
 import com.ing.datalib.or.mobile.MobileORPage;
 import com.ing.datalib.or.web.WebOR;
@@ -92,20 +92,20 @@ public class YamlORWriter {
     }
     
     /**
-     * Write entire API OR to YAML files (one per page).
+     * Write entire Structured Data OR to YAML files (one per page).
      * 
-     * @param apiOR The APIOR to write
+     * @param structuredDataOR The StructuredDataOR to write
      * @param orLocation The ObjectRepository directory
      */
-    public void writeAPIOR(APIOR apiOR, File orLocation) throws IOException {
-        File apiPagesDir = new File(orLocation, "API/pages");
-        ensureDirectory(apiPagesDir);
+    public void writeStructuredDataOR(StructuredData structuredDataOR, File orLocation) throws IOException {
+        File structuredDataPagesDir = new File(orLocation, "StructuredData/pages");
+        ensureDirectory(structuredDataPagesDir);
         
-        List<APIORPage> pages = apiOR.getPages();
-        LOGGER.info("Writing " + pages.size() + " API pages to YAML");
+        List<StructuredDataORPage> pages = structuredDataOR.getPages();
+        LOGGER.info("Writing " + pages.size() + " Structured Data pages to YAML");
         
-        for (APIORPage page : pages) {
-            writeAPIPage(page, apiPagesDir);
+        for (StructuredDataORPage page : pages) {
+            writeStructuredDataPage(page, structuredDataPagesDir);
         }
     }
     
@@ -132,14 +132,14 @@ public class YamlORWriter {
     }
     
     /**
-     * Write a single API page to YAML.
+     * Write a single Structured Data page to YAML.
      */
-    public void writeAPIPage(APIORPage page, File pagesDir) throws IOException {
-        YamlAPIPageDefinition pageDef = YamlAPIPageDefinition.fromAPIORPage(page);
+    public void writeStructuredDataPage(StructuredDataORPage page, File pagesDir) throws IOException {
+        YamlStructuredDataPageDefinition pageDef = YamlStructuredDataPageDefinition.fromStructuredDataORPage(page);
         File yamlFile = new File(pagesDir, sanitizeFileName(page.getName()) + ".yaml");
         
         yamlMapper.writeValue(yamlFile, pageDef);
-        LOGGER.fine("Wrote API page: " + yamlFile.getName());
+        LOGGER.fine("Wrote Structured Data page: " + yamlFile.getName());
     }
     
     /**
@@ -177,16 +177,16 @@ public class YamlORWriter {
     }
     
     /**
-     * Delete an API page YAML file.
+     * Delete an Structured Data page YAML file.
      */
-    public boolean deleteAPIPage(String pageName, File orLocation) {
-        File apiPagesDir = new File(orLocation, "API/pages");
-        File yamlFile = new File(apiPagesDir, sanitizeFileName(pageName) + ".yaml");
+    public boolean deleteStructuredDataPage(String pageName, File orLocation) {
+        File structuredDataPagesDir = new File(orLocation, "StructuredData/pages");
+        File yamlFile = new File(structuredDataPagesDir, sanitizeFileName(pageName) + ".yaml");
         
         if (yamlFile.exists()) {
             boolean deleted = yamlFile.delete();
             if (deleted) {
-                LOGGER.info("Deleted API page YAML: " + pageName);
+                LOGGER.info("Deleted Structured Data page YAML: " + pageName);
             }
             return deleted;
         }
@@ -240,22 +240,22 @@ public class YamlORWriter {
     }
     
     /**
-     * Rename an API page YAML file.
+     * Rename an Structured Data page YAML file.
      * 
      * @param oldName The current page name
      * @param newName The new page name
      * @param orLocation The ObjectRepository directory
      * @return true if rename was successful
      */
-    public boolean renameAPIPage(String oldName, String newName, File orLocation) {
-        File apiPagesDir = new File(orLocation, "API/pages");
-        File oldFile = new File(apiPagesDir, sanitizeFileName(oldName) + ".yaml");
-        File newFile = new File(apiPagesDir, sanitizeFileName(newName) + ".yaml");
+    public boolean renameStructuredDataPage(String oldName, String newName, File orLocation) {
+        File structuredDataPagesDir = new File(orLocation, "StructuredData/pages");
+        File oldFile = new File(structuredDataPagesDir, sanitizeFileName(oldName) + ".yaml");
+        File newFile = new File(structuredDataPagesDir, sanitizeFileName(newName) + ".yaml");
         
         if (oldFile.exists() && !newFile.exists()) {
             boolean renamed = oldFile.renameTo(newFile);
             if (renamed) {
-                LOGGER.info("Renamed API page YAML: " + oldName + " -> " + newName);
+                LOGGER.info("Renamed Structured Data page YAML: " + oldName + " -> " + newName);
             }
             return renamed;
         }

--- a/Datalib/src/main/java/com/ing/datalib/or/yaml/YamlORWriter.java
+++ b/Datalib/src/main/java/com/ing/datalib/or/yaml/YamlORWriter.java
@@ -1,6 +1,6 @@
 package com.ing.datalib.or.yaml;
 
-import com.ing.datalib.or.structureddata.StructuredData;
+import com.ing.datalib.or.structureddata.StructuredDataOR;
 import com.ing.datalib.or.structureddata.StructuredDataORPage;
 import com.ing.datalib.or.mobile.MobileOR;
 import com.ing.datalib.or.mobile.MobileORPage;
@@ -13,8 +13,12 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.logging.Level;
+import java.util.Map;
+import java.util.Set;
 import java.util.logging.Logger;
 
 /**
@@ -62,11 +66,11 @@ public class YamlORWriter {
      * @param orLocation The ObjectRepository directory
      */
     public void writeWebOR(WebOR webOR, File orLocation) throws IOException {
-        File webPagesDir = new File(orLocation, "Web/pages");
+        File webPagesDir = new File(orLocation, "Web");
         ensureDirectory(webPagesDir);
         
         List<WebORPage> pages = webOR.getPages();
-        LOGGER.info("Writing " + pages.size() + " Web pages to YAML");
+        LOGGER.info(() -> "Writing " + pages.size() + " Web pages to YAML");
         
         for (WebORPage page : pages) {
             writeWebPage(page, webPagesDir);
@@ -80,11 +84,11 @@ public class YamlORWriter {
      * @param orLocation The ObjectRepository directory
      */
     public void writeMobileOR(MobileOR mobileOR, File orLocation) throws IOException {
-        File mobilePagesDir = new File(orLocation, "Mobile/pages");
+        File mobilePagesDir = new File(orLocation, "Mobile");
         ensureDirectory(mobilePagesDir);
         
         List<MobileORPage> pages = mobileOR.getPages();
-        LOGGER.info("Writing " + pages.size() + " Mobile pages to YAML");
+        LOGGER.info(() -> "Writing " + pages.size() + " Mobile pages to YAML");
         
         for (MobileORPage page : pages) {
             writeMobilePage(page, mobilePagesDir);
@@ -97,7 +101,7 @@ public class YamlORWriter {
      * @param structuredDataOR The StructuredDataOR to write
      * @param orLocation The ObjectRepository directory
      */
-    public void writeStructuredDataOR(StructuredData structuredDataOR, File orLocation) throws IOException {
+    public void writeStructuredDataOR(StructuredDataOR structuredDataOR, File orLocation) throws IOException {
         File structuredDataPagesDir = new File(orLocation, "StructuredData/pages");
         ensureDirectory(structuredDataPagesDir);
         
@@ -117,7 +121,7 @@ public class YamlORWriter {
         File yamlFile = new File(pagesDir, sanitizeFileName(page.getName()) + ".yaml");
         
         yamlMapper.writeValue(yamlFile, pageDef);
-        LOGGER.fine("Wrote Web page: " + yamlFile.getName());
+        LOGGER.fine(() -> "Wrote Web page: " + yamlFile.getName());
     }
     
     /**
@@ -128,7 +132,7 @@ public class YamlORWriter {
         File yamlFile = new File(pagesDir, sanitizeFileName(page.getName()) + ".yaml");
         
         yamlMapper.writeValue(yamlFile, pageDef);
-        LOGGER.fine("Wrote Mobile page: " + yamlFile.getName());
+        LOGGER.fine(() -> "Wrote Mobile page: " + yamlFile.getName());
     }
     
     /**
@@ -146,13 +150,13 @@ public class YamlORWriter {
      * Delete a Web page YAML file.
      */
     public boolean deleteWebPage(String pageName, File orLocation) {
-        File webPagesDir = new File(orLocation, "Web/pages");
+        File webPagesDir = new File(orLocation, "Web");
         File yamlFile = new File(webPagesDir, sanitizeFileName(pageName) + ".yaml");
         
         if (yamlFile.exists()) {
             boolean deleted = yamlFile.delete();
             if (deleted) {
-                LOGGER.info("Deleted Web page YAML: " + pageName);
+                LOGGER.info(() -> "Deleted Web page YAML: " + pageName);
             }
             return deleted;
         }
@@ -163,13 +167,13 @@ public class YamlORWriter {
      * Delete a Mobile page YAML file.
      */
     public boolean deleteMobilePage(String pageName, File orLocation) {
-        File mobilePagesDir = new File(orLocation, "Mobile/pages");
+        File mobilePagesDir = new File(orLocation, "Mobile");
         File yamlFile = new File(mobilePagesDir, sanitizeFileName(pageName) + ".yaml");
         
         if (yamlFile.exists()) {
             boolean deleted = yamlFile.delete();
             if (deleted) {
-                LOGGER.info("Deleted Mobile page YAML: " + pageName);
+                LOGGER.info(() -> "Deleted Mobile page YAML: " + pageName);
             }
             return deleted;
         }
@@ -202,14 +206,14 @@ public class YamlORWriter {
      * @return true if rename was successful
      */
     public boolean renameWebPage(String oldName, String newName, File orLocation) {
-        File webPagesDir = new File(orLocation, "Web/pages");
+        File webPagesDir = new File(orLocation, "Web");
         File oldFile = new File(webPagesDir, sanitizeFileName(oldName) + ".yaml");
         File newFile = new File(webPagesDir, sanitizeFileName(newName) + ".yaml");
         
         if (oldFile.exists() && !newFile.exists()) {
             boolean renamed = oldFile.renameTo(newFile);
             if (renamed) {
-                LOGGER.info("Renamed Web page YAML: " + oldName + " -> " + newName);
+                LOGGER.info(() -> "Renamed Web page YAML: " + oldName + " -> " + newName);
             }
             return renamed;
         }
@@ -225,14 +229,14 @@ public class YamlORWriter {
      * @return true if rename was successful
      */
     public boolean renameMobilePage(String oldName, String newName, File orLocation) {
-        File mobilePagesDir = new File(orLocation, "Mobile/pages");
+        File mobilePagesDir = new File(orLocation, "Mobile");
         File oldFile = new File(mobilePagesDir, sanitizeFileName(oldName) + ".yaml");
         File newFile = new File(mobilePagesDir, sanitizeFileName(newName) + ".yaml");
         
         if (oldFile.exists() && !newFile.exists()) {
             boolean renamed = oldFile.renameTo(newFile);
             if (renamed) {
-                LOGGER.info("Renamed Mobile page YAML: " + oldName + " -> " + newName);
+                LOGGER.info(() -> "Renamed Mobile page YAML: " + oldName + " -> " + newName);
             }
             return renamed;
         }
@@ -274,12 +278,14 @@ public class YamlORWriter {
         
         if (webOR != null && !webOR.getPages().isEmpty()) {
             writeWebOR(webOR, orLocation);
-            LOGGER.info("Converted " + webOR.getPages().size() + " Web pages to YAML");
+            writeSharedMetadata(webOR, orLocation);
+            LOGGER.info(() -> "Converted " + webOR.getPages().size() + " Web pages to YAML");
         }
         
         if (mobileOR != null && !mobileOR.getPages().isEmpty()) {
             writeMobileOR(mobileOR, orLocation);
-            LOGGER.info("Converted " + mobileOR.getPages().size() + " Mobile pages to YAML");
+            writeSharedMetadata(mobileOR, orLocation);
+            LOGGER.info(() -> "Converted " + mobileOR.getPages().size() + " Mobile pages to YAML");
         }
     }
     
@@ -312,5 +318,72 @@ public class YamlORWriter {
      */
     public ObjectMapper getYamlMapper() {
         return yamlMapper;
+    }
+
+    private void writeSharedMetadataInternal(String orType, List<String> newProjects, String fileName, File sharedRoot) throws IOException {
+        if (newProjects == null || newProjects.isEmpty()) {
+            return;
+        }
+        File metadataFile = new File(sharedRoot, fileName);
+
+        Set<String> mergedProjects = new LinkedHashSet<>();
+        mergedProjects.addAll(readExistingProjects(metadataFile));
+        mergedProjects.addAll(newProjects);
+
+        Map<String, Object> metadata = new LinkedHashMap<>();
+        metadata.put("type", orType);
+        metadata.put("scope", "SHARED");
+        metadata.put("projects", new ArrayList<>(mergedProjects));
+
+        yamlMapper.writeValue(metadataFile, metadata);
+    }
+
+    public boolean sharedMetadataExists(String fileName, File sharedRoot) {
+        return new File(sharedRoot, fileName).exists();
+    }
+    
+    @SuppressWarnings("unchecked")
+    public List<String> readExistingProjects(File metadataFile) {
+        if (metadataFile == null || !metadataFile.exists()) {
+            return List.of();
+        }
+        try {
+            Map<String, Object> data = yamlMapper.readValue(metadataFile, Map.class);
+            Object projectsObj = data.get("projects");
+            if (projectsObj instanceof List<?>) {
+                List<String> result = new ArrayList<>();
+                for (Object o : (List<?>) projectsObj) {
+                    if (o != null) {
+                        result.add(o.toString().trim());
+                    }
+                }
+                return result;
+            }
+        } catch (Exception e) {
+        }
+        return List.of();
+    }
+    public void writeSharedMetadata(WebOR webSharedOR, File sharedRoot) throws IOException {
+        if (webSharedOR == null || !webSharedOR.isShared()) {
+            return;
+        }
+        writeSharedMetadataInternal(
+            "WebOR",
+            webSharedOR.getSharedProjects(),
+            "webor-projectsdata.yaml",
+            sharedRoot
+        );
+    }
+
+    public void writeSharedMetadata(MobileOR mobileSharedOR, File sharedRoot) throws IOException {
+        if (mobileSharedOR == null || !mobileSharedOR.isShared()) {
+            return;
+        }
+        writeSharedMetadataInternal(
+            "MobileOR",
+            mobileSharedOR.getSharedProjects(),
+            "mobileor-projectsdata.yaml",
+            sharedRoot
+        );
     }
 }

--- a/Datalib/src/main/java/com/ing/datalib/or/yaml/YamlPageDefinition.java
+++ b/Datalib/src/main/java/com/ing/datalib/or/yaml/YamlPageDefinition.java
@@ -30,7 +30,7 @@ import java.util.Map;
  * </pre>
  */
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-@JsonPropertyOrder({"page", "description", "urlPattern", "tags", "elements"})
+@JsonPropertyOrder({"page", "scope", "description", "urlPattern", "tags", "elements"})
 public class YamlPageDefinition {
     
     private String page;
@@ -38,6 +38,7 @@ public class YamlPageDefinition {
     private String urlPattern;
     private List<String> tags;
     private Map<String, YamlElementDefinition> elements = new LinkedHashMap<>();
+    private WebOR.ORScope scope;
     
     public YamlPageDefinition() {
     }
@@ -54,6 +55,14 @@ public class YamlPageDefinition {
 
     public void setPage(String page) {
         this.page = page;
+    }
+
+    public WebOR.ORScope getScope() {
+        return scope;
+    }
+
+    public void setScope(WebOR.ORScope scope) {
+        this.scope = scope;
     }
 
     public String getDescription() {
@@ -97,6 +106,10 @@ public class YamlPageDefinition {
         YamlPageDefinition yaml = new YamlPageDefinition();
         yaml.setPage(page.getName());
         
+        if (page.getRoot() != null) {
+            yaml.setScope(page.getRoot().getScope());
+        }
+
         // Iterate through object groups and objects using Lists
         for (ObjectGroup<WebORObject> group : page.getObjectGroups()) {
             for (WebORObject obj : group.getObjects()) {
@@ -115,6 +128,10 @@ public class YamlPageDefinition {
     public WebORPage toWebORPage(WebOR root) {
         WebORPage page = new WebORPage(this.page, root);
         
+        if (this.scope != null && root != null && this.scope != root.getScope()) { 
+            throw new IllegalStateException("Scope mismatch: YAML page '" + page + "' declares scope " + scope + " but is loaded under OR scope " + root.getScope());
+        }
+
         // Convert each element to WebORObject using direct list manipulation
         // to avoid calling factory methods that require ObjectRepository
         for (Map.Entry<String, YamlElementDefinition> entry : elements.entrySet()) {

--- a/Datalib/src/main/java/com/ing/datalib/or/yaml/YamlStructuredDataElementDefinition.java
+++ b/Datalib/src/main/java/com/ing/datalib/or/yaml/YamlStructuredDataElementDefinition.java
@@ -1,7 +1,7 @@
 package com.ing.datalib.or.yaml;
 
-import com.ing.datalib.or.api.APIOR;
-import com.ing.datalib.or.api.APIORObject;
+import com.ing.datalib.or.structureddata.StructuredData;
+import com.ing.datalib.or.structureddata.StructuredDataORObject;
 import com.ing.datalib.or.common.ORAttribute;
 import com.ing.datalib.or.common.ObjectGroup;
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
@@ -9,12 +9,13 @@ import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.ing.datalib.or.structureddata.StructuredDataAttribute;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
- * YAML representation of an API OR element.
+ * YAML representation of an Structured Data OR element.
  * Only non-empty properties are serialized to YAML.
  * 
  * Example YAML output:
@@ -26,9 +27,9 @@ import java.util.Map;
  */
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 @JsonPropertyOrder({"jsonPath", "xpath", "description"})
-public class YamlAPIElementDefinition {
+public class YamlStructuredDataElementDefinition {
     
-    // API locator properties
+    // Structured Data locator properties
     private String jsonPath;
     private String xpath;
     
@@ -39,7 +40,7 @@ public class YamlAPIElementDefinition {
     @JsonIgnore
     private Map<String, Object> additionalProperties = new LinkedHashMap<>();
     
-    public YamlAPIElementDefinition() {
+    public YamlStructuredDataElementDefinition() {
     }
     
     // ==================== Getters and Setters ====================
@@ -81,14 +82,14 @@ public class YamlAPIElementDefinition {
     // ==================== Conversion Methods ====================
     
     /**
-     * Convert an APIORObject to YamlAPIElementDefinition.
+     * Convert an StructuredDataORObject to YamlStructuredDataElementDefinition.
      * Only non-empty attributes are captured.
      */
-    public static YamlAPIElementDefinition fromAPIORObject(APIORObject obj) {
-        YamlAPIElementDefinition elem = new YamlAPIElementDefinition();
+    public static YamlStructuredDataElementDefinition fromStructuredDataORObject(StructuredDataORObject obj) {
+        YamlStructuredDataElementDefinition elem = new YamlStructuredDataElementDefinition();
         
         // Map attributes to properties (only non-empty values)
-        for (ORAttribute attr : obj.getAttributes()) {
+        for (StructuredDataAttribute attr : obj.getAttributes()) {
             if (attr.getValue() != null && !attr.getValue().isEmpty()) {
                 String attrName = attr.getName().toLowerCase();
                 switch (attrName) {
@@ -109,10 +110,10 @@ public class YamlAPIElementDefinition {
     }
     
     /**
-     * Convert YamlAPIElementDefinition to an APIORObject.
+     * Convert YamlStructuredDataElementDefinition to an StructuredDataORObject.
      */
-    public APIORObject toAPIORObject(String name, ObjectGroup<APIORObject> group) {
-        APIORObject obj = new APIORObject(name, group);
+    public StructuredDataORObject toStructuredDataORObject(String name, ObjectGroup<StructuredDataORObject> group) {
+        StructuredDataORObject obj = new StructuredDataORObject(name, group);
         
         // Set attribute values
         setAttributeIfPresent(obj, "JsonPath", jsonPath);
@@ -121,9 +122,9 @@ public class YamlAPIElementDefinition {
         return obj;
     }
     
-    private void setAttributeIfPresent(APIORObject obj, String name, String value) {
+    private void setAttributeIfPresent(StructuredDataORObject obj, String name, String value) {
         if (value != null && !value.isEmpty()) {
-            ORAttribute attr = obj.getAttribute(name);
+            StructuredDataAttribute attr = obj.getAttribute(name);
             if (attr != null) {
                 attr.setValue(value);
             }

--- a/Datalib/src/main/java/com/ing/datalib/or/yaml/YamlStructuredDataElementDefinition.java
+++ b/Datalib/src/main/java/com/ing/datalib/or/yaml/YamlStructuredDataElementDefinition.java
@@ -1,6 +1,6 @@
 package com.ing.datalib.or.yaml;
 
-import com.ing.datalib.or.structureddata.StructuredData;
+import com.ing.datalib.or.structureddata.StructuredDataOR;
 import com.ing.datalib.or.structureddata.StructuredDataORObject;
 import com.ing.datalib.or.common.ORAttribute;
 import com.ing.datalib.or.common.ObjectGroup;

--- a/Datalib/src/main/java/com/ing/datalib/or/yaml/YamlStructuredDataPageDefinition.java
+++ b/Datalib/src/main/java/com/ing/datalib/or/yaml/YamlStructuredDataPageDefinition.java
@@ -1,6 +1,6 @@
 package com.ing.datalib.or.yaml;
 
-import com.ing.datalib.or.structureddata.StructuredData;
+import com.ing.datalib.or.structureddata.StructuredDataOR;
 import com.ing.datalib.or.structureddata.StructuredDataORObject;
 import com.ing.datalib.or.structureddata.StructuredDataORPage;
 import com.ing.datalib.or.common.ObjectGroup;
@@ -101,7 +101,7 @@ public class YamlStructuredDataPageDefinition {
     /**
      * Convert YamlStructuredDataPageDefinition to an StructuredDataORPage.
      */
-    public StructuredDataORPage toStructuredDataORPage(StructuredData root) {
+    public StructuredDataORPage toStructuredDataORPage(StructuredDataOR root) {
         StructuredDataORPage page = new StructuredDataORPage(this.page, root);
         
         // Convert each element to StructuredDataORObject using direct list manipulation

--- a/Datalib/src/main/java/com/ing/datalib/or/yaml/YamlStructuredDataPageDefinition.java
+++ b/Datalib/src/main/java/com/ing/datalib/or/yaml/YamlStructuredDataPageDefinition.java
@@ -1,8 +1,8 @@
 package com.ing.datalib.or.yaml;
 
-import com.ing.datalib.or.api.APIOR;
-import com.ing.datalib.or.api.APIORObject;
-import com.ing.datalib.or.api.APIORPage;
+import com.ing.datalib.or.structureddata.StructuredData;
+import com.ing.datalib.or.structureddata.StructuredDataORObject;
+import com.ing.datalib.or.structureddata.StructuredDataORPage;
 import com.ing.datalib.or.common.ObjectGroup;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -13,7 +13,7 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * YAML representation of an API OR page.
+ * YAML representation of an Structured Data OR page.
  * 
  * Example YAML output:
  * <pre>
@@ -29,17 +29,17 @@ import java.util.Map;
  */
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 @JsonPropertyOrder({"page", "description", "tags", "elements"})
-public class YamlAPIPageDefinition {
+public class YamlStructuredDataPageDefinition {
     
     private String page;
     private String description;
     private List<String> tags;
-    private Map<String, YamlAPIElementDefinition> elements = new LinkedHashMap<>();
+    private Map<String, YamlStructuredDataElementDefinition> elements = new LinkedHashMap<>();
     
-    public YamlAPIPageDefinition() {
+    public YamlStructuredDataPageDefinition() {
     }
     
-    public YamlAPIPageDefinition(String page) {
+    public YamlStructuredDataPageDefinition(String page) {
         this.page = page;
     }
     
@@ -69,27 +69,27 @@ public class YamlAPIPageDefinition {
         this.tags = tags;
     }
 
-    public Map<String, YamlAPIElementDefinition> getElements() {
+    public Map<String, YamlStructuredDataElementDefinition> getElements() {
         return elements;
     }
 
-    public void setElements(Map<String, YamlAPIElementDefinition> elements) {
+    public void setElements(Map<String, YamlStructuredDataElementDefinition> elements) {
         this.elements = elements;
     }
     
     // ==================== Conversion Methods ====================
     
     /**
-     * Convert an APIORPage to YamlAPIPageDefinition.
+     * Convert an StructuredDataORPage to YamlStructuredDataPageDefinition.
      */
-    public static YamlAPIPageDefinition fromAPIORPage(APIORPage page) {
-        YamlAPIPageDefinition yaml = new YamlAPIPageDefinition();
+    public static YamlStructuredDataPageDefinition fromStructuredDataORPage(StructuredDataORPage page) {
+        YamlStructuredDataPageDefinition yaml = new YamlStructuredDataPageDefinition();
         yaml.setPage(page.getName());
         
         // Iterate through object groups and objects using Lists
-        for (ObjectGroup<APIORObject> group : page.getObjectGroups()) {
-            for (APIORObject obj : group.getObjects()) {
-                YamlAPIElementDefinition element = YamlAPIElementDefinition.fromAPIORObject(obj);
+        for (ObjectGroup<StructuredDataORObject> group : page.getObjectGroups()) {
+            for (StructuredDataORObject obj : group.getObjects()) {
+                YamlStructuredDataElementDefinition element = YamlStructuredDataElementDefinition.fromStructuredDataORObject(obj);
                 // Use object name as key
                 yaml.getElements().put(obj.getName(), element);
             }
@@ -99,22 +99,22 @@ public class YamlAPIPageDefinition {
     }
     
     /**
-     * Convert YamlAPIPageDefinition to an APIORPage.
+     * Convert YamlStructuredDataPageDefinition to an StructuredDataORPage.
      */
-    public APIORPage toAPIORPage(APIOR root) {
-        APIORPage page = new APIORPage(this.page, root);
+    public StructuredDataORPage toStructuredDataORPage(StructuredData root) {
+        StructuredDataORPage page = new StructuredDataORPage(this.page, root);
         
-        // Convert each element to APIORObject using direct list manipulation
+        // Convert each element to StructuredDataORObject using direct list manipulation
         // to avoid calling factory methods that require ObjectRepository
-        for (Map.Entry<String, YamlAPIElementDefinition> entry : elements.entrySet()) {
+        for (Map.Entry<String, YamlStructuredDataElementDefinition> entry : elements.entrySet()) {
             String elementName = entry.getKey();
-            YamlAPIElementDefinition elementDef = entry.getValue();
+            YamlStructuredDataElementDefinition elementDef = entry.getValue();
             
             // Create object group directly
-            ObjectGroup<APIORObject> group = new ObjectGroup<>(elementName, page);
+            ObjectGroup<StructuredDataORObject> group = new ObjectGroup<>(elementName, page);
             
             // Create object and add to group
-            APIORObject obj = elementDef.toAPIORObject(elementName, group);
+            StructuredDataORObject obj = elementDef.toStructuredDataORObject(elementName, group);
             group.getObjects().add(obj);
             
             // Add group to page directly
@@ -135,7 +135,7 @@ public class YamlAPIPageDefinition {
     /**
      * Add an element to this page.
      */
-    public void addElement(String name, YamlAPIElementDefinition element) {
+    public void addElement(String name, YamlStructuredDataElementDefinition element) {
         elements.put(name, element);
     }
     
@@ -149,7 +149,7 @@ public class YamlAPIPageDefinition {
     /**
      * Get an element by name.
      */
-    public YamlAPIElementDefinition getElement(String name) {
+    public YamlStructuredDataElementDefinition getElement(String name) {
         return elements.get(name);
     }
 }

--- a/Datalib/src/test/java/com/ing/datalib/or/yaml/YamlORTest.java
+++ b/Datalib/src/test/java/com/ing/datalib/or/yaml/YamlORTest.java
@@ -203,7 +203,7 @@ public class YamlORTest {
         writer.writeWebOR(webOR, tempDir.toFile());
         
         // Verify file exists
-        File yamlFile = new File(tempDir.toFile(), "Web/pages/HomePage.yaml");
+        File yamlFile = new File(tempDir.toFile(), "Web/HomePage.yaml");
         assertThat(yamlFile).exists();
         
         // Read back
@@ -233,7 +233,7 @@ public class YamlORTest {
         writer.writeMobileOR(mobileOR, tempDir.toFile());
         
         // Verify file exists
-        File yamlFile = new File(tempDir.toFile(), "Mobile/pages/LoginScreen.yaml");
+        File yamlFile = new File(tempDir.toFile(), "Mobile/LoginScreen.yaml");
         assertThat(yamlFile).exists();
         
         // Read back

--- a/Engine/src/main/java/com/ing/engine/commands/browser/Command.java
+++ b/Engine/src/main/java/com/ing/engine/commands/browser/Command.java
@@ -365,6 +365,19 @@ public class Command {
     }
 
     /**
+     * Checks if a runtime or user-defined variable exists.
+     * 
+     * <p>This method delegates to CommandControl's isVarExist method to verify whether
+     * a variable is defined. See {@link CommandControl#isVarExist(String)} for details.</p>
+     * 
+     * @param key the variable key to check, with or without percent signs (e.g., "%varName%" or "varName")
+     * @return true if the variable exists and has a non-null value, false otherwise
+     */
+    public boolean isVarExist(String key) {
+        return Commander.isVarExist(key);
+    }
+
+    /**
      * ******************************
      */
 }

--- a/Engine/src/main/java/com/ing/engine/commands/browser/Command.java
+++ b/Engine/src/main/java/com/ing/engine/commands/browser/Command.java
@@ -24,6 +24,7 @@ import java.util.Stack;
 
 import com.ing.engine.drivers.WebDriverCreation;
 import com.ing.engine.drivers.MobileObject;
+import com.ing.engine.drivers.StructuredDataObject;
 import java.io.File;
 import java.util.List;
 import java.util.Properties;
@@ -51,6 +52,7 @@ public class Command {
     public BrowserContext BrowserContext;
     public AutomationObject AObject;
     public MobileObject MObject;
+    public StructuredDataObject SObject;
     public PlaywrightDriverCreation Driver;
     public String Data;
     public String ObjectName;
@@ -205,6 +207,7 @@ public class Command {
             Playwright = Commander.Playwright.playwright;
             BrowserContext = Commander.BrowserContext.browserContext;
             AObject = Commander.AObject;
+            SObject = Commander.SObject;
             Driver = Commander.Page;
             Data = Commander.Data;
             ObjectName = Commander.ObjectName;

--- a/Engine/src/main/java/com/ing/engine/commands/general/GeneralOperations.java
+++ b/Engine/src/main/java/com/ing/engine/commands/general/GeneralOperations.java
@@ -1,5 +1,12 @@
 package com.ing.engine.commands.general;
 
+import java.text.DecimalFormat;
+import java.time.Instant;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 import com.ing.engine.commands.browser.CommonMethods;
 import com.ing.engine.commands.browser.General;
 import com.ing.engine.core.CommandControl;
@@ -8,10 +15,6 @@ import com.ing.engine.support.Status;
 import com.ing.engine.support.methodInf.Action;
 import com.ing.engine.support.methodInf.InputType;
 import com.ing.engine.support.methodInf.ObjectType;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 public class GeneralOperations extends General {
 
@@ -387,6 +390,28 @@ public class GeneralOperations extends General {
         Report.updateTestLog("resetPreviousTestCaseDataVariables", " Variables %PreviousScenario%, %PreviousTestCase%, %PreviousIteration% and %PreviousSubIteration% has been reset." + Input, Status.DONE);  
     }
     
+    /**
+     * Stores a value in the global datasheet.
+     * <p>
+     * This method stores data that can be accessed across different test scenarios and test cases.
+     * The global datasheet is identified by a unique ID and column name combination.
+     * </p>
+     * 
+     * @see #Data Contains the value to be stored in the global datasheet
+     * @see #Condition Contains the global datasheet reference in format "GlobalDataID:ColumnName"
+     * 
+     * <p><b>Usage Example:</b></p>
+     * <pre>
+     * Input (Data): myValue123
+     * Condition: GlobalSheet:UserData
+     * </pre>
+     * 
+     * <p><b>Behavior:</b></p>
+     * <ul>
+     *     <li>If Condition is null or invalid, reports an error with Status.DEBUG</li>
+     *     <li>If successful, stores the value with Status.DONE</li>
+     * </ul>
+     */
     @Action(object = ObjectType.GENERAL, desc = "store in Global Datasheet", input = InputType.YES, condition = InputType.YES)
     public void storeInGlobalDataSheet() {
         if (Condition != null) {
@@ -401,4 +426,95 @@ public class GeneralOperations extends General {
             System.out.println("Incorrect input format " + Condition);
         }
     }
+
+    /**
+     * Stores the current Epoch timestamp in a specified variable with flexible format options.
+     * <p>
+     * This method captures the current system time and converts it to Epoch timestamp
+     * (time since January 1, 1970, 00:00:00 UTC) in one of three formats:
+     * seconds, milliseconds, or seconds with millisecond precision.
+     * </p>
+     * 
+     * @see #Data Contains the format option: "Seconds", "Milliseconds", or "Seconds+Milliseconds"
+     * @see #Condition Contains the variable name where the timestamp will be stored
+     * 
+     * <p><b>Usage Examples:</b></p>
+     * <pre>
+     * Input (Data): @seconds
+     * Condition: %EpochSeconds%
+     * Result: Variable %EpochSeconds% contains epoch seconds (e.g., 1714176000)
+     * 
+     * Input (Data): @milliseconds
+     * Condition: %EpochMillis%
+     * Result: Variable %EpochMillis% contains epoch milliseconds (e.g., 1714176000000)
+     * 
+     * Input (Data): @seconds+milliseconds
+     * Condition: %EpochPrecise%
+     * Result: Variable %EpochPrecise% contains seconds with 3 decimal places (e.g., 1714176000.123)
+     * </pre>
+     * 
+     * <p><b>Validation:</b></p>
+     * <ul>
+     *     <li>Data must be one of: "seconds", "milliseconds", or "seconds+milliseconds" (case-insensitive)</li>
+     *     <li>Condition must contain a valid variable name</li>
+     *     <li>If validation fails, reports error with Status.FAIL and does not continue</li>
+     * </ul>
+     * 
+     * <p><b>Behavior:</b></p>
+     * <ul>
+     *     <li>Uses {@link Instant#now()} to get current system time</li>
+     *     <li>"seconds" - Converts to epoch seconds using {@link Instant#getEpochSecond()}</li>
+     *     <li>"milliseconds" - Converts to epoch milliseconds using {@link Instant#toEpochMilli()}</li>
+     *     <li>"seconds+milliseconds" - Provides decimal representation with 3 decimal places</li>
+     *     <li>Stores value in variable accessible via {@code addVar()}</li>
+     *     <li>Reports success with Status.DONE or failure with Status.FAIL</li>
+     * </ul>
+     */
+    @Action(object = ObjectType.GENERAL, desc = "Store Epoch Timestamp in variable", input = InputType.YES, condition = InputType.YES)
+    public void storeEpochTimestampInVariable() {
+        if (Condition == null || Condition.isBlank() || Condition.equals("%%")) {
+            Report.updateTestLog(Action, "Variable name is required. Please provide a valid variable name in the Condition field.", Status.FAIL);
+            return;
+        }
+        
+        if (Data == null || Data.isBlank()) {
+            Report.updateTestLog(Action, "Format option is required. Use: 'seconds', 'milliseconds', or 'seconds+milliseconds'.", Status.FAIL);
+            return;
+        }
+        
+        try {
+            String epochTimestamp = "";
+            String option = Data.trim().toLowerCase();
+
+            switch (option) {
+                case "seconds":
+                    epochTimestamp = String.valueOf(Instant.now().getEpochSecond());
+                    break;
+
+                case "milliseconds":
+                    epochTimestamp = String.valueOf(Instant.now().toEpochMilli());
+                    break;
+
+                case "seconds+milliseconds":
+                    DecimalFormat df = new DecimalFormat("0.000");
+                    df.setMaximumFractionDigits(3);
+                    double epochWithMs = Instant.now().toEpochMilli() / 1000.0;
+                    epochTimestamp = df.format(epochWithMs);
+                    break;
+
+                default:
+                    Report.updateTestLog(Action, "Invalid input. Use: 'seconds', 'milliseconds', or 'seconds+milliseconds'.", Status.FAIL);
+                    return;
+            }
+
+            addVar(Condition, epochTimestamp);
+            Report.updateTestLog(Action, "Timestamp added in variable with value '" + epochTimestamp + "'", Status.DONE);
+
+        } catch (Exception e) {
+            Report.updateTestLog(Action, e.getMessage(), Status.FAIL);
+            Logger.getLogger(CommonMethods.class.getName()).log(Level.SEVERE, null, e);
+        }
+
+    }
+ 
 }

--- a/Engine/src/main/java/com/ing/engine/commands/structuredData/StructuredData.java
+++ b/Engine/src/main/java/com/ing/engine/commands/structuredData/StructuredData.java
@@ -1,0 +1,659 @@
+package com.ing.engine.commands.structuredData;
+
+import com.ing.engine.commands.browser.General;
+import com.ing.engine.core.CommandControl;
+import com.ing.engine.support.Status;
+import com.ing.engine.support.methodInf.Action;
+import com.ing.engine.support.methodInf.InputType;
+import com.ing.engine.support.methodInf.ObjectType;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.io.IOException;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathFactory;
+import com.jayway.jsonpath.*;
+import org.w3c.dom.Document;
+import org.w3c.dom.NodeList;
+import org.w3c.dom.Node;
+import org.xml.sax.InputSource;
+import java.io.StringReader;
+import java.util.Map;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.xpath.XPathExpressionException;
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
+import org.w3c.dom.DOMException;
+import org.xml.sax.SAXException;
+
+/**
+ * Provides comprehensive webservice testing actions for REST and SOAP API automation.
+ * <p>
+ * This class extends {@link General} and offers a complete suite of HTTP/HTTPS operations
+ * for testing web services, including request execution, response validation, data extraction,
+ * and assertion capabilities for both JSON and XML responses.
+ * </p>
+ *
+ * <h2>Configuration</h2>
+ * <p>
+ * API-specific configurations can be loaded using aliases in the Condition field of {@link #setEndPoint()}.
+ * Settings include SSL verification, proxy configuration, redirect policies, and custom HTTP agents.
+ * </p>
+ */
+public class StructuredData extends General {
+
+    public StructuredData(CommandControl cc) {
+        super(cc);
+    }
+
+    public enum PathType {
+        DEFAULT,
+        JSONPATH,
+        XMLPATH
+    }
+
+
+    /****** JsonPath Actions ******/
+
+    /**
+     * Asserts that a JsonPath query result contains the expected substring.
+     * <p>
+     * Uses JsonPath to extract a value from the last Webservice JSON response and verifies it contains
+     * the specified substring.
+     * <ul>
+     *   <li>Input: Expected substring</li>
+     * </ul>
+     */
+    @Action(object = ObjectType.STRUCTUREDDATA, desc = "Assert JsonPath Result Contains ", input = InputType.YES)
+    public void assertJsonPathResultContains() {
+        try {
+            String response = responsebodies.get(key);
+            String jsonpath = Data;
+            String value = JsonPath.read(response, jsonpath).toString();
+            String strObj = getInputValue(Input);
+            if (value.contains(strObj)) {
+                Report.updateTestLog(Action, "Element text contains [" + strObj + "] is as expected", Status.PASSNS);
+            } else {
+                Report.updateTestLog(Action, "Element text [" + value + "] does not contain [" + strObj + "]",
+                        Status.FAILNS);
+            }
+        } catch (Exception ex) {
+            Logger.getLogger(this.getClass().getName()).log(Level.OFF, null, ex);
+            Report.updateTestLog(Action, "Error in validating JSON element :" + "\n" + ex.getMessage(), Status.DEBUG);
+        }
+    }
+
+    /**
+     * Asserts that a JsonPath query result does NOT contain the specified text.
+     * <p>
+     * Uses JsonPath to extract a value from the last Webservice JSON response and verifies it does NOT
+     * contain the specified substring. This is the negative assertion counterpart to
+     * {@link #assertJsonPathResultContains()}.
+     * <ul>
+     *   <li>Input: Substring that should NOT be present</li>
+     * </ul>
+     */
+    @Action(object = ObjectType.STRUCTUREDDATA, desc = "Assert JsonPath Result Not Contains ", input = InputType.YES)
+    public void assertJsonPathResultNotContains() {
+        try {
+            String response = responsebodies.get(key);
+            String jsonpath = Data;
+            String value = JsonPath.read(response, jsonpath).toString();
+            String strObj = getInputValue(Input);
+            if (!value.contains(strObj)) {
+                Report.updateTestLog(Action, "Element text [" + value + "] does not contain [" + strObj + "] as expected", Status.PASSNS);
+            } else {
+                Report.updateTestLog(Action, "Element text [" + value + "] contains [" + strObj + "] but should not",
+                        Status.FAILNS);
+            }
+        } catch (Exception ex) {
+            Logger.getLogger(this.getClass().getName()).log(Level.OFF, null, ex);
+            Report.updateTestLog(Action, "Error in validating JSON element :" + "\n" + ex.getMessage(), Status.DEBUG);
+        }
+    }
+
+    /**
+     * Asserts that a JsonPath query result contains the expected substring.
+     * <p>
+     * Uses JsonPath to extract a value from the last Webservice JSON response and verifies it matches
+     * the expected value exactly.
+     * <ul>
+     *   <li>Input: Expected value</li>
+     * </ul>
+     */
+    @Action(object = ObjectType.STRUCTUREDDATA, desc = "Assert JsonPath Result Equals ", input = InputType.YES)
+    public void assertJsonPathResultEquals() {
+        try {
+            String response = responsebodies.get(key);
+            String jsonpath = Data;
+            String value = JsonPath.read(response, jsonpath).toString();
+            String strObj = getInputValue(Input);
+            if (value.equals(strObj)) {
+                Report.updateTestLog(Action, "Element text [" + value + "] is as expected", Status.PASSNS);
+            } else {
+                Report.updateTestLog(Action, "Element text is [" + value + "] but is expected to be [" + strObj + "]",
+                        Status.FAILNS);
+            }
+        } catch (Exception ex) {
+            Logger.getLogger(this.getClass().getName()).log(Level.OFF, null, ex);
+            Report.updateTestLog(Action, "Error in validating JSON element :" + "\n" + ex.getMessage(), Status.DEBUG);
+        }
+    }
+
+    /**
+     * Asserts that a JsonPath query result does NOT equal the specified value.
+     * <p>
+     * Uses JsonPath to extract a value from the last Webservice JSON response and verifies it does NOT
+     * match the specified value exactly. This is the negative assertion counterpart to
+     * {@link #assertJsonPathResultEquals()}.
+     * <ul>
+     *   <li>Input: Value that should NOT match</li>
+     * </ul>
+     */
+    @Action(object = ObjectType.STRUCTUREDDATA, desc = "Assert JsonPath Result Not Equals ", input = InputType.YES)
+    public void assertJsonPathResultNotEquals() {
+        try {
+            String response = responsebodies.get(key);
+            String jsonpath = Data;
+            String value = JsonPath.read(response, jsonpath).toString();
+            String strObj = getInputValue(Input);
+            if (!value.equals(strObj)) {
+                Report.updateTestLog(Action, "Element text [" + value + "] is not equal to [" + strObj + "] as expected", Status.PASSNS);
+            } else {
+                Report.updateTestLog(Action, "Element text is [" + value + "] but should not be equal to [" + strObj + "]",
+                        Status.FAILNS);
+            }
+        } catch (Exception ex) {
+            Logger.getLogger(this.getClass().getName()).log(Level.OFF, null, ex);
+            Report.updateTestLog(Action, "Error in validating JSON element :" + "\n" + ex.getMessage(), Status.DEBUG);
+        }
+    }
+
+    /**
+     * Asserts that the count of JSON elements from a JsonPath query result matches the expected number.
+     * <p>
+     * Uses JsonPath to select elements and counts them, then verifies the count
+     * matches the expected value. Works with arrays and objects.
+     * <ul>
+     *   <li>Input: Expected count (integer)</li>
+     * </ul>
+     */
+    @Action(object = ObjectType.STRUCTUREDDATA, desc = "Assert JsonPath Result Count ", input = InputType.YES)
+    public void assertJsonPathResultCount() {
+        try {
+            String response = responsebodies.get(key);
+            int actualObjectCount = 0;
+            JSONParser parser = new JSONParser();
+            JSONObject json = (JSONObject) parser.parse(response);
+            String strObj = getInputValue(Input);
+            try {
+                Map<String, String> objectMap = JsonPath.read(json, Data);
+                actualObjectCount = objectMap.keySet().size();
+            } catch (Exception ex) {
+                try {
+                    JSONArray objectMap = JsonPath.read(json, Data);
+                    actualObjectCount = objectMap.size();
+                } catch (Exception ex1) {
+                    try {
+                        net.minidev.json.JSONArray objectMap = JsonPath.read(json, Data);
+                        actualObjectCount = objectMap.size();
+                    } catch (Exception ex2) {
+                        String objectMap = JsonPath.read(json, Data);
+                        actualObjectCount = 1;
+                    }
+                }
+            }
+
+            int expectedObjectCount = Integer.parseInt(strObj);
+            if (actualObjectCount == expectedObjectCount) {
+                Report.updateTestLog(Action, "Element count [" + expectedObjectCount + "] is as expected", Status.PASSNS);
+            } else {
+                Report.updateTestLog(Action, "Element count is [" + actualObjectCount + "] but is expected to be [" + expectedObjectCount + "]", Status.FAILNS);
+            }
+
+        } catch (Exception ex) {
+            Logger.getLogger(this.getClass().getName()).log(Level.OFF, null, ex);
+            Report.updateTestLog(Action, "Error in validating JSON element :" + "\n" + ex.getMessage(), Status.DEBUG);
+        }
+    }
+
+    /**
+     * Stores the count of JSON elements from a JsonPath query result in a datasheet column.
+     * <p>
+     * Uses JsonPath to select elements, counts them, and stores the count in
+     * the specified datasheet column.
+     * <ul>
+     *   <li>Input: sheetName:ColumnName</li>
+     * </ul>
+     */
+    @Action(object = ObjectType.STRUCTUREDDATA, desc = "Store JsonPath Result count in Datasheet ", input = InputType.YES)
+    public void storeJsonPathResultCountInDataSheet() {
+        try {
+            String dataSheetReference = Input;
+            if (dataSheetReference.matches(".*:.*")) {
+                try {
+                    System.out.println("Updating value in SubIteration " + userData.getSubIteration());
+                    String sheetName = dataSheetReference.split(":", 2)[0];
+                    String columnName = dataSheetReference.split(":", 2)[1];
+                    String actualObjectCount = Integer.toString(getJsonElementCount());
+                    userData.putData(sheetName, columnName, actualObjectCount);
+                    Report.updateTestLog(Action, "Element count [" + actualObjectCount + "] is stored in " + dataSheetReference,
+                            Status.DONE);
+                } catch (Exception ex) {
+                    Logger.getLogger(this.getClass().getName()).log(Level.OFF, ex.getMessage(), ex);
+                    Report.updateTestLog(Action, "Error Storing JSON element in datasheet :" + "\n" + ex.getMessage(),
+                            Status.DEBUG);
+                }
+            } else {
+                Report.updateTestLog(Action,
+                        "Given input [" + Input + "] format is invalid. It should be [sheetName:ColumnName]",
+                        Status.DEBUG);
+            }
+        } catch (Exception ex) {
+            Logger.getLogger(this.getClass().getName()).log(Level.OFF, null, ex);
+            Report.updateTestLog(Action, "Error Storing JSON element in datasheet :" + "\n" + ex.getMessage(),
+                    Status.DEBUG);
+        }
+
+    }
+
+    /**
+     * Stores the count of JSON elements from a JsonPath query result in a variable.
+     * <p>
+     * Uses JsonPath to select elements, counts them, and stores the count in a variable.
+     * <ul>
+     *   <li>Input: JsonPath expression (e.g., $.items[*])</li>
+     * </ul>
+     */
+    @Action(object = ObjectType.STRUCTUREDDATA, desc = "Store JsonPath Result count in variable ", input = InputType.YES)
+    public void storeJsonPathResultCountInVariable() {
+        try {
+            String varName = Input;
+            if (varName.matches("%.*%")) {
+                try {
+                    System.out.println("Updating value in SubIteration " + userData.getSubIteration());
+                    String actualObjectCount = Integer.toString(getJsonElementCount());
+                    addVar(varName, actualObjectCount);
+                    Report.updateTestLog(Action, "Element count [" + actualObjectCount + "] is stored in " + varName,
+                            Status.DONE);
+                } catch (Exception ex) {
+                    Logger.getLogger(this.getClass().getName()).log(Level.OFF, ex.getMessage(), ex);
+                    Report.updateTestLog(Action, "Error Storing JSON element in Variable :" + "\n" + ex.getMessage(),
+                            Status.DEBUG);
+                }
+            } else {
+                Report.updateTestLog(Action,
+                        "Given condition [" + Condition + "] format is invalid. It should be [%Var%]",
+                        Status.DEBUG);
+            }
+        } catch (Exception ex) {
+            Logger.getLogger(this.getClass().getName()).log(Level.OFF, null, ex);
+            Report.updateTestLog(Action, "Error Storing JSON element in Variable :" + "\n" + ex.getMessage(),
+                    Status.DEBUG);
+        }
+
+    }
+
+    /**
+     * Stores a JsonPath query result value in a datasheet column.
+     * <p>
+     * Extracts a value from the JSON response using JsonPath and stores it in the
+     * specified datasheet column.
+     * <ul>
+     *   <li>Input: sheetName:ColumnName</li>
+     * </ul>
+     */
+    @Action(object = ObjectType.STRUCTUREDDATA, desc = "Store JsonPath Result In DataSheet ", input = InputType.YES)
+    public void storeJsonPathResultInDataSheet() {
+        try {
+            String dataSheetReference = Input;
+            if (dataSheetReference.matches(".*:.*")) {
+                try {
+                    System.out.println("Updating value in SubIteration " + userData.getSubIteration());
+                    String sheetName = dataSheetReference.split(":", 2)[0];
+                    String columnName = dataSheetReference.split(":", 2)[1];
+                    String response = responsebodies.get(key);
+                    String jsonpath = Data;
+                    String value = JsonPath.read(response, jsonpath).toString();
+                    userData.putData(sheetName, columnName, value);
+                    Report.updateTestLog(Action, "Element text [" + value + "] is stored in " + dataSheetReference, Status.DONE);
+                } catch (Exception ex) {
+                    Logger.getLogger(this.getClass().getName()).log(Level.OFF, ex.getMessage(), ex);
+                    Report.updateTestLog(Action, "Error Storing JSON element in datasheet :" + "\n" + ex.getMessage(),
+                            Status.DEBUG);
+                }
+            } else {
+                Report.updateTestLog(Action,
+                        "Given input [" + Input + "] format is invalid. It should be [sheetName:ColumnName]",
+                        Status.DEBUG);
+            }
+        } catch (Exception ex) {
+            Logger.getLogger(this.getClass().getName()).log(Level.OFF, null, ex);
+            Report.updateTestLog(Action, "Error Storing JSON element in datasheet :" + "\n" + ex.getMessage(),
+                    Status.DEBUG);
+        }
+    }
+
+    /**
+     * Stores a JsonPath query result value in a variable.
+     * <p>
+     * Extracts a value from the JSON response using JsonPath and stores it in a variable.
+     * <ul>
+     *   <li>Input: JsonPath expression (e.g., $.data.token)</li>
+     * </ul>
+     */
+    @Action(object = ObjectType.STRUCTUREDDATA, desc = "Store JsonPath Result", input = InputType.YES)
+    public void storeJsonPathResultInVariable() {
+        try {
+            String variableName = Input;
+            String jsonpath = Data;
+            if (variableName.matches("%.*%")) {
+                addVar(variableName, JsonPath.read(responsebodies.get(key), jsonpath).toString());
+                Report.updateTestLog(Action, "JSON element value stored", Status.DONE);
+            } else {
+                Report.updateTestLog(Action, "Variable format is not correct", Status.DEBUG);
+            }
+        } catch (Exception ex) {
+            Logger.getLogger(this.getClass().getName()).log(Level.OFF, null, ex);
+            Report.updateTestLog(Action, "Error Storing JSON element :" + "\n" + ex.getMessage(), Status.DEBUG);
+        }
+    }
+
+
+    
+    /****** XmlPath Actions ******/
+
+    /**
+     * Asserts that an XmlPath query result value contains the expected substring.
+     * <p>
+     * Uses XPath to extract a value from the XML response and verifies it contains
+     * the specified substring.
+     * <ul>
+     *   <li>Input: Expected substring</li>
+     * </ul>
+     */
+    @Action(object = ObjectType.STRUCTUREDDATA, desc = "Assert XmlPath Result Contains ", input = InputType.YES)
+    public void assertXmlPathResultContains() {
+        try {
+            DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
+            DocumentBuilder dBuilder;
+            InputSource inputSource = new InputSource();
+            inputSource.setCharacterStream(new StringReader(responsebodies.get(key)));
+            dBuilder = dbFactory.newDocumentBuilder();
+            Document doc = dBuilder.parse(inputSource);
+            doc.getDocumentElement().normalize();
+            XPath xPath = XPathFactory.newInstance().newXPath();
+            String expression = Data;
+            NodeList nodeList = (NodeList) xPath.compile(expression).evaluate(doc, XPathConstants.NODESET);
+            Node nNode = nodeList.item(0);
+            String value = nNode.getNodeValue();
+            String inputValue = getInputValue(Input);
+            if (value.contains(inputValue)) {
+                Report.updateTestLog(Action, "Element text contains [" + inputValue + "] is as expected", Status.PASSNS);
+            } else {
+                Report.updateTestLog(Action, "Element text [" + value + "] does not contain [" + inputValue + "]",
+                        Status.FAILNS);
+            }
+        } catch (IOException | ParserConfigurationException | XPathExpressionException | DOMException
+                | SAXException ex) {
+            Logger.getLogger(this.getClass().getName()).log(Level.OFF, null, ex);
+            Report.updateTestLog(Action, "Error validating XML element :" + "\n" + ex.getMessage(), Status.DEBUG);
+        }
+    }
+
+    /**
+     * Asserts that an XmlPath query result does NOT contain the specified text.
+     * <p>
+     * Uses XPath to extract a value from the XML response and verifies it does NOT
+     * contain the specified substring. This is the negative assertion counterpart to
+     * {@link #assertXmlPathResultContains()}.
+     * <ul>
+     *   <li>Input: Substring that should NOT be present</li>
+     * </ul>
+     */
+    @Action(object = ObjectType.STRUCTUREDDATA, desc = "Assert XmlPath Result Not Contains ", input = InputType.YES)
+    public void assertXmlPathResultNotContains() {
+        try {
+            DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
+            DocumentBuilder dBuilder;
+            InputSource inputSource = new InputSource();
+            inputSource.setCharacterStream(new StringReader(responsebodies.get(key)));
+            dBuilder = dbFactory.newDocumentBuilder();
+            Document doc = dBuilder.parse(inputSource);
+            doc.getDocumentElement().normalize();
+            XPath xPath = XPathFactory.newInstance().newXPath();
+            String expression = Data;
+            NodeList nodeList = (NodeList) xPath.compile(expression).evaluate(doc, XPathConstants.NODESET);
+            Node nNode = nodeList.item(0);
+            String value = nNode.getNodeValue();
+            if (!value.contains(Input)) {
+                Report.updateTestLog(Action, "Element text [" + value + "] does not contain [" + Input + "] as expected", Status.PASSNS);
+            } else {
+                Report.updateTestLog(Action, "Element text [" + value + "] contains [" + Input + "] but should not",
+                        Status.FAILNS);
+            }
+        } catch (IOException | ParserConfigurationException | XPathExpressionException | DOMException
+                | SAXException ex) {
+            Logger.getLogger(this.getClass().getName()).log(Level.OFF, null, ex);
+            Report.updateTestLog(Action, "Error validating XML element :" + "\n" + ex.getMessage(), Status.DEBUG);
+        }
+    }
+
+    /**
+     * Asserts that an XmlPath query result equals the expected value.
+     * <p>
+     * Uses XPath to extract a value from the XML response and verifies it matches
+     * the expected value exactly.
+     * <ul>
+     *   <li>Input: Expected value</li>
+     * </ul>
+     */
+    @Action(object = ObjectType.STRUCTUREDDATA, desc = "Assert XmlPath Result Equals ", input = InputType.YES)
+    public void assertXmlPathResultEquals() {
+        try {
+            DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
+            DocumentBuilder dBuilder;
+            InputSource inputSource = new InputSource();
+            inputSource.setCharacterStream(new StringReader(responsebodies.get(key)));
+            dBuilder = dbFactory.newDocumentBuilder();
+            Document doc = dBuilder.parse(inputSource);
+            doc.getDocumentElement().normalize();
+            XPath xPath = XPathFactory.newInstance().newXPath();
+            String expression = Data;
+            NodeList nodeList = (NodeList) xPath.compile(expression).evaluate(doc, XPathConstants.NODESET);
+            Node nNode = nodeList.item(0);
+            String value = nNode.getNodeValue();
+            String inputValue = getInputValue(Input);
+            if (value.equals(inputValue)) {
+                Report.updateTestLog(Action, "Element text [" + value + "] is as expected", Status.PASSNS);
+            } else {
+                Report.updateTestLog(Action, "Element text [" + value + "] is not as expected. " + Data, Status.FAILNS);
+            }
+        } catch (IOException | ParserConfigurationException | XPathExpressionException | DOMException
+                | SAXException ex) {
+            Logger.getLogger(this.getClass().getName()).log(Level.OFF, null, ex);
+            Report.updateTestLog(Action, "Error validating XML element :" + "\n" + ex.getMessage(), Status.DEBUG);
+        }
+    }
+
+    /**
+     * Asserts that an XmlPath query result does NOT equal the specified value.
+     * <p>
+     * Uses XPath to extract a value from the XML response and verifies it does NOT
+     * match the specified value exactly. This is the negative assertion counterpart to
+     * {@link #assertXmlPathResultEquals()}.
+     * <ul>
+     *   <li>Input: Value that should NOT match</li>
+     * </ul>
+     */
+    @Action(object = ObjectType.STRUCTUREDDATA, desc = "Assert XmlPath Result Not Equals ", input = InputType.YES)
+    public void assertXmlPathResultNotEquals() {
+        try {
+            DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
+            DocumentBuilder dBuilder;
+            InputSource inputSource = new InputSource();
+            inputSource.setCharacterStream(new StringReader(responsebodies.get(key)));
+            dBuilder = dbFactory.newDocumentBuilder();
+            Document doc = dBuilder.parse(inputSource);
+            doc.getDocumentElement().normalize();
+            XPath xPath = XPathFactory.newInstance().newXPath();
+            String expression = Data;
+            NodeList nodeList = (NodeList) xPath.compile(expression).evaluate(doc, XPathConstants.NODESET);
+            Node nNode = nodeList.item(0);
+            String value = nNode.getNodeValue();
+            String inputValue = getInputValue(Input);
+            if (!value.equals(inputValue)) {
+                Report.updateTestLog(Action, "Element text [" + value + "] is not equal to [" + inputValue + "] as expected", Status.PASSNS);
+            } else {
+                Report.updateTestLog(Action, "Element text [" + value + "] should not be equal to [" + inputValue + "]", Status.FAILNS);
+            }
+        } catch (IOException | ParserConfigurationException | XPathExpressionException | DOMException
+                | SAXException ex) {
+            Logger.getLogger(this.getClass().getName()).log(Level.OFF, null, ex);
+            Report.updateTestLog(Action, "Error validating XML element :" + "\n" + ex.getMessage(), Status.DEBUG);
+        }
+    }
+    
+    /**
+     * Stores an XmlPath query result in a datasheet column.
+     * <p>
+     * Extracts a value from the XML response using XPath and stores it in the
+     * specified datasheet column.
+     * <ul>
+     *   <li>Input: sheetName:ColumnName</li>
+     * </ul>
+     */
+    @Action(object = ObjectType.STRUCTUREDDATA, desc = "Store XmlPath Result In DataSheet ", input = InputType.YES)
+    public void storeXmlPathResultInDataSheet() {
+        try {
+            String strObj = Input;
+            if (strObj.matches(".*:.*")) {
+                try {
+                    System.out.println("Updating value in SubIteration " + userData.getSubIteration());
+                    String sheetName = strObj.split(":", 2)[0];
+                    String columnName = strObj.split(":", 2)[1];
+                    String xmlText = responsebodies.get(key);
+                    DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
+                    DocumentBuilder dBuilder;
+                    InputSource inputSource = new InputSource();
+                    inputSource.setCharacterStream(new StringReader(xmlText));
+                    dBuilder = dbFactory.newDocumentBuilder();
+                    Document doc = dBuilder.parse(inputSource);
+                    doc.getDocumentElement().normalize();
+                    XPath xPath = XPathFactory.newInstance().newXPath();
+                    String expression = Data;
+                    NodeList nodeList = (NodeList) xPath.compile(expression).evaluate(doc, XPathConstants.NODESET);
+                    Node nNode = nodeList.item(0);
+                    String value = nNode.getNodeValue();
+                    userData.putData(sheetName, columnName, value);
+                    Report.updateTestLog(Action, "Element text [" + value + "] is stored in " + strObj, Status.DONE);
+                } catch (IOException | ParserConfigurationException | XPathExpressionException | DOMException
+                        | SAXException ex) {
+                    Logger.getLogger(this.getClass().getName()).log(Level.OFF, ex.getMessage(), ex);
+                    Report.updateTestLog(Action, "Error Storing XML element in datasheet :" + "\n" + ex.getMessage(),
+                            Status.DEBUG);
+                }
+            } else {
+                Report.updateTestLog(Action,
+                        "Given input [" + Input + "] format is invalid. It should be [sheetName:ColumnName]",
+                        Status.DEBUG);
+            }
+        } catch (Exception ex) {
+            Logger.getLogger(this.getClass().getName()).log(Level.OFF, null, ex);
+            Report.updateTestLog(Action, "Error Storing XML element in datasheet :" + "\n" + ex.getMessage(),
+                    Status.DEBUG);
+        }
+    }
+
+    /**
+     * Stores an XmlPath query result in a variable.
+     * <p>
+     * Extracts a value from the XML response using XPath and stores it in a variable.
+     * <ul>
+     *   <li>Input: XPath expression (e.g., //response/token)</li>
+     * </ul>
+     */
+    @Action(object = ObjectType.STRUCTUREDDATA, desc = "Store XmlPath Result", input = InputType.YES)
+    public void storeXmlPathResultInVariable() {
+        try {
+            String variableName = Input;
+            String expression = Data;
+            if (variableName.matches("%.*%")) {
+                DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
+                DocumentBuilder dBuilder;
+                InputSource inputSource = new InputSource();
+                inputSource.setCharacterStream(new StringReader(responsebodies.get(key)));
+                dBuilder = dbFactory.newDocumentBuilder();
+                Document doc = dBuilder.parse(inputSource);
+                doc.getDocumentElement().normalize();
+                XPath xPath = XPathFactory.newInstance().newXPath();
+                NodeList nodeList = (NodeList) xPath.compile(expression).evaluate(doc, XPathConstants.NODESET);
+                Node nNode = nodeList.item(0);
+                String value = nNode.getNodeValue();
+                addVar(variableName, value);
+                Report.updateTestLog(Action, "XML element value stored", Status.DONE);
+            } else {
+                Report.updateTestLog(Action, "Variable format is not correct", Status.DEBUG);
+            }
+        } catch (IOException | ParserConfigurationException | XPathExpressionException | DOMException
+                | SAXException ex) {
+            Logger.getLogger(this.getClass().getName()).log(Level.OFF, null, ex);
+            Report.updateTestLog(Action, "Error Storing XML element :" + "\n" + ex.getMessage(), Status.DEBUG);
+        }
+    }
+
+
+
+    /****** Helper Methods ******/
+
+    /*
+    * Calculates the count of JSON elements matched by the JsonPath expression.
+    * <p>
+    * Internal method that handles different JSON types (objects, arrays, primitives)
+    * and returns the appropriate count.
+    *
+    * @return the count of elements matched by the JsonPath expression
+    * @throws org.json.simple.parser.ParseException if JSON parsing fails
+    */
+    public int getJsonElementCount() throws org.json.simple.parser.ParseException {
+        int actualObjectCount = 0;
+        JSONParser parser = new JSONParser();
+        JSONObject json = (JSONObject) parser.parse(responsebodies.get(key));
+
+        try {
+            Map<String, String> objectMap = JsonPath.read(json, Data);
+            actualObjectCount = objectMap.keySet().size();
+        } catch (Exception ex) {
+            try {
+                JSONArray objectMap = JsonPath.read(json, Data);
+                actualObjectCount = objectMap.size();
+            } catch (Exception ex1) {
+                try {
+                    net.minidev.json.JSONArray objectMap = JsonPath.read(json, Data);
+                    actualObjectCount = objectMap.size();
+                } catch (Exception ex2) {
+                    String objectMap = JsonPath.read(json, Data);
+                    actualObjectCount = 1;
+                }
+            }
+        }
+        return actualObjectCount;
+    }
+    
+    public String getInputValue(String strObj){
+        if (strObj!=null && strObj.length()!=0){
+            if (strObj.startsWith("@")){
+                return strObj.substring(1);
+            } else if (strObj.matches(("%.*%"))){
+                return getVar(strObj);
+            } else if (strObj.matches(".*:.*")){
+                return getDatasheet(strObj);
+            }
+        }
+        return strObj;
+    }
+
+}

--- a/Engine/src/main/java/com/ing/engine/commands/webservice/Webservice.java
+++ b/Engine/src/main/java/com/ing/engine/commands/webservice/Webservice.java
@@ -1456,34 +1456,62 @@ public class Webservice extends General {
      */
     private void setRequestMethod(String method, String payload) throws IOException {
         BodyPublisher payloadBody = null;
+
         if (isformUrlencoded()) {
             payload = urlencodedParams();
         }
-        if (isMultiPart()) {
-            Path filePath = Path.of(getVar("%filePath%"));
-            filePath = Path.of(Control.getCurrentProject().getLocation() + "/" + filePath);
-            String mimeType = Files.probeContentType(filePath);
-            System.out.println("Path of the file === " + filePath);
-            String boundary = "Boundary-" + System.currentTimeMillis();
-            String fileName = filePath.getFileName().toString();
 
-            /* String body = "--" + boundary.getBytes(StandardCharsets.UTF_8)+ "\r\n"
-                    + "Content-Disposition: form-data; name=\"file\"; filename=\"" + fileName + "\"\r\n"
-                    + "Content-Type: " + mimeType // Set Content-Type to text/csv
-                    + Files.readString(filePath, StandardCharsets.UTF_8) + "\r\n"
-                    + ("--" + boundary + "--\r\n").getBytes(StandardCharsets.UTF_8);*/
+        if (isMultiPart()) {
+            String boundary = "Boundary-" + System.currentTimeMillis();
             var byteArrays = new ArrayList<byte[]>();
-            byteArrays.add(("--" + boundary + "\r\n").getBytes(StandardCharsets.UTF_8));
-            byteArrays.add(("Content-Disposition: form-data; name=\"file\"; filename=\"" + fileName + "\"\r\n").getBytes(StandardCharsets.UTF_8));
-            byteArrays.add(("Content-Type: " + mimeType + "\r\n\r\n").getBytes(StandardCharsets.UTF_8));
-            byteArrays.add(Files.readAllBytes(filePath));
-            byteArrays.add(("\r\n--" + boundary + "--\r\n").getBytes(StandardCharsets.UTF_8));
+
+            if (urlParams.containsKey(key) && urlParams.get(key) != null) {
+                ArrayList<String> params = urlParams.get(key);
+                for (String param : params) {
+                    if (param.contains("=")) {
+                        String[] keyValue = param.split("=", 2);
+                        String fieldName = keyValue[0];
+                        String fieldValue = keyValue.length > 1 ? keyValue[1] : "";
+
+                        byteArrays.add(("--" + boundary + "\r\n").getBytes(StandardCharsets.UTF_8));
+                        byteArrays.add(("Content-Disposition: form-data; name=\"" + fieldName + "\"\r\n\r\n").getBytes(StandardCharsets.UTF_8));
+                        byteArrays.add((fieldValue + "\r\n").getBytes(StandardCharsets.UTF_8));
+                    }
+                }
+            }
+
+            if (isVarExist("%filePath%")) {
+                String filePathVar = getVar("%filePath%");
+                if (filePathVar != null && !filePathVar.isEmpty()) {
+                    addFilePartToMultipart(byteArrays, boundary, filePathVar, "file");
+
+                    int fileIndex = 1;
+                    boolean continueChecking = true;
+
+                    while (continueChecking) {
+                        if (isVarExist("%filePath" + fileIndex + "%")) {
+                            String filePathVarIndexed = getVar("%filePath" + fileIndex + "%");
+                            addFilePartToMultipart(byteArrays, boundary, filePathVarIndexed, "file" + fileIndex);
+                            fileIndex++;
+                        } else {
+                            // Stop checking if current filePathN is not available
+                            continueChecking = false;
+                        }
+                    }
+                }
+            } else {
+                Report.updateTestLog(Action, "filePath variable is not defined for multipart request", Status.FAIL);
+                throw new IOException("filePath variable is required for multipart/form-data requests but is not defined");
+            }
+
+            byteArrays.add(("--" + boundary + "--\r\n").getBytes(StandardCharsets.UTF_8));
 
             payloadBody = HttpRequest.BodyPublishers.ofByteArrays(byteArrays);
             httpRequestBuilder.put(key, httpRequestBuilder.get(key).setHeader("Content-Type", "multipart/form-data; boundary=" + boundary));
         } else {
             payloadBody = HttpRequest.BodyPublishers.ofString(payload);
         }
+
         try {
             switch (method) {
                 case "POST": {
@@ -2017,6 +2045,32 @@ public class Webservice extends General {
             Logger.getLogger(this.getClass().getName()).log(Level.OFF, null, ex);
             Report.updateTestLog(Action, "Error in validating response body :" + "\n" + ex.getMessage(), Status.DEBUG);
         }
+    }
+
+    private void addFilePartToMultipart(ArrayList<byte[]> byteArrays, String boundary, String filePathVar, String fieldName) throws IOException {
+        Path filePath = Path.of(filePathVar);
+        if (!filePath.isAbsolute()) {
+            String currentWorkingDir = System.getProperty("user.dir");           
+            filePath = Path.of(currentWorkingDir, filePathVar);   
+        } 
+
+        if (!Files.exists(filePath)) {
+            Report.updateTestLog(Action, "File not found at path: " + filePath, Status.FAIL);
+            throw new IOException("File not found at path: " + filePath);
+        }
+
+        long fileSize = Files.size(filePath);
+
+        String mimeType = Files.probeContentType(filePath);
+        if (mimeType == null) {
+            mimeType = "application/octet-stream"; // Default MIME type
+        }
+        String fileName = filePath.getFileName().toString();
+        byteArrays.add(("--" + boundary + "\r\n").getBytes(StandardCharsets.UTF_8));
+        byteArrays.add(("Content-Disposition: form-data; name=\"" + fieldName + "\"; filename=\"" + fileName + "\"\r\n").getBytes(StandardCharsets.UTF_8));
+        byteArrays.add(("Content-Type: " + mimeType + "\r\n\r\n").getBytes(StandardCharsets.UTF_8));
+        byteArrays.add(Files.readAllBytes(filePath));
+        byteArrays.add(("\r\n").getBytes(StandardCharsets.UTF_8));
     }
 
 }

--- a/Engine/src/main/java/com/ing/engine/core/CommandControl.java
+++ b/Engine/src/main/java/com/ing/engine/core/CommandControl.java
@@ -9,6 +9,7 @@ import com.ing.datalib.settings.DriverProperties;
 import com.ing.engine.drivers.AutomationObject;
 import com.ing.engine.drivers.AutomationObject.FindType;
 import com.ing.engine.drivers.PlaywrightDriverCreation;
+import com.ing.engine.drivers.StructuredDataObject;
 import com.ing.engine.execution.data.DataProcessor;
 import com.ing.engine.execution.data.UserDataAccess;
 import com.ing.engine.execution.exception.UnCaughtException;
@@ -40,6 +41,7 @@ public abstract class CommandControl {
     public PlaywrightDriverCreation Page;
     public PlaywrightDriverCreation BrowserContext;
     public AutomationObject AObject;
+    
     public String Data;
     public String Action;
     public String ObjectName;
@@ -57,10 +59,16 @@ public abstract class CommandControl {
     private Stack<Locator> runTimeElement = new Stack<>();
     
     public MobileObject MObject;
+    public StructuredDataObject SObject;
     public WebDriverCreation webDriver;
     public WebElement Element;
+    public String structuredData;
 
-    public CommandControl(PlaywrightDriverCreation playwright, PlaywrightDriverCreation page, PlaywrightDriverCreation browserContext ,WebDriverCreation driver,TestCaseReport report) {
+    public CommandControl(PlaywrightDriverCreation playwright,
+            PlaywrightDriverCreation page,
+            PlaywrightDriverCreation browserContext,
+            WebDriverCreation driver,
+            TestCaseReport report) {
         Playwright = playwright;
         BrowserContext = browserContext;
         Page = page;
@@ -71,13 +79,11 @@ public abstract class CommandControl {
                 return (TestCaseRunner) CommandControl.this.context();
             }
         };
-        if(webDriver==null)
-        {
+        if(webDriver==null) {
            AObject = new AutomationObject(Page.page); 
-        }
-        else if(webDriver!=null)
-        {
-           MObject=new MobileObject(webDriver.driver); 
+           SObject = new StructuredDataObject(Page.page);
+        } else if(webDriver!=null) {
+           MObject = new MobileObject(webDriver.driver); 
         }
         Report = (TestCaseReport) report;
 
@@ -90,18 +96,12 @@ public abstract class CommandControl {
     }
 
     public void sync(Step curr) throws UnCaughtException {
-        if(webDriver==null)
-        {
+            
         refresh();
-        //AObject.setDriver(seDriver.driver);
         this.Description = curr.Description;
         this.Action = curr.Action;
         this.Input = curr.Input;
         this.Data = curr.Data;
-
-        /********** Updates the Action for NLP_locator****************/
-        AutomationObject.Action = this.Action;
-        /**************************************************************/
         
         if (curr.Condition != null && curr.Condition.length() > 0) {
             this.Condition = curr.Condition;
@@ -114,82 +114,63 @@ public abstract class CommandControl {
                 this.Reference = curr.Reference;
                 if (!curr.Action.startsWith("img")) {
                     if (canIFindElement()) {
-                        
-                        Locator = AObject.findElement(ObjectName, Reference, FindType.fromString(Condition));
-                        
-                    }
-                }
-            }
-        }
-    }
-         else
-    { 
-       refresh();
-//        mobileObject.setDriver(mobileDriver.driver);
-        this.Description = curr.Description;
-        this.Action = curr.Action;
-        this.Input = curr.Input;
-        this.Data = curr.Data;
 
-        /********** Updates the Action for NLP_locator****************/
-        MobileObject.Action = this.Action;
-        /**************************************************************/
+                            structuredData = SObject.findElement(ObjectName, Reference);
+                        if (structuredData!= null) {
+                            StructuredDataObject.Action = this.Action;
+                            
+                            Data = structuredData;
+                        } else if (webDriver==null) {
+                            /********** Updates the Action for NLP_locator****************/
+                            AutomationObject.Action = this.Action;
+                            /**************************************************************/
 
-        if (curr.Condition != null && curr.Condition.length() > 0) {
-            this.Condition = curr.Condition;
-        }
+                            Locator = AObject.findElement(ObjectName, Reference, FindType.fromString(Condition));
+                        } else {
+                            /********** Updates the Action for NLP_locator****************/
+                            MobileObject.Action = this.Action;
+                            /**************************************************************/
 
-        if (curr.ObjectName != null && curr.ObjectName.length() > 0) {
-            this.ObjectName = curr.ObjectName.trim();
-
-            if (!(ObjectName.matches("(?i:app|browser|execute|executeclass)"))) {
-                this.Reference = curr.Reference;
-                if (!curr.Action.startsWith("img")) {
-                    if (canIFindElement()) {
-                        Element = MObject.findElement(ObjectName, Reference, FindmType.fromString(Condition));
-
+                            Element = MObject.findElement(ObjectName, Reference, FindmType.fromString(Condition));
+                        }
 
                     }
                 }
             }
         } 
-    }
+        
     }
 
     private Boolean canIFindElement() {
-        if(webDriver!=null)
-        {
-        if(webDriver.isAlive())
-        {
-            if (webDriver.getCurrentBrowser().equalsIgnoreCase("ProtractorJS")) {
-                return false;
-            } else {
-                switch (Action) {
-                    case "waitForElementToBePresent":
-                    case "setObjectProperty":
-                    case "setMobileObjectProperty":
-                    case "setMobileGlobalProperty":
-                        return false;
-                    default:
-                        return true;
+        if (webDriver!=null) {
+            if (webDriver.isAlive()) {
+                if (webDriver.getCurrentBrowser().equalsIgnoreCase("ProtractorJS")) {
+                    return false;
+                } else {
+                    switch (Action) {
+                        case "waitForElementToBePresent":
+                        case "setObjectProperty":
+                        case "setMobileObjectProperty":
+                        case "setMobileGlobalProperty":
+                            return false;
+                        default:
+                            return true;
+                    }
                 }
             }
-        }
-        }
-        else
-        {
-        if (Page.isAlive()) {
-                switch (Action) {
-                    case "waitForElementToBePresent":
-                    case "setObjectProperty":
-                    case "setMobileObjectProperty":
-                    case "setMobileGlobalProperty":
-                        return false;
-                    default:
-                        return true;
-                }
-            
-        }
+        } else {
+            if (Page.isAlive()) {
+                    switch (Action) {
+                        case "waitForElementToBePresent":
+                        case "setObjectProperty":
+                        case "setMobileObjectProperty":
+                        case "setMobileGlobalProperty":
+                            return false;
+                        default:
+                            return true;
+                    }
+
+            }
         }
         return false;
     }

--- a/Engine/src/main/java/com/ing/engine/core/CommandControl.java
+++ b/Engine/src/main/java/com/ing/engine/core/CommandControl.java
@@ -391,4 +391,30 @@ public abstract class CommandControl {
         }
         return str;
     }
+
+    /**
+     * Checks if a runtime or user-defined variable exists.
+     * 
+     * <p>This method verifies whether a variable is defined in either the runtime variables map
+     * or the user-defined settings. The key can be provided with or without percent signs.</p>
+     * 
+     * <p>Variable resolution order:
+     * <ol>
+     *   <li>Runtime variables (set during test execution via addVar)</li>
+     *   <li>User-defined variables (configured in project settings)</li>
+     * </ol>
+     * 
+     * <p>Example usage:
+     * <ul>
+     *   <li>isVarExist("%filePath%") - checks if filePath variable exists</li>
+     *   <li>isVarExist("filePath") - equivalent to above</li>
+     * </ul>
+     * 
+     * @param key the variable key to check, with or without percent signs (e.g., "%varName%" or "varName")
+     * @return true if the variable exists and has a non-null value, false otherwise
+     */
+    public boolean isVarExist(String key) {
+        String val = getDynamicValue(key);
+        if (val == null) { return false; } return true;
+    }
 }

--- a/Engine/src/main/java/com/ing/engine/drivers/PlaywrightDriverCreation.java
+++ b/Engine/src/main/java/com/ing/engine/drivers/PlaywrightDriverCreation.java
@@ -166,4 +166,8 @@ public class PlaywrightDriverCreation {
         return browserContext.browser().version();
     }
 
+    public RunContext getRunContext() {
+        return runContext;
+    }
+
 }

--- a/Engine/src/main/java/com/ing/engine/drivers/StructuredDataObject.java
+++ b/Engine/src/main/java/com/ing/engine/drivers/StructuredDataObject.java
@@ -1,0 +1,435 @@
+package com.ing.engine.drivers;
+
+import com.ing.datalib.or.ObjectRepository;
+import com.ing.datalib.or.structureddata.StructuredDataAttribute;
+import com.ing.datalib.or.structureddata.StructuredDataORObject;
+import com.ing.datalib.or.structureddata.StructuredDataORPage;
+import com.ing.datalib.or.structureddata.ResolvedStructuredDataObject;
+import com.ing.datalib.or.common.ORAttribute;
+import com.ing.datalib.or.common.ObjectGroup;
+import com.ing.datalib.or.mobile.MobileORObject;
+import com.ing.datalib.or.mobile.MobileORPage;
+import com.ing.datalib.or.mobile.ResolvedMobileObject;
+import com.ing.datalib.or.web.WebORObject;
+import com.ing.datalib.or.web.WebORPage;
+import com.ing.datalib.or.web.ResolvedWebObject;
+import com.ing.engine.constants.SystemDefaults;
+import com.ing.engine.core.Control;
+import com.ing.engine.core.CommandControl;
+import com.microsoft.playwright.BrowserContext;
+import com.microsoft.playwright.FrameLocator;
+import com.microsoft.playwright.Locator;
+import com.microsoft.playwright.Page;
+import com.microsoft.playwright.options.AriaRole;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.WebElement;
+
+public class StructuredDataObject {
+
+    public StructuredDataObject(CommandControl cc) {
+        super();
+    }
+
+    public Page page;
+    BrowserContext browserContext;
+
+    public Page getPage() {
+        return page;
+    }
+
+    public void setPage(Page page) {
+        this.page = page;
+    }
+
+    String pageName;
+    String objectName;
+    FindType findType;
+    private Duration waitTime;
+
+    public static HashMap<String, Map<String, Map<String, String>>> dynamicValue = new HashMap<>();
+    public static HashMap<String, String> globalDynamicValue = new HashMap<>();
+    public static String Action = "";
+    static HashMap<String, String> chainLocatorMaping = new HashMap<String, String>();
+    public static final Map<String, List<String>> locatorFiltersMap = new HashMap<>();
+
+    public enum FindType {
+        GLOBAL_OBJECT, DEFAULT;
+
+        public static FindType fromString(String val) {
+            switch (val.toLowerCase()) {
+                case "globalobject":
+                    return GLOBAL_OBJECT;
+                default:
+                    return DEFAULT;
+            }
+        }
+    }
+
+    public StructuredDataObject() {
+    }
+
+    public StructuredDataObject(Page Page) {
+        this.page = Page;
+    }
+
+    public StructuredDataObject(BrowserContext BrowserContext) {
+        this.browserContext = BrowserContext;
+    }
+
+    /**
+     *
+     * @param objectKey ObjectName in pageKey in OR
+     * @param pageKey PageName in OR
+     * @return
+     */
+    public String findElement(String objectKey, String pageKey) {
+        String e = findElement(objectKey, pageKey, FindType.DEFAULT);
+        return e;
+    }
+
+    /**
+     *
+     * @param element Driver or WebElement
+     * @param objectKey ObjectName in pageKey in OR
+     * @param Attribute
+     * @param condition
+     * @param pageKey PageName in OR
+     * @return
+     */
+    public String findElement(String objectKey, String pageKey, String Attribute) {
+        return findElement(objectKey, pageKey, Attribute, FindType.DEFAULT);
+    }
+
+    public String findElement(String objectKey, String pageKey, FindType condition) {
+        return findElement(page, objectKey, pageKey, condition);
+    }
+
+    public String findElement(Page page, String objectKey, String pageKey, FindType condition) {
+        pageName = pageKey;
+        objectName = objectKey;
+        findType = condition;
+        return getElementFromList(findElements(getORObject(pageKey, objectKey), null));
+    }
+
+    public String findElement(String objectKey, String pageKey, String Attribute, FindType condition) {
+        pageName = pageKey;
+        objectName = objectKey;
+        findType = condition;
+
+        return getElementFromList(findElements(getORObject(pageKey, objectKey), Attribute));
+    }
+
+    public List<String> findElements(String objectKey, String pageKey) {
+        return findElements(objectKey, pageKey, FindType.DEFAULT);
+    }
+
+    public List<String> findElements(String objectKey, String pageKey, String Attribute) {
+        return findElements(objectKey, pageKey, Attribute, FindType.DEFAULT);
+    }
+
+    public List<String> findElements(String objectKey, String pageKey, FindType condition) {
+        //return findElements(objectKey, pageKey, condition);
+        return findElements(objectKey, pageKey, null, condition);
+    }
+
+    public List<String> findElements(String objectKey, String pageKey, String Attribute, FindType condition) {
+        return findElements(objectKey, pageKey, Attribute, condition);
+    }
+
+    private String getElementFromList(List<String> elements) {
+
+        return elements != null && !elements.isEmpty() ? elements.get(0) : null;
+    }
+
+    public ObjectGroup<?> getORObject(String page, String object) {
+        ObjectRepository objRep = Control.getCurrentProject().getObjectRepository();
+        try {
+            ResolvedWebObject.PageRef wref = ResolvedWebObject.PageRef.parse(page);
+            ResolvedWebObject wresolved = objRep.resolveWebObject(wref, object);
+            if (wresolved != null && wresolved.getGroup() != null) {
+                return wresolved.getGroup();
+            }
+        } catch (Exception ignore) { }
+        try {
+            ResolvedMobileObject.PageRef mref = ResolvedMobileObject.PageRef.parse(page);
+            ResolvedMobileObject mresolved = objRep.resolveMobileObject(mref, object);
+            if (mresolved != null && mresolved.getGroup() != null) {
+                return mresolved.getGroup();
+            }
+        } catch (Exception ignore) { }
+        try {
+            ResolvedStructuredDataObject.PageRef aref = ResolvedStructuredDataObject.PageRef.parse(page);
+            ResolvedStructuredDataObject aresolved = objRep.resolveStructuredDataObject(aref, object);
+            if (aresolved != null && aresolved.getGroup() != null) {
+                return aresolved.getGroup();
+            }
+        } catch (Exception ignore) { }
+        if (objRep.getWebOR() != null && objRep.getWebOR().getPageByName(page) != null) {
+            return objRep.getWebOR().getPageByName(page).getObjectGroupByName(object);
+        } else if (objRep.getWebSharedOR() != null && objRep.getWebSharedOR().getPageByName(page) != null) {
+            return objRep.getWebSharedOR().getPageByName(page).getObjectGroupByName(object);
+        } else if (objRep.getMobileOR() != null && objRep.getMobileOR().getPageByName(page) != null) {
+            return objRep.getMobileOR().getPageByName(page).getObjectGroupByName(object);
+        } else if (objRep.getMobileSharedOR() != null && objRep.getMobileSharedOR().getPageByName(page) != null) {
+            return objRep.getMobileSharedOR().getPageByName(page).getObjectGroupByName(object);
+        } else if (objRep.getStructuredDataOR() != null && objRep.getStructuredDataOR().getPageByName(page) != null) {
+            return objRep.getStructuredDataOR().getPageByName(page).getObjectGroupByName(object);
+        } else if (objRep.getStructuredDataSharedOR() != null && objRep.getStructuredDataSharedOR().getPageByName(page) != null) {
+            return objRep.getStructuredDataSharedOR().getPageByName(page).getObjectGroupByName(object);
+        }
+        return null;
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private synchronized List<String> findElements(ObjectGroup objectGroup, String prop) {
+
+        if (objectGroup != null && !objectGroup.getObjects().isEmpty()) {
+            if (objectGroup.getObjects().get(0) instanceof StructuredDataORObject) {
+
+                return getAPIElements(objectGroup, prop);
+            }
+        }
+        return null;
+    }
+
+    private List<String> getAPIElements(ObjectGroup<StructuredDataORObject> objectGroup, String prop) {
+        long startTime = System.nanoTime();
+        List<String> elements = null;
+        for (StructuredDataORObject object : objectGroup.getObjects()) {
+            elements = getElements(object.getAttributes());
+            if (elements != null && !elements.isEmpty()) {
+                break;
+            }
+        }
+        //printStats(elements, objectGroup, startTime, System.nanoTime());
+        return elements;
+    }
+
+    private void printStats(List<String> elements, ObjectGroup<?> objectGroup, long startTime, long stopTime) {
+        if (getElementFromList(elements) != null) {
+            System.out.println(elements);
+            System.out.println(foundElementIn(objectGroup, stopTime, startTime));
+        } else {
+            System.out.println(notFoundIn(objectGroup));
+        }
+    }
+
+    private static String foundElementBy(String attr, String val) {
+        return String.format("Object being identified with [%s] = [%s], ", attr, val);
+    }
+
+    private static String foundElementIn(ObjectGroup<?> objectGroup, long stopTime, long startTime) {
+        return String.format("Object [%s] found in [%s] ms", objectGroup.getName(), (stopTime - startTime) / 1000000);
+    }
+
+    private String notFoundIn(ObjectGroup<?> objectGroup) {
+        return String.format("Couldn't find Object '%s' in stipulated Time '%s' Seconds", objectGroup.getName(),
+                String.valueOf(getWaitTime().toSeconds()));
+    }
+
+    private List<String> getElements(final List<StructuredDataAttribute> attributes) {
+        return getElementsInternal(attributes);
+//        return getElementsInternal(attributes -> {
+//            String el = null;
+////            switch (tag) {
+////                case "Text":
+////                    locator = this.page.getByText(value, (Page.GetByTextOptions) options);
+////                    break;
+////                case "Label":
+////                    locator = this.page.getByLabel(value, (Page.GetByLabelOptions) options);
+////                    break;
+////                case "Placeholder":
+////                    locator = this.page.getByPlaceholder(value, (Page.GetByPlaceholderOptions) options);
+////                    break;
+////                case "AltText":
+////                    locator = this.page.getByAltText(value, (Page.GetByAltTextOptions) options);
+////                    break;
+////                case "Title":
+////                    locator = this.page.getByTitle(value, (Page.GetByTitleOptions) options);
+////                    break;
+////                case "TestId":
+////                    locator = this.page.getByTestId(value);
+////                    break;
+////                case "css":
+////                    locator = this.page.locator("css=" + value);
+////                    break;
+////                case "xpath":
+////                    locator = this.page.locator("xpath=" + value);
+////                    break;
+////                case "Role":
+////                    locator = createRoleLocator(value, this.page);
+////                    break;
+////                case "ChainedLocator":
+////                    locator = createChainedLocator(value, this.page);
+////                    break;
+////                default:
+////                    locator = null;
+////            }
+////            // Apply filter if required
+////            if (locator != null) {
+////                locator = setFilter(locator);
+////            }
+//            return el;
+//        });
+    }
+
+    private String getRuntimeValue(String value) {
+        if (findType != null && findType.equals(FindType.GLOBAL_OBJECT)) {
+            for (String Key : globalDynamicValue.keySet()) {
+                value = value.replace(Key, globalDynamicValue.get(Key));
+            }
+        }
+        if (dynamicValue.containsKey(pageName) && dynamicValue.get(pageName).containsKey(objectName)) {
+            for (String Key : dynamicValue.get(pageName).get(objectName).keySet()) {
+                value = value.replace(Key, dynamicValue.get(pageName).get(objectName).get(Key));
+            }
+        }
+
+        return value;
+    }
+
+    public void setDriver(Page page) {
+        this.page = page;
+    }
+
+    private String stripScope(String pageKey) {
+        if (pageKey == null) return null;
+        int at = pageKey.lastIndexOf('@');
+        return (at > 0) ? pageKey.substring(0, at) : pageKey;
+    }
+
+    public List<String> getObjectList(String page, String regexObject) {
+        if (page == null || page.trim().isEmpty()) {
+            throw new RuntimeException("Page Name is empty please give a valid pageName");
+        }
+        ObjectRepository objRep = Control.getCurrentProject().getObjectRepository();
+        WebORPage wPage = null;
+        MobileORPage mPage = null;
+        StructuredDataORPage aPage = null;
+        try {
+            ResolvedWebObject.PageRef ref = ResolvedWebObject.PageRef.parse(page);
+
+            if (ref != null && ref.scope != null) {
+                // Scoped: pick only the specified OR
+                if (ref.scope.name().equals("SHARED")) {
+                    wPage = objRep.getWebSharedOR().getPageByName(ref.name);
+                } else {
+                    wPage = objRep.getWebOR().getPageByName(ref.name);
+                }
+            } else {
+                // Unscoped: project-first then shared
+                wPage = objRep.getWebOR().getPageByName(ref.name);
+                if (wPage == null) wPage = objRep.getWebSharedOR().getPageByName(ref.name);
+            }
+
+        } catch (Exception ignore) {
+            // If parsing fails, treat as plain page name
+            wPage = objRep.getWebOR().getPageByName(page);
+            if (wPage == null) wPage = objRep.getWebSharedOR().getPageByName(page);
+        }
+
+        if (wPage == null && objRep.getMobileOR().getPageByName(stripScope(page)) != null) {
+            mPage = objRep.getMobileOR().getPageByName(stripScope(page));
+        }
+        
+        if (mPage == null && objRep.getStructuredDataOR().getPageByName(stripScope(page)) != null) {
+            aPage = objRep.getStructuredDataOR().getPageByName(stripScope(page));
+        }
+
+        if (wPage == null && mPage == null && aPage == null) {
+            throw new RuntimeException("Page [" + page + "] is not available in ObjectRepository");
+        }
+        List<String> elementList = new ArrayList<>();
+        if (wPage != null) {
+            for (ObjectGroup<WebORObject> objectgroup : wPage.getObjectGroups()) {
+                if (objectgroup.getName().matches(regexObject)) {
+                    elementList.add(regexObject);
+                }
+            }
+        } else if (mPage != null) {
+            for (ObjectGroup<MobileORObject> objectgroup : mPage.getObjectGroups()) {
+                if (objectgroup.getName().matches(regexObject)) {
+                    elementList.add(regexObject);
+                }
+            }
+        } else if (aPage != null) {
+            for (ObjectGroup<StructuredDataORObject> objectgroup : aPage.getObjectGroups()) {
+                if (objectgroup.getName().matches(regexObject)) {
+                    elementList.add(regexObject);
+                }
+            }
+        }
+        return elementList;
+    }
+
+    public void setWaitTime(Duration waitTime) {
+        this.waitTime = waitTime;
+    }
+
+    public void resetWaitTime() {
+        this.waitTime = null;
+    }
+
+    private Duration getWaitTime() {
+        return this.waitTime != null ? this.waitTime : SystemDefaults.elementWaitTime;
+    }
+
+    public void storeElementDetailsinOR(List<ORAttribute> attributes, String attribute, String value) {
+        for (ORAttribute attr : attributes) {
+            if (attr.getName().contentEquals(attribute)) {
+                attr.setValue(value);
+                break;
+            }
+        }
+    }
+
+    public String getAttributeValue(List<ORAttribute> attributes, String attribute) {
+        for (ORAttribute attr : attributes) {
+            if (attr.getName().contentEquals(attribute)) {
+                return attr.getValue();
+            }
+        }
+        return null;
+    }
+
+    private int getMinKey(Map<Integer, Integer> map, Object... object) {
+        int minKey = 0;
+        int minValue = Integer.MAX_VALUE;
+        for (Object key : object) {
+            int value = map.get(key);
+            if (value < minValue) {
+                minValue = value;
+                minKey = (int) key;
+            }
+        }
+        return minKey;
+    }
+
+    @FunctionalInterface
+    private interface LocatorFactory {
+        Locator create(String tag, String value, Object options);
+    }
+
+    private List<String> getElementsInternal(final List<StructuredDataAttribute> attributes) {
+        if (attributes == null || attributes.isEmpty()) return null;
+        List<String> elements = new ArrayList<>();
+        for (StructuredDataAttribute attr : attributes) {
+            String value = getRuntimeValue(attr.getValue() != null ? attr.getValue() : "");
+            if (value.trim().isEmpty()) continue;
+            elements.add(value);
+            break; // Only first valid locator
+//            }
+        }
+        return elements.isEmpty() ? null : elements;
+    }
+
+
+}

--- a/Engine/src/main/java/com/ing/engine/drivers/WebDriverCreation.java
+++ b/Engine/src/main/java/com/ing/engine/drivers/WebDriverCreation.java
@@ -216,4 +216,8 @@ public class WebDriverCreation {
             return false;
         }
     }
+    
+    public RunContext getRunContext() {
+        return runContext;
+    }
 }

--- a/Engine/src/main/java/com/ing/engine/reporting/impl/html/HtmlTestCaseHandler.java
+++ b/Engine/src/main/java/com/ing/engine/reporting/impl/html/HtmlTestCaseHandler.java
@@ -65,11 +65,13 @@ public class HtmlTestCaseHandler extends TestCaseHandler implements PrimaryHandl
 
     }
 
+
     @Override
     public void setPlaywrightDriver(PlaywrightDriverCreation driver) {
         testCaseData.put(TestCase.B_VERSION, getPlaywrightDriver().getBrowserVersion());
         testCaseData.put(TestCase.PLATFORM, System.getProperty("os.name")+ " " +System.getProperty("os.version")+ " " +System.getProperty("os.arch"));
         testCaseData.put(TestCase.BROWSER, getPlaywrightDriver().getCurrentBrowser());
+        testCaseData.put("browserTypeLabel", resolveBrowserTypeLabel(driver != null ? driver.getRunContext() : null, false));
     }
     
     @Override
@@ -77,6 +79,33 @@ public class HtmlTestCaseHandler extends TestCaseHandler implements PrimaryHandl
         testCaseData.put(TestCase.B_VERSION, getWebDriver().getCurrentBrowserVersion());
         testCaseData.put(TestCase.PLATFORM, getWebDriver().getPlatform());
         testCaseData.put(TestCase.BROWSER, getWebDriver().getCurrentBrowser());
+        testCaseData.put("browserTypeLabel", resolveBrowserTypeLabel(driver != null ? driver.getRunContext() : null, driver != null && driver.isMobileExecution()));
+    }
+
+    /**
+     * Returns the dynamic label for browser/device for reporting.
+     * @param runContext The RunContext (may be null)
+     * @param isMobile True if mobile execution (for WebDriver), false otherwise
+     * @return "Device", "Browser", or "Browser/Device"
+     */
+    private String resolveBrowserTypeLabel(RunContext runContext, boolean isMobile) {
+        try {
+            if (runContext != null) {
+                String browserName = runContext.BrowserName;
+                if (isMobile || "Android".equalsIgnoreCase(browserName) || "iOS".equalsIgnoreCase(browserName)) {
+                    return "Device";
+                } else if ("Chromium".equalsIgnoreCase(browserName) ||
+                        "WebKit".equalsIgnoreCase(browserName) ||
+                        "Firefox".equalsIgnoreCase(browserName)) {
+                    return "Browser";
+                } else {
+                    return "Browser/Device";
+                }
+            }
+        } catch (Exception e) {
+            // ignore
+        }
+        return "Browser/Device";
     }
 
     @Override

--- a/Engine/src/main/java/com/ing/engine/support/methodInf/ObjectType.java
+++ b/Engine/src/main/java/com/ing/engine/support/methodInf/ObjectType.java
@@ -18,6 +18,6 @@ public enum ObjectType {
     QUEUE,
     DATA,
     GENERAL,
-    STRINGOPERATIONS
-    
+    STRINGOPERATIONS,
+    STRUCTUREDDATA
 }

--- a/IDE/src/main/java/com/ing/ide/main/fx/INGIcons.java
+++ b/IDE/src/main/java/com/ing/ide/main/fx/INGIcons.java
@@ -106,13 +106,15 @@ public final class INGIcons {
         register("or.Web",              MaterialDesignW.WEB,                           CLR_DATA);  // violet
         register("or.Mobile",           MaterialDesignC.CELLPHONE,                     CLR_DATA);  // violet
         register("or.API",              MaterialDesignA.API,                           CLR_DATA);  // violet
+        register("or.StructuredData",   MaterialDesignC.CODE_JSON,                     CLR_DATA);  // violet
         register("or.propViewer",       MaterialDesignT.TABLE_EYE,                     CLR_SEARCH);
         
         // ── Dark Mode Colors for OR Icons (brighter violet for visibility) ──
-        COLOR_MAP_DARK.put("or.Web",    CLR_DATA_DARK);
-        COLOR_MAP_DARK.put("or.Mobile", CLR_DATA_DARK);
-        COLOR_MAP_DARK.put("or.API",    CLR_DATA_DARK);
-        COLOR_MAP_DARK.put("or.Root",   CLR_DATA_DARK);
+        COLOR_MAP_DARK.put("or.Web",                CLR_DATA_DARK);
+        COLOR_MAP_DARK.put("or.Mobile",             CLR_DATA_DARK);
+        COLOR_MAP_DARK.put("or.API",                CLR_DATA_DARK);
+        COLOR_MAP_DARK.put("or.StructuredData",     CLR_DATA_DARK);
+        COLOR_MAP_DARK.put("or.Root",               CLR_DATA_DARK);
 
         // ── Tree: Reusable ──
         register("reusable.Root",       MaterialDesignR.RECYCLE,                       CLR_SAVE);

--- a/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/or/ObjectPopupMenu.java
+++ b/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/or/ObjectPopupMenu.java
@@ -4,17 +4,15 @@ package com.ing.ide.main.mainui.components.testdesign.or;
 import com.ing.datalib.or.common.ORObjectInf;
 import com.ing.datalib.or.common.ORPageInf;
 import com.ing.datalib.or.common.ORRootInf;
-import com.ing.datalib.or.common.ObjectGroup;
-import com.ing.ide.main.utils.dnd.TransferActionListener;
+import com.ing.ide.main.mainui.components.testdesign.or.clipboard.ORClipboardManager;
+import com.ing.ide.main.mainui.components.testdesign.or.clipboard.ORObjectClipboard;
 import com.ing.ide.main.utils.keys.Keystroke;
 import com.ing.ide.util.Canvas;
 import java.awt.event.ActionListener;
 import java.awt.event.KeyEvent;
-import javax.swing.Action;
 import javax.swing.JMenuItem;
 import javax.swing.JPopupMenu;
 import javax.swing.KeyStroke;
-import javax.swing.TransferHandler;
 
 /**
  * Context (right-click) popup menu for Object Repository (OR) tree nodes in the Test Design UI.
@@ -42,7 +40,7 @@ public class ObjectPopupMenu extends JPopupMenu {
     private JMenuItem renameObject;
     private JMenuItem deleteObject;
     private JMenuItem removeUnusedObject;
-    private JMenuItem copyToShared;
+    private JMenuItem moveToShared;
 
     private JMenuItem openPageDump;
 
@@ -54,6 +52,8 @@ public class ObjectPopupMenu extends JPopupMenu {
     private JMenuItem sort;
 
     private final ActionListener listener;
+    
+    private Object currentSelection;
 
     public ObjectPopupMenu(ActionListener listener) {
         this.listener = listener;
@@ -65,68 +65,71 @@ public class ObjectPopupMenu extends JPopupMenu {
         add(renamePage = create("Rename Page", Keystroke.RENAME));
         add(deletePage = create("Delete Page", Keystroke.DELETE));
         addSeparator();
+        
         add(renameObjectGroup = create("Rename Object Group", Keystroke.RENAME));
         add(deleteObjectGroup = create("Delete Object Group", Keystroke.DELETE));
         addSeparator();
+        
         add(addObject = create("Add Object", Keystroke.NEW));
         add(renameObject = create("Rename Object", Keystroke.RENAME));
         add(deleteObject = create("Delete Object", Keystroke.DELETE));
         add(removeUnusedObject = create("Remove Unused Object",Keystroke.REMOVE_OBJECT));
         addSeparator();
-        copyToShared = create("Copy to Shared", null);
-        add(copyToShared);
 
-
+        moveToShared = create("Move to Shared", null);
+        moveToShared.setActionCommand("Move to Shared");
+        moveToShared.addActionListener(listener);
+        add(moveToShared);
         add(openPageDump = create("Open Page Dump", null));
         add(impactAnalysis = create("Get Impacted TestCases", null));
-
         addSeparator();
-
+        
         setCCP();
         addSeparator();
+        
         add(sort = create("Sort", null));
         sort.setIcon(Canvas.EmptyIcon);
     }
 
     public void togglePopupMenu(Object selected) {
-        copyToShared.setEnabled(false);
+        this.currentSelection = selected;
+        copy.setEnabled(false);
+        cut.setEnabled(false);
+        paste.setEnabled((currentSelection instanceof ORPageInf || currentSelection instanceof ORObjectInf)&& ORClipboardManager.hasData());
 
         if (selected instanceof ORRootInf) {
             forRoot();
             return;
         } else if (selected instanceof ORPageInf) {
             forPage();
-        } else if (selected instanceof ObjectGroup) {
-            forObjectGroup();
         } else if (selected instanceof ORObjectInf) {
             forObject();
         }
-        copyToShared.setEnabled(!isSharedSelection(selected));
-        removeUnusedObject.setEnabled(!isSharedSelection(selected));
+        moveToShared.setEnabled(!isSharedSelection(currentSelection));
     }
 
     private void forPage() {
+        addPage.setEnabled(false);
         renamePage.setEnabled(true);
         deletePage.setEnabled(true);
-
-        addPage.setEnabled(false);
+        
         renameObjectGroup.setEnabled(false);
         deleteObjectGroup.setEnabled(false);
-
+        
         addObject.setEnabled(true);
         renameObject.setEnabled(false);
         deleteObject.setEnabled(false);
-        removeUnusedObject.setEnabled(true);
+        removeUnusedObject.setEnabled(!isSharedSelection(currentSelection));
         
         impactAnalysis.setEnabled(false);
-
+        
         copy.setEnabled(true);
-        cut.setEnabled(true);
+        cut.setEnabled(isSameOR(currentSelection));
         paste.setEnabled(true);
 
         sort.setEnabled(true);
     }
-
+    
     private void forObjectGroup() {
         addPage.setEnabled(false);
         renamePage.setEnabled(false);
@@ -138,57 +141,58 @@ public class ObjectPopupMenu extends JPopupMenu {
         addObject.setEnabled(true);
         renameObject.setEnabled(false);
         deleteObject.setEnabled(false);
+        removeUnusedObject.setEnabled(false);
 
         impactAnalysis.setEnabled(true);
 
         copy.setEnabled(true);
-        cut.setEnabled(true);
+        cut.setEnabled(isSameOR(currentSelection));
         paste.setEnabled(true);
 
-        sort.setEnabled(false);
+        sort.setEnabled(true);
     }
 
     private void forObject() {
         addPage.setEnabled(false);
         renamePage.setEnabled(false);
         deletePage.setEnabled(false);
-
+        
         renameObjectGroup.setEnabled(false);
         deleteObjectGroup.setEnabled(false);
 
-        addObject.setEnabled(true);
+        addObject.setEnabled(false);
         renameObject.setEnabled(true);
         deleteObject.setEnabled(true);
+        removeUnusedObject.setEnabled(false);
 
         impactAnalysis.setEnabled(true);
 
         copy.setEnabled(true);
-        cut.setEnabled(true);
+        cut.setEnabled(isSameOR(currentSelection));
         paste.setEnabled(true);
 
         sort.setEnabled(false);
     }
 
     private void forRoot() {
+        boolean hasClipboard = ORClipboardManager.hasData();
+        
         addPage.setEnabled(true);
-        removeUnusedObject.setEnabled(false);
-
         renamePage.setEnabled(false);
         deletePage.setEnabled(false);
-
+        
         renameObjectGroup.setEnabled(false);
         deleteObjectGroup.setEnabled(false);
 
         addObject.setEnabled(false);
         renameObject.setEnabled(false);
         deleteObject.setEnabled(false);
+        removeUnusedObject.setEnabled(false);
 
         impactAnalysis.setEnabled(false);
-
-        copy.setEnabled(false);
-        cut.setEnabled(false);
-        paste.setEnabled(false);
-
+        
+        cut.setEnabled(isSameOR(currentSelection));
+        paste.setEnabled( hasClipboard && ORClipboardManager.get().getType() == ORObjectClipboard.Type.PAGE);
         sort.setEnabled(true);
     }
 
@@ -201,26 +205,25 @@ public class ObjectPopupMenu extends JPopupMenu {
     }
 
     private void setCCP() {
-        TransferActionListener actionListener = new TransferActionListener();
         cut = new JMenuItem("Cut");
-        cut.setActionCommand((String) TransferHandler.getCutAction().getValue(Action.NAME));
-        cut.addActionListener(actionListener);
+        cut.setActionCommand("Cut");           // for Pages
         cut.setAccelerator(Keystroke.CUT);
         cut.setMnemonic(KeyEvent.VK_T);
+        cut.addActionListener(listener);
         add(cut);
 
         copy = new JMenuItem("Copy");
-        copy.setActionCommand((String) TransferHandler.getCopyAction().getValue(Action.NAME));
-        copy.addActionListener(actionListener);
+        copy.setActionCommand("Copy");         // for Pages
         copy.setAccelerator(Keystroke.COPY);
         copy.setMnemonic(KeyEvent.VK_C);
+        copy.addActionListener(listener);
         add(copy);
 
         paste = new JMenuItem("Paste");
-        paste.setActionCommand((String) TransferHandler.getPasteAction().getValue(Action.NAME));
-        paste.addActionListener(actionListener);
+        paste.setActionCommand("Paste");       // for Pages
         paste.setAccelerator(Keystroke.PASTE);
         paste.setMnemonic(KeyEvent.VK_P);
+        paste.addActionListener(listener);
         add(paste);
     }
 
@@ -230,9 +233,8 @@ public class ObjectPopupMenu extends JPopupMenu {
             page = (ORPageInf) selected;
         } else if (selected instanceof ORObjectInf) {
             page = ((ORObjectInf) selected).getPage();
-        } else if (selected instanceof ObjectGroup) {
-            page = ((ObjectGroup) selected).getParent();
         }
+        
         if (page != null && page.getRoot() instanceof com.ing.datalib.or.web.WebOR) {
             com.ing.datalib.or.web.WebOR root = (com.ing.datalib.or.web.WebOR) page.getRoot();
             return root.isShared();
@@ -242,5 +244,28 @@ public class ObjectPopupMenu extends JPopupMenu {
             return root.isShared();
         }
         return false;
+    }
+    
+    private boolean isSameOR(Object selected) {
+        if (selected instanceof ORPageInf) {
+            return ((ORPageInf) selected).getParent() == getCurrentRoot();
+        }
+        if (selected instanceof ORObjectInf) {
+            return ((ORObjectInf) selected).getPage().getParent() == getCurrentRoot();
+        }
+        return false;
+    }
+
+    private ORRootInf getCurrentRoot() {
+        if (currentSelection instanceof ORRootInf) {
+            return (ORRootInf) currentSelection;
+        }
+        if (currentSelection instanceof ORPageInf) {
+            return (ORRootInf) ((ORPageInf) currentSelection).getParent();
+        }
+        if (currentSelection instanceof ORObjectInf) {
+            return (ORRootInf) ((ORObjectInf) currentSelection).getPage().getParent();
+        }
+        return null;
     }
 }

--- a/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/or/ObjectRepDnD.java
+++ b/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/or/ObjectRepDnD.java
@@ -4,6 +4,8 @@ package com.ing.ide.main.mainui.components.testdesign.or;
 import com.ing.datalib.or.common.ORObjectInf;
 import com.ing.datalib.or.common.ORPageInf;
 import com.ing.datalib.or.common.ObjectGroup;
+import com.ing.datalib.or.mobile.MobileOR;
+import com.ing.datalib.or.web.WebOR;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -102,11 +104,18 @@ public class ObjectRepDnD {
     }
     
     private String scopeOf(ORPageInf page) {
-        try {
-            var m = page.getClass().getMethod("getSource");
-            Object src = m.invoke(page);
-            if (src != null && src.toString().equalsIgnoreCase("SHARED")) return "SHARED";
-        } catch (Exception ignore) { }
+        if (page == null) {
+            return "PROJECT";
+        }
+        Object parent = page.getParent();
+        if (parent instanceof WebOR) {
+            WebOR root = (WebOR) parent;
+            return root.getScope().name();
+        }
+        if (parent instanceof MobileOR) {
+            MobileOR root = (MobileOR) parent;
+            return root.getScope().name();
+        }
         return "PROJECT";
     }
 

--- a/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/or/ObjectRepo.java
+++ b/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/or/ObjectRepo.java
@@ -4,7 +4,7 @@ package com.ing.ide.main.mainui.components.testdesign.or;
 import com.ing.ide.main.fx.FXPanelHeader;
 import com.ing.ide.main.fx.INGIcons;
 import com.ing.ide.main.mainui.components.testdesign.TestDesign;
-import com.ing.ide.main.mainui.components.testdesign.or.api.APIORPanel;
+import com.ing.ide.main.mainui.components.testdesign.or.structureddata.StructuredDataORPanel;
 import com.ing.ide.main.mainui.components.testdesign.or.mobile.MobileORPanel;
 import com.ing.ide.main.mainui.components.testdesign.or.web.WebORPanel;
 import java.awt.BorderLayout;
@@ -45,7 +45,7 @@ public class ObjectRepo extends JPanel implements ItemListener {
 
     private final MobileORPanel mobileOR;
 
-    private final APIORPanel apiOR;
+    private final StructuredDataORPanel structuredDataOR;
 
     public ObjectRepo(TestDesign testDesign) {
         this.testDesign = testDesign;
@@ -53,7 +53,7 @@ public class ObjectRepo extends JPanel implements ItemListener {
         repos = new JPanel();
         webOR = new WebORPanel(testDesign);
         mobileOR = new MobileORPanel(testDesign);
-        apiOR = new APIORPanel(testDesign);
+        structuredDataOR = new StructuredDataORPanel(testDesign);
         init();
     }
 
@@ -78,7 +78,7 @@ public class ObjectRepo extends JPanel implements ItemListener {
         repos.setOpaque(false);
         repos.add(webOR, "Web");
         repos.add(mobileOR, "Mobile");
-        repos.add(apiOR, "API");
+        repos.add(structuredDataOR, "Structured Data");
         switchToolBar.bgroup.getElements().nextElement().setSelected(true);
     }
 
@@ -97,8 +97,8 @@ public class ObjectRepo extends JPanel implements ItemListener {
                     case "Mobile":
                         mobileOR.adjustUI();
                         break;
-                    case "API":
-                        apiOR.adjustUI();
+                    case "StructuredData":
+                        structuredDataOR.adjustUI();
                         break;
                 }
             });
@@ -108,13 +108,13 @@ public class ObjectRepo extends JPanel implements ItemListener {
     public void load() {
         webOR.load();
         mobileOR.load();
-        apiOR.load();
+        structuredDataOR.load();
     }
 
     public void adjustUI() {
         webOR.adjustUI();
         mobileOR.adjustUI();
-        apiOR.adjustUI();
+        structuredDataOR.adjustUI();
     }
 
     public WebORPanel getWebOR() {
@@ -125,8 +125,8 @@ public class ObjectRepo extends JPanel implements ItemListener {
         return mobileOR;
     }
 
-    public APIORPanel getAPIOR() {
-        return apiOR;
+    public StructuredDataORPanel getStructuredDataOR() {
+        return structuredDataOR;
     }
 
     public Boolean navigateToObject(String objectName, String pageName) {
@@ -136,8 +136,8 @@ public class ObjectRepo extends JPanel implements ItemListener {
         } else if (mobileOR.navigateToObject(objectName, pageName)) {
             switchToolBar.mobileButton.setSelected(true);
             return true;
-        } else if (apiOR.navigateToObject(objectName, pageName)) {
-            switchToolBar.apiButton.setSelected(true);
+        } else if (structuredDataOR.navigateToObject(objectName, pageName)) {
+            switchToolBar.structuredDataButton.setSelected(true);
             return true;
         }
         return false;
@@ -150,7 +150,7 @@ public class ObjectRepo extends JPanel implements ItemListener {
         private JToggleButton webButton;
         //private JToggleButton imageButton;
         private JToggleButton mobileButton;
-        private JToggleButton apiButton;
+        private JToggleButton structuredDataButton;
 
         public SwitchToolBar() {
             init();
@@ -168,7 +168,7 @@ public class ObjectRepo extends JPanel implements ItemListener {
             add(webButton = create("Web", "or.Web"));
             //add(imageButton = create("Image"));
             add(mobileButton = create("Mobile", "or.Mobile"));
-            add(apiButton = create("API", "or.API"));
+            add(structuredDataButton = create("Structured Data", "or.StructuredData"));
         }
 
         private JToggleButton create(String text, String iconKey) {

--- a/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/or/ObjectTree.java
+++ b/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/or/ObjectTree.java
@@ -2,14 +2,22 @@
 package com.ing.ide.main.mainui.components.testdesign.or;
 
 import com.ing.datalib.component.Project;
+import com.ing.datalib.component.Scenario;
 import com.ing.datalib.component.TestCase;
+import com.ing.datalib.component.TestStep;
 import com.ing.datalib.or.ObjectRepository;
 import com.ing.datalib.or.common.ORObjectInf;
 import com.ing.datalib.or.common.ORPageInf;
 import com.ing.datalib.or.common.ORRootInf;
 import com.ing.datalib.or.common.ObjectGroup;
+import com.ing.datalib.or.mobile.MobileOR;
+import com.ing.datalib.or.mobile.MobileORObject;
+import com.ing.datalib.or.mobile.MobileORPage;
+import com.ing.datalib.or.mobile.ResolvedMobileObject;
 import com.ing.datalib.or.web.ResolvedWebObject;
 import com.ing.datalib.or.web.WebOR;
+import com.ing.datalib.or.web.WebORObject;
+import com.ing.datalib.or.web.WebORPage;
 import com.ing.ide.main.help.Help;
 
 import com.ing.ide.main.utils.keys.Keystroke;
@@ -31,6 +39,11 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import com.ing.ide.main.mainui.AppMainFrame;
+import com.ing.ide.main.mainui.components.testdesign.or.clipboard.ORClipboardManager;
+import com.ing.ide.main.mainui.components.testdesign.or.clipboard.ORObjectClipboard;
+import com.ing.ide.main.mainui.components.testdesign.or.mobile.MobileORPanel;
+import com.ing.ide.main.mainui.components.testdesign.or.mobile.MobileObjectTree;
+import com.ing.ide.main.mainui.components.testdesign.or.web.WebORPanel;
 import com.ing.ide.main.mainui.components.testdesign.or.web.WebObjectTree;
 import java.awt.Toolkit;
 import java.awt.event.KeyEvent;
@@ -52,7 +65,6 @@ import javax.swing.tree.DefaultTreeModel;
 import javax.swing.tree.TreeNode;
 import javax.swing.tree.TreePath;
 import java.io.File;
-import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerFactory;
@@ -62,12 +74,13 @@ import javax.xml.xpath.XPathConstants;
 import javax.xml.xpath.XPathExpression;
 import javax.xml.xpath.XPathFactory;
 import org.w3c.dom.Document;
-import org.w3c.dom.Element;
 import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Enumeration;
+import java.util.HashSet;
+import java.util.Iterator;
 
 /**
  * Base abstract class representing a fully interactive Object Repository (OR) tree.
@@ -300,8 +313,17 @@ public abstract class ObjectTree implements ActionListener {
             case "Open Page Dump":
                 openPageDump();
                 break;
-            case "Copy to Shared":
-                copyToShared();
+            case "Move to Shared":
+                moveToShared();
+                break;
+            case "Copy":
+                copySelection();
+                break;
+            case "Cut":
+                cutSelection();
+                break;
+            case "Paste":
+                pasteSelection();
                 break;
             default:
                 throw new UnsupportedOperationException();
@@ -471,116 +493,155 @@ public abstract class ObjectTree implements ActionListener {
             }
         }
     }
-    
+
     private void removeUnusedObject() {
+        boolean webDeletionPerformed = false;
+        boolean mobileDeletionPerformed = false;
         try {
-            Map<String, List> allORObject = new HashMap<String, List>();
-            Map<String, List> unUsedbject = new HashMap<String, List>();
-            List<String> objects = new ArrayList<>();
-            List<ORPageInf> pages = getSelectedPages();
-            if (!pages.isEmpty()) {
-                for (ORPageInf selectedPage : pages) {
-                    String page = selectedPage.toString();
-                    String orFilePath = getProject().getLocation() + "/OR.object";
-                    DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
-                    DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();
-                    Document doc = documentBuilder.parse(orFilePath);
-                    NodeList pageList = doc.getElementsByTagName("Page");
-                    for (int i = 0; i < pageList.getLength(); i++) {
-
-                        Node pageNode = pageList.item(i);
-                        if (pageNode.getNodeType() == Node.ELEMENT_NODE) {
-                            Element pageElement = (Element) pageNode;
-                            String pageName = pageElement.getAttribute("ref");
-                            if (pageName.equals(page)) {
-                                NodeList objectGroupNodeList = pageElement.getChildNodes();
-                                for (int j = 0; j < objectGroupNodeList.getLength(); j++) {
-
-                                    Node objectGroupNode = objectGroupNodeList.item(j);
-                                    if (objectGroupNode.getNodeType() == Node.ELEMENT_NODE) {
-                                        if (pageNode.getNodeType() == Node.ELEMENT_NODE) {
-                                            Element objectGroupElement = (Element) objectGroupNode;
-                                            NodeList objectList = objectGroupElement.getChildNodes();
-
-                                            for (int k = 0; k < objectList.getLength(); k++) {
-                                                Node objectNode = objectList.item(k);
-                                                if (objectNode.getNodeType() == Node.ELEMENT_NODE) {
-
-                                                    Element objectElement = (Element) objectNode;
-                                                    String objectName = objectElement.getAttribute("ref");
-                                                    if (!allORObject.containsKey(page)) {
-                                                        allORObject.put(page, new ArrayList<String>());
-                                                        allORObject.get(page).add(objectName);
-                                                    } else {
-                                                        allORObject.get(page).add(objectName);
-                                                    }
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
+            List<ORPageInf> selectedPages = getSelectedPages();
+            if (selectedPages == null || selectedPages.isEmpty()) {
+                return;
+            }
+            ObjectRepository repo = getProject().getObjectRepository();
+            WebOR projectWebOR = repo.getWebOR();
+            MobileOR projectMobileOR = repo.getMobileOR();
+            Set<String> usedProjectObjects = new HashSet<>();
+            for (Scenario scenario : getProject().getAllScenarios()) {
+                for (TestCase testCase : scenario.getTestCases()) {
+                    testCase.loadTableModel();
+                    for (TestStep step : testCase.getTestSteps()) {
+                        if (!step.isPageObjectStep()) {
+                            continue;
+                        }
+                        String ref = step.getReference();
+                        if (ref == null || ref.isBlank()) {
+                            continue;
+                        }
+                        String pageName = normalizePageRef(ref);
+                        String objectName = step.getObject();
+                        if (!pageName.isBlank() && !objectName.isBlank()) {
+                            usedProjectObjects.add(pageName + "@" + objectName);
+                        }
+                    }
+                }
+            }
+            for (ORPageInf selectedPage : selectedPages) {
+                String pageName = selectedPage.getName();
+                WebORPage webPage = projectWebOR.getPageByName(pageName);
+                if (webPage == null) {
+                    continue;
+                }
+                List<String> unusedWebObjects = new ArrayList<>();
+                for (ObjectGroup group : webPage.getObjectGroups()) {
+                    if (!usedProjectObjects.contains(pageName + "@" + group.getName())) {
+                        unusedWebObjects.add(group.getName());
+                    }
+                }
+                if (!unusedWebObjects.isEmpty()) {
+                    int option = JOptionPane.showConfirmDialog(
+                        null,
+                        "<html><body><p style='width: 260px;'>"
+                        + "Delete the following Web objects from page [ "
+                        + pageName + " ]?<br>"
+                        + unusedWebObjects
+                        + "</p></body></html>",
+                        "Delete Web Objects",
+                        JOptionPane.YES_NO_OPTION
+                    );
+                    if (option == JOptionPane.YES_OPTION) {
+                        Iterator<ObjectGroup<WebORObject>> it = webPage.getObjectGroups().iterator();
+                        while (it.hasNext()) {
+                            ObjectGroup group = it.next();
+                            if (unusedWebObjects.contains(group.getName())) {
+                                it.remove();
+                                projectWebOR.setSaved(false);
+                                webDeletionPerformed = true;
                             }
                         }
-                    }
-                }
-            }
-            unUsedbject = UnusedObject(allORObject, usedObject());
-            int unusedObjectCount = 0;
-            for (String page : unUsedbject.keySet()) {
-
-                List<String> unUsedobjects = unUsedbject.get(page);
-                if (!unUsedobjects.isEmpty()) {
-                    unusedObjectCount = unusedObjectCount + 1;
-                    int option = JOptionPane.showConfirmDialog(null,
-                            "<html><body><p style='width: 200px;'>"
-                            + "Are you sure want to delete the following Objects from page [ "
-                            + page
-                            + " ]"
-                            + " ?<br>"
-                            + unUsedobjects
-                            + "</p></body></html>",
-                            "Delete Objects",
-                            JOptionPane.YES_NO_OPTION);
-                    if (option == JOptionPane.YES_OPTION) {
-                        for (String objectName : unUsedobjects) {
-                            deleteUnusedObject(page, objectName);
-
+                        if (webDeletionPerformed) {
+                            repo.saveWebPageNow(webPage);
                         }
-
                     }
                 }
-
             }
-            if (unusedObjectCount != 0) {
-                int option = JOptionPane.showConfirmDialog(null,
-                        "<html><body><p style='width: 200px;'>"
-                        + "Do you want to restart INGenious to load updated Object Repository ?"
-                        + " <br>"
+            for (ORPageInf selectedPage : selectedPages) {
+                String pageName = selectedPage.getName();
+                MobileORPage mobilePage = projectMobileOR.getPageByName(pageName);
+                if (mobilePage == null) {
+                    continue;
+                }
+                List<String> unusedMobileObjects = new ArrayList<>();
+                for (ObjectGroup group : mobilePage.getObjectGroups()) {
+                    if (!usedProjectObjects.contains(pageName + "@" + group.getName())) {
+                        unusedMobileObjects.add(group.getName());
+                    }
+                }
+                if (!unusedMobileObjects.isEmpty()) {
+                    int option = JOptionPane.showConfirmDialog(
+                        null,
+                        "<html><body><p style='width: 260px;'>"
+                        + "Delete the following Mobile objects from page [ "
+                        + pageName + " ]?<br>"
+                        + unusedMobileObjects
                         + "</p></body></html>",
-                        "Restart INGenious",
-                        JOptionPane.YES_NO_OPTION);
+                        "Delete Mobile Objects",
+                        JOptionPane.YES_NO_OPTION
+                    );
+                    if (option == JOptionPane.YES_OPTION) {
+                        Iterator<ObjectGroup<MobileORObject>> it = mobilePage.getObjectGroups().iterator();
+                        while (it.hasNext()) {
+                            ObjectGroup group = it.next();
+                            if (unusedMobileObjects.contains(group.getName())) {
+                                it.remove();
+                                projectMobileOR.setSaved(false);
+                                mobileDeletionPerformed = true;
+                            }
+                        }
+                        if (mobileDeletionPerformed) {
+                            repo.saveMobilePageNow(mobilePage);
+                        }
+                    }
+                }
+            }
+            if (webDeletionPerformed || mobileDeletionPerformed) {
+                repo.save();
+                int option = JOptionPane.showConfirmDialog(
+                    null,
+                    "<html><body><p style='width: 260px;'>"
+                    + "Do you want to restart INGenious to load the updated Object Repository?"
+                    + "</p></body></html>",
+                    "Restart INGenious",
+                    JOptionPane.YES_NO_OPTION
+                );
                 if (option == JOptionPane.YES_OPTION) {
-                    AppMainFrame s = new AppMainFrame();
-                    s.restart();
+                    new AppMainFrame().restart();
                 }
             } else {
-                 
-                 JOptionPane.showMessageDialog(null,
-                        "<html><body><p style='width: 200px;'>"
-                        + "No unused object found"
-                        + " <br>"
-                        + "</p></body></html>",
-                        "Unused Object",
-                        JOptionPane.OK_OPTION);
+                JOptionPane.showMessageDialog(
+                    null,
+                    "<html><body><p style='width: 240px;'>"
+                    + "No unused object found or removal was cancelled."
+                    + "</p></body></html>",
+                    "Unused Object",
+                    JOptionPane.INFORMATION_MESSAGE
+                );
             }
-
+            ((DefaultTreeModel) tree.getModel()).reload();
+            tree.updateUI();
         } catch (Exception e) {
             e.printStackTrace();
         }
+    }
 
+    private String normalizePageRef(String ref) {
+        if (ref == null) return "";
+        ref = ref.trim();
+        if (ref.startsWith("[Project] ")) return ref.substring(10).trim();
+        if (ref.startsWith("[Shared] "))  return ref.substring(9).trim();
+        return ref;
     }
     
-        public Map usedObject() {   
+    public Map usedObject() {   
         Map<String, ArrayList<String>> attributeMap = new HashMap<>();
         ArrayList<String> records = new ArrayList<>();
         try {
@@ -821,121 +882,108 @@ public abstract class ObjectTree implements ActionListener {
         }
     }
 
-    private void copyToShared() {
-        ORObjectInf obj = getSelectedObject();
-        ObjectGroup group = getSelectedObjectGroup();
-        ORPageInf selectedPage = getSelectedPage();
-
-        if (obj == null && group == null && selectedPage == null) {
-            com.ing.ide.util.Notification.show("Select an Object, Object Group, or Page.");
+    private void moveToShared() {
+        if (isSharedScope()) {
+            Notification.show("Objects already in Shared Repository");
             return;
         }
-
-        ORPageInf page = (obj != null) ? obj.getPage()
-                : (group != null) ? group.getParent()
-                : selectedPage;
-
-        ObjectRepository repo = getProject().getObjectRepository();
-
-        ORRootInf root = getOR();
-        boolean isWeb = (root instanceof com.ing.datalib.or.web.WebOR);
-        boolean isMobile = (root instanceof com.ing.datalib.or.mobile.MobileOR);
-
-        if (obj == null && group == null && selectedPage != null) {
-            if (isWeb) {
-                String newName = repo.copyWebPage(page.getName(), page.getName());
-                if (newName != null) {
-                    com.ing.ide.util.Notification.show("Copied Page '" + page.getName() + "' to Shared Web Object successfully as '" + newName + "'.");
-                } else {
-                    com.ing.ide.util.Notification.show("Copy failed. Could not copy Page '" + page.getName() + "' to Shared Web Objects.");
-                }
-                if (newName != null) {
-                    if (this instanceof com.ing.ide.main.mainui.components.testdesign.or.web.WebObjectTree) {
-                        com.ing.ide.main.mainui.components.testdesign.or.web.WebORPanel panel =
-                            ((com.ing.ide.main.mainui.components.testdesign.or.web.WebObjectTree) this).getORPanel();
-                        panel.getSharedTree().load();
-                    } else {
-                        reload();
-                    }
-                }
-                return;
-            } else if (isMobile) {
-                String newName = repo.copyMobilePage(page.getName(), page.getName());
-                if (newName != null) {
-                    com.ing.ide.util.Notification.show("Copied Page '" + page.getName() + "' to Shared Mobile Object successfully as '" + newName + "'.");
-                } else {
-                    com.ing.ide.util.Notification.show("Copy failed. Could not copy Page '" + page.getName() + "' to Shared Mobile Objects.");
-                }
-                if (newName != null) {
-                    if (this instanceof com.ing.ide.main.mainui.components.testdesign.or.mobile.MobileObjectTree) {
-                        com.ing.ide.main.mainui.components.testdesign.or.mobile.MobileORPanel panel =
-                            ((com.ing.ide.main.mainui.components.testdesign.or.mobile.MobileObjectTree) this).getORPanel();
-                        panel.getSharedTree().load();
-                    } else {
-                        reload();
-                    }
-                }
-                return;
-            }
+        if (getSelectedObject() != null) {
+            moveObjectToShared(getSelectedObject());
+            return;
         }
+        if (getSelectedPage() != null) {
+            movePageToShared(getSelectedPage());
+        }
+    }
 
-        String objectName = (obj != null) ? obj.getName() : group.getName();
-
+    private void moveObjectToShared(ORObjectInf obj) {
+        ObjectRepository repo = getProject().getObjectRepository();
+        ORPageInf page = obj.getPage();
+        ORRootInf root = getOR();
+        boolean isWeb = root instanceof WebOR;
+        boolean isMobile = root instanceof MobileOR;
+        String objectName = obj.getName().toString();
         if (isWeb) {
             ResolvedWebObject resolved =
                 repo.resolveWebObject(
-                    new ResolvedWebObject.PageRef(page.getName(), com.ing.datalib.or.web.WebOR.ORScope.PROJECT),
-                    objectName
-                );
-            if (resolved == null) {
-                com.ing.ide.util.Notification.show("Object '" + objectName + "' not found in Project OR (Page '" + page.getName() + "').");
-                return;
-            }
-
-            String copiedName = repo.copyWebObject(resolved, page.getName());
-            if (copiedName != null) {
-                com.ing.ide.util.Notification.show("Copied Object '" + copiedName + "' from Page '" + page.getName() + "' to Shared Web Object successfully.");
-            } else {
-                com.ing.ide.util.Notification.show("Copy failed. Could not copy Object '" + objectName + "' to Shared Web Object (Page '" + page.getName() + "').");
-            }
-            if (copiedName != null) {
-                if (this instanceof com.ing.ide.main.mainui.components.testdesign.or.web.WebObjectTree) {
-                    com.ing.ide.main.mainui.components.testdesign.or.web.WebORPanel panel =
-                        ((com.ing.ide.main.mainui.components.testdesign.or.web.WebObjectTree) this).getORPanel();
-                    panel.getSharedTree().load();
-                } else {
-                    reload();
-                }
-            }
-        } else if (isMobile) {
-            com.ing.datalib.or.mobile.ResolvedMobileObject mresolved =
-                repo.resolveMobileObject(
-                    new com.ing.datalib.or.mobile.ResolvedMobileObject.PageRef(
+                    new ResolvedWebObject.PageRef(
                         page.getName(),
-                        com.ing.datalib.or.web.WebOR.ORScope.PROJECT
+                        WebOR.ORScope.PROJECT
                     ),
                     objectName
                 );
-            if (mresolved == null) {
-                com.ing.ide.util.Notification.show("Object '" + objectName + "' not found in Project Mobile OR (Page '" + page.getName() + "').");
+            if (resolved == null) {
+                Notification.show("Object not found in Project OR");
                 return;
             }
+            String newName = repo.moveWebObject(resolved, page.getName());
+            if (newName != null) {
+                objectRemoved(obj);
+                obj.removeFromParent();
+                repo.save();
+                refreshSharedTree();
+                Notification.show("Moved Object '" + newName + "' to Shared OR");
+            }
+        }
+        if (isMobile) {
+            ResolvedMobileObject resolved =
+                repo.resolveMobileObject(
+                    new ResolvedMobileObject.PageRef(
+                        page.getName(),
+                        WebOR.ORScope.PROJECT
+                    ),
+                    objectName
+                );
+            if (resolved == null || !resolved.isPresent()) {
+                Notification.show("Mobile Object not found in Project OR");
+                return;
+            }
+            String newName = repo.moveMobileObject(resolved, page.getName());
+            if (newName != null) {
+                objectRemoved(obj);
+                obj.removeFromParent();
+                repo.save();
+                refreshSharedTree();
+                Notification.show("Moved Mobile Object '" + newName + "' to Shared OR");
+            }
+        }
+    }
 
-            String copiedName = repo.copyMobileObject(mresolved, page.getName());
-            if (copiedName != null) {
-                com.ing.ide.util.Notification.show("Copied Object '" + copiedName + "' from Page '" + page.getName() + "' to Shared Mobile Object successfully.");
-            } else {
-                com.ing.ide.util.Notification.show("Copy failed. Could not copy Object '" + objectName + "' to Shared Mobile Object (Page '" + page.getName() + "').");
+    private void movePageToShared(ORPageInf page) {
+        ObjectRepository repo = getProject().getObjectRepository();
+        ORRootInf root = getOR();
+        boolean isWeb = root instanceof WebOR;
+        boolean isMobile = root instanceof MobileOR;
+        if (isWeb) {
+            String newPageName = repo.copyWebPage(page.getName(), page.getName());
+            if (newPageName != null) {
+                pageRemoved(page);
+                page.removeFromParent();
+                repo.save();
+                refreshSharedTree();
+                Notification.show( "Moved Page '" + page.getName() + "' to Shared OR");
             }
-            if (copiedName != null) {
-                if (this instanceof com.ing.ide.main.mainui.components.testdesign.or.mobile.MobileObjectTree) {
-                    com.ing.ide.main.mainui.components.testdesign.or.mobile.MobileORPanel panel =
-                        ((com.ing.ide.main.mainui.components.testdesign.or.mobile.MobileObjectTree) this).getORPanel();
-                    panel.getSharedTree().load();
-                } else {
-                    reload();
-                }
+        }
+        if (isMobile) {
+            String newPageName = repo.copyMobilePage(page.getName(), page.getName());
+            if (newPageName != null) {
+                pageRemoved(page);
+                page.removeFromParent();
+                repo.save();
+                refreshSharedTree();
+                Notification.show("Moved Mobile Page '" + page.getName() + "' to Shared OR");
             }
+        }
+    }
+
+    private void refreshSharedTree() {
+        if (this instanceof WebObjectTree) {
+            WebORPanel panel = ((WebObjectTree) this).getORPanel();
+            panel.getSharedTree().load();
+
+        } else if (this instanceof MobileObjectTree) {
+            MobileORPanel panel = ((MobileObjectTree) this).getORPanel();
+            panel.getSharedTree().load();
         }
     }
 
@@ -1117,4 +1165,417 @@ public abstract class ObjectTree implements ActionListener {
         }
         return "";
     }
+    
+    private void pasteObject() {
+        if (!ORClipboardManager.hasData()) {
+            return;
+        }
+        ORObjectClipboard cb = ORClipboardManager.get();
+        ORObjectInf source = cb.getObject();
+        boolean cut = cb.isCut();
+        ORPageInf targetPage = getSelectedPage();
+        if (targetPage == null && getSelectedObjectGroup() != null) {
+            targetPage = getSelectedObjectGroup().getParent();
+        }
+        if (targetPage == null || source == null) {
+            return;
+        }
+        ORRootInf currentOR = getOR();
+        ORRootInf sourceOR  = (ORRootInf) source.getPage().getParent();
+        ObjectGroup sourceGroup = source.getParent();
+        ObjectRepository repo = getProject().getObjectRepository();
+        if (cut && sourceOR instanceof WebOR && ((WebOR) sourceOR).isShared() && currentOR instanceof WebOR && !((WebOR) currentOR).isShared()) {
+            Notification.show("Cut is not allowed from Shared to Project Object Repository");
+            return;
+        }
+        if (cut && sourceOR instanceof MobileOR && ((MobileOR) sourceOR).isShared() && currentOR instanceof MobileOR && !((MobileOR) currentOR).isShared()) {
+            Notification.show("Cut is not allowed from Shared to Project Object Repository");
+            return;
+        }
+        if (cut && sourceOR instanceof WebOR && !((WebOR) sourceOR).isShared() && currentOR instanceof WebOR && ((WebOR) currentOR).isShared()) {
+            Notification.show("Cut is not allowed in Shared Object Repository. Use `Move to Shared` instead.");
+            return;
+        }
+        if (cut && sourceOR instanceof MobileOR && !((MobileOR) sourceOR).isShared() && currentOR instanceof MobileOR && ((MobileOR) currentOR).isShared()) {
+            Notification.show("Cut is not allowed in Shared Object Repository. Use `Move to Shared` instead.");
+            return;
+        }
+        if (sourceOR == currentOR) {
+            String newGroupName;
+            if (!cut) {
+                newGroupName = computeCopyName(
+                    targetPage,
+                    (ORObjectInf) sourceGroup.getObjects().get(0)
+                );
+            } else {
+                if (targetPage.getObjectGroupByName(sourceGroup.getName()) != null) {
+                    newGroupName = computeCopyName(
+                        targetPage,
+                        (ORObjectInf) sourceGroup.getObjects().get(0)
+                    );
+                } else {
+                    newGroupName = sourceGroup.getName();
+                }
+            }
+            ObjectGroup newGroup = new ObjectGroup(newGroupName, targetPage);
+            if (currentOR instanceof WebOR) {
+                for (Object o : sourceGroup.getObjects()) {
+                    WebORObject srcObj = (WebORObject) o;
+                    String newObjectName;
+                    if (!cut) {
+                        newObjectName = computeCopyName(targetPage, srcObj);
+                    } else {
+                        if (objectNameExists(targetPage, srcObj.getName())) {
+                            newObjectName = computeCopyName(targetPage, srcObj);
+                        } else {
+                            newObjectName = srcObj.getName();
+                        }
+                    }
+                    WebORObject cloned = new WebORObject();
+                    cloned.setName(newObjectName);
+                    cloned.setParent(newGroup);
+                    srcObj.clone(cloned);
+                    newGroup.getObjects().add(cloned);
+                }
+                targetPage.getObjectGroups().add(newGroup);
+                ((WebOR) currentOR).setSaved(false);
+                repo.saveWebPageNow((WebORPage) targetPage);
+            }
+            else if (currentOR instanceof MobileOR) {
+                for (Object o : sourceGroup.getObjects()) {
+                    MobileORObject srcObj = (MobileORObject) o;
+                    String newObjectName;
+                    if (!cut) {
+                        newObjectName = computeCopyName(targetPage, srcObj);
+                    } else {
+                        if (objectNameExists(targetPage, srcObj.getName())) {
+                            newObjectName = computeCopyName(targetPage, srcObj);
+                        } else {
+                            newObjectName = srcObj.getName();
+                        }
+                    }
+                    MobileORObject cloned = new MobileORObject();
+                    cloned.setName(newObjectName);
+                    cloned.setParent(newGroup);
+                    srcObj.clone(cloned);
+                    newGroup.getObjects().add(cloned);
+                }
+                targetPage.getObjectGroups().add(newGroup);
+                ((MobileOR) currentOR).setSaved(false);
+                repo.saveMobilePageNow((MobileORPage) targetPage);
+            }
+            if (cut) {
+                ORPageInf sourcePage = source.getPage();
+                objectRemoved(source);
+                sourceGroup.removeFromParent();
+                ORClipboardManager.clear();
+                if (sourceOR instanceof WebOR) {
+                    ((WebOR) sourceOR).setSaved(false);
+                    repo.saveWebPageNow((WebORPage) sourcePage);
+                } else if (sourceOR instanceof MobileOR) {
+                    ((MobileOR) sourceOR).setSaved(false);
+                    repo.saveMobilePageNow((MobileORPage) sourcePage);
+                }
+            }
+            reload();
+            return;
+        }
+        if (currentOR instanceof WebOR && !((WebOR) currentOR).isShared() && sourceOR instanceof WebOR && ((WebOR) sourceOR).isShared()) {
+            String baseName = sourceGroup.getName().replaceAll("_Copy_\\d+$", "");
+            String newGroupName;
+            int i = 1;
+            do {
+                newGroupName = baseName + "_Copy_" + i++;
+            } while (targetPage.getObjectGroupByName(newGroupName) != null);
+            ObjectGroup<WebORObject> newGroup = new ObjectGroup<>(newGroupName, (WebORPage) targetPage);
+            for (Object o : sourceGroup.getObjects()) {
+                WebORObject srcObj = (WebORObject) o;
+                WebORObject cloned = new WebORObject();
+                cloned.setName(newGroupName);
+                cloned.setParent(newGroup);
+                srcObj.clone(cloned);
+                newGroup.getObjects().add(cloned);
+            }
+            targetPage.getObjectGroups().add(newGroup);
+            reload();
+            return;
+        }
+        if (currentOR instanceof WebOR) {
+            ResolvedWebObject resolved =
+                repo.resolveWebObjectWithScope(
+                    source.getPage().getName(),
+                    sourceGroup.getName()
+                );
+            if (resolved == null) {
+                Notification.show("Failed to resolve Web object");
+                return;
+            }
+            repo.copyWebObject(resolved, targetPage.getName());
+            if (cut) {
+                objectRemoved(source);
+                source.removeFromParent();
+                ORClipboardManager.clear();
+            }
+            reload();
+            return;
+        }
+        if (currentOR instanceof MobileOR) {
+            ResolvedMobileObject resolved =
+                repo.resolveMobileObjectWithScope(
+                    source.getPage().getName(),
+                    sourceGroup.getName()
+                );
+            if (resolved == null || !resolved.isPresent()) {
+                Notification.show("Failed to resolve Mobile object");
+                return;
+            }
+            repo.copyMobileObject(resolved, targetPage.getName());
+            if (cut) {
+                objectRemoved(source);
+                source.removeFromParent();
+                ORClipboardManager.clear();
+            }
+            reload();
+        }
+    }
+
+    private String computeCopyName(ORPageInf page, ORObjectInf source) {
+        String original = source.getName();
+        String base = original.replaceAll("_Copy_\\d+$", "");
+        int index = 1;
+        String candidate;
+        do {
+            candidate = base + "_Copy_" + index++;
+        } while (objectNameExists(page, candidate));
+        return candidate;
+    }
+
+    private boolean objectNameExists(ORPageInf page, String name) {
+        for (Object groupObj : page.getObjectGroups()) {
+            ObjectGroup group = (ObjectGroup) groupObj;
+            Enumeration<?> children = group.children();
+            while (children.hasMoreElements()) {
+                Object child = children.nextElement();
+                if (child instanceof ORObjectInf) {
+                    ORObjectInf obj = (ORObjectInf) child;
+                    if (name.equals(obj.getName())) {
+                        return true;
+                    }
+                }
+            }
+        }
+        return false;
+    }
+    
+    private void copySelection() {
+        if (getSelectedObject() != null) {
+            ORClipboardManager.copy(getSelectedObject());
+            return;
+        }
+        if (getSelectedPage() != null) {
+            ORClipboardManager.copy(getSelectedPage());
+        }
+    }
+    private void cutSelection() {
+        if (getSelectedObject() != null) {
+            ORObjectInf obj = getSelectedObject();
+            ORRootInf sourceOR = (ORRootInf) obj.getPage().getParent();
+            ORRootInf currentOR = getOR();
+            if (sourceOR != currentOR) {
+                Notification.show("Cut is allowed only within the same Object Repository.");
+                return;
+            }
+            ORClipboardManager.cut(obj);
+            return;
+        }
+        if (getSelectedPage() != null) {
+            ORPageInf page = getSelectedPage();
+            ORRootInf sourceOR = (ORRootInf) page.getParent();
+            ORRootInf currentOR = getOR();
+            if (sourceOR != currentOR) {
+                Notification.show("Cut is allowed only within the same Object Repository.");
+                return;
+            }
+            ORClipboardManager.cut(page);
+        }
+    }
+
+    private void pasteSelection() {
+        if (!ORClipboardManager.hasData()) {
+            return;
+        }
+        ORObjectClipboard cb = ORClipboardManager.get();
+        if (cb.getType() == ORObjectClipboard.Type.OBJECT) {
+            pasteObject();
+            return;
+        }
+        if (cb.getType() == ORObjectClipboard.Type.PAGE) {
+            pastePage();
+        }
+    }
+
+    private void pastePage() {
+        if (!ORClipboardManager.hasData()) {
+            return;
+        }
+        ORObjectClipboard cb = ORClipboardManager.get();
+        ORPageInf sourcePage = cb.getPage();
+        boolean cut = cb.isCut();
+        if (sourcePage == null) {
+            return;
+        }
+        ORRootInf currentOR = getOR();
+        ORRootInf sourceOR = (ORRootInf) sourcePage.getParent();
+        ObjectRepository repo = getProject().getObjectRepository();
+        if (cut && sourceOR instanceof WebOR && ((WebOR) sourceOR).isShared() && currentOR instanceof WebOR && !((WebOR) currentOR).isShared()) {
+            Notification.show("Cut is not allowed from Shared to Project Object Repository"
+            );
+            return;
+        }
+        if (cut && sourceOR instanceof MobileOR && ((MobileOR) sourceOR).isShared() && currentOR instanceof MobileOR && !((MobileOR) currentOR).isShared()) {
+            Notification.show("Cut is not allowed from Shared to Project Object Repository"
+            );
+            return;
+        }
+        if (cut && sourceOR instanceof WebOR && !((WebOR) sourceOR).isShared() && currentOR instanceof WebOR && ((WebOR) currentOR).isShared()) {
+            Notification.show( "Cut is not allowed in Shared Object Repository. Use `Move to Shared` instead.");
+            return;
+        }
+        if (cut && sourceOR instanceof MobileOR && !((MobileOR) sourceOR).isShared() && currentOR instanceof MobileOR && ((MobileOR) currentOR).isShared()) {
+            Notification.show( "Cut is not allowed in Shared Object Repository. Use `Move to Shared` instead.");
+            return;
+        }
+        if (sourceOR == currentOR) {
+            String newPageName = cut
+                ? sourcePage.getName()
+                : computeCopyPageName(sourcePage);
+            ORPageInf newPage = getOR().addPage(newPageName);
+            if (currentOR instanceof WebOR) {
+                WebORPage srcPage = (WebORPage) sourcePage;
+                WebORPage tgtPage = (WebORPage) newPage;
+                for (Object g : srcPage.getObjectGroups()) {
+                    ObjectGroup srcGroup = (ObjectGroup) g;
+                    ObjectGroup newGroup = new ObjectGroup(srcGroup.getName(), tgtPage);
+                    for (Object o : srcGroup.getObjects()) {
+                        WebORObject srcObj = (WebORObject) o;
+                        WebORObject cloned = new WebORObject();
+                        cloned.setName(srcObj.getName());
+                        cloned.setParent(newGroup);
+                        srcObj.clone(cloned);
+                        newGroup.getObjects().add(cloned);
+                    }
+                    tgtPage.getObjectGroups().add(newGroup);
+                }
+            }
+            else if (currentOR instanceof MobileOR) {
+                MobileORPage srcPage = (MobileORPage) sourcePage;
+                MobileORPage tgtPage = (MobileORPage) newPage;
+                for (Object g : srcPage.getObjectGroups()) {
+                    ObjectGroup srcGroup = (ObjectGroup) g;
+                    ObjectGroup newGroup = new ObjectGroup(srcGroup.getName(), tgtPage);
+                    for (Object o : srcGroup.getObjects()) {
+                        MobileORObject srcObj = (MobileORObject) o;
+                        MobileORObject cloned = new MobileORObject();
+                        cloned.setName(srcObj.getName());
+                        cloned.setParent(newGroup);
+                        srcObj.clone(cloned);
+                        newGroup.getObjects().add(cloned);
+                    }
+                    tgtPage.getObjectGroups().add(newGroup);
+                }
+            }
+            pageAdded(newPage);
+            if (cut) {
+                pageRemoved(sourcePage);
+                sourcePage.removeFromParent();
+                ORClipboardManager.clear();
+            }
+            reload();
+            return;
+        }
+        if (currentOR instanceof WebOR && !((WebOR) currentOR).isShared() && sourceOR instanceof WebOR && ((WebOR) sourceOR).isShared()) {
+            String newPageName = cut
+                ? sourcePage.getName()
+                : computeCopyPageName(sourcePage);
+            ORPageInf newPage = getOR().addPage(newPageName);
+            WebORPage srcPage = (WebORPage) sourcePage;
+            WebORPage tgtPage = (WebORPage) newPage;
+            for (Object g : srcPage.getObjectGroups()) {
+                ObjectGroup srcGroup = (ObjectGroup) g;
+                ObjectGroup newGroup = new ObjectGroup(srcGroup.getName(), tgtPage);
+                for (Object o : srcGroup.getObjects()) {
+                    WebORObject srcObj = (WebORObject) o;
+                    WebORObject cloned = new WebORObject();
+                    cloned.setName(srcObj.getName());
+                    cloned.setParent(newGroup);
+                    srcObj.clone(cloned);
+                    newGroup.getObjects().add(cloned);
+                }
+                tgtPage.getObjectGroups().add(newGroup);
+            }
+            pageAdded(newPage);
+            reload();
+            return;
+        }
+        if (currentOR instanceof MobileOR && !((MobileOR) currentOR).isShared() && sourceOR instanceof MobileOR && ((MobileOR) sourceOR).isShared()) {
+            String newPageName = cut
+                ? sourcePage.getName()
+                : computeCopyPageName(sourcePage);
+            ORPageInf newPage = getOR().addPage(newPageName);
+            MobileORPage srcPage = (MobileORPage) sourcePage;
+            MobileORPage tgtPage = (MobileORPage) newPage;
+            for (Object g : srcPage.getObjectGroups()) {
+                ObjectGroup srcGroup = (ObjectGroup) g;
+                ObjectGroup newGroup = new ObjectGroup(srcGroup.getName(), tgtPage);
+                for (Object o : srcGroup.getObjects()) {
+                    MobileORObject srcObj = (MobileORObject) o;
+                    MobileORObject cloned = new MobileORObject();
+                    cloned.setName(srcObj.getName());
+                    cloned.setParent(newGroup);
+                    srcObj.clone(cloned);
+                    newGroup.getObjects().add(cloned);
+                }
+                tgtPage.getObjectGroups().add(newGroup);
+            }
+            pageAdded(newPage);
+            reload();
+            return;
+        }
+        if (currentOR instanceof WebOR) {
+            String targetName = cut
+                ? sourcePage.getName()
+                : computeCopyPageName(sourcePage);
+            repo.copyWebPage(sourcePage.getName(), targetName);
+            if (cut) {
+                pageRemoved(sourcePage);
+                sourcePage.removeFromParent();
+                ORClipboardManager.clear();
+            }
+            reload();
+            return;
+        }
+        if (currentOR instanceof MobileOR) {
+            String targetName = cut
+                ? sourcePage.getName()
+                : computeCopyPageName(sourcePage);
+            repo.copyMobilePage(sourcePage.getName(), targetName);
+            if (cut) {
+                pageRemoved(sourcePage);
+                sourcePage.removeFromParent();
+                ORClipboardManager.clear();
+            }
+            reload();
+        }
+    }
+
+    private String computeCopyPageName(ORPageInf source) {
+        String base = source.getName().replaceAll("_Copy_\\d+$", "");
+        int i = 1;
+        String candidate;
+        do {
+            candidate = base + "_Copy_" + i++;
+        } while (getOR().getPageByName(candidate) != null);
+        return candidate;
+    }
+
 }

--- a/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/or/clipboard/ORClipboardManager.java
+++ b/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/or/clipboard/ORClipboardManager.java
@@ -1,0 +1,42 @@
+
+package com.ing.ide.main.mainui.components.testdesign.or.clipboard;
+
+import com.ing.datalib.or.common.ORObjectInf;
+import com.ing.datalib.or.common.ORPageInf;
+
+/**
+ * Simple application-level clipboard manager
+ * for OR objects.
+ */
+public final class ORClipboardManager {
+
+    private static ORObjectClipboard clipboard;
+
+    public static void copy(ORObjectInf object) {
+        clipboard = new ORObjectClipboard(object, false);
+    }
+
+    public static void cut(ORObjectInf object) {
+        clipboard = new ORObjectClipboard(object, true);
+    }
+
+    public static void copy(ORPageInf page) {
+        clipboard = new ORObjectClipboard(page, false);
+    }
+
+    public static void cut(ORPageInf page) {
+        clipboard = new ORObjectClipboard(page, true);
+    }
+
+    public static boolean hasData() {
+        return clipboard != null;
+    }
+
+    public static ORObjectClipboard get() {
+        return clipboard;
+    }
+
+    public static void clear() {
+        clipboard = null;
+    }
+}

--- a/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/or/clipboard/ORObjectClipboard.java
+++ b/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/or/clipboard/ORObjectClipboard.java
@@ -1,0 +1,48 @@
+
+package com.ing.ide.main.mainui.components.testdesign.or.clipboard;
+
+import com.ing.datalib.or.common.ORObjectInf;
+import com.ing.datalib.or.common.ORPageInf;
+
+/**
+ * Holds a single OR object in clipboard along with
+ * the action type (copy or cut).
+ *
+ * This is a UI-level helper class.
+ */
+public class ORObjectClipboard {
+
+    public enum Type { OBJECT, PAGE }
+
+    private final Object data;     // ORObjectInf or ORPageInf
+    private final boolean cut;
+    private final Type type;
+
+    public ORObjectClipboard(ORObjectInf object, boolean cut) {
+        this.data = object;
+        this.cut = cut;
+        this.type = Type.OBJECT;
+    }
+
+    public ORObjectClipboard(ORPageInf page, boolean cut) {
+        this.data = page;
+        this.cut = cut;
+        this.type = Type.PAGE;
+    }
+
+    public boolean isCut() {
+        return cut;
+    }
+
+    public Type getType() {
+        return type;
+    }
+
+    public ORObjectInf getObject() {
+        return (ORObjectInf) data;
+    }
+
+    public ORPageInf getPage() {
+        return (ORPageInf) data;
+    }
+}

--- a/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/or/structureddata/StructuredDataORPanel.java
+++ b/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/or/structureddata/StructuredDataORPanel.java
@@ -1,7 +1,7 @@
-package com.ing.ide.main.mainui.components.testdesign.or.api;
+package com.ing.ide.main.mainui.components.testdesign.or.structureddata;
 
 import com.ing.datalib.component.Project;
-import com.ing.datalib.or.api.APIORObject;
+import com.ing.datalib.or.structureddata.StructuredDataORObject;
 import com.ing.datalib.or.common.ObjectGroup;
 import com.ing.ide.main.mainui.components.testdesign.TestDesign;
 import com.ing.ide.main.utils.tree.TreeSearch;
@@ -10,22 +10,22 @@ import javax.swing.JPanel;
 import javax.swing.JSplitPane;
 
 /**
- * Panel for API Object Repository.
+ * Panel for Structured Data Object Repository.
  * Contains tree view and property table for API objects.
  */
-public class APIORPanel extends JPanel {
+public class StructuredDataORPanel extends JPanel {
 
-    private final APIObjectTree objectTree;
-    private final APIORTable objectTable;
+    private final StructuredDataObjectTree objectTree;
+    private final StructuredDataORTable objectTable;
 
     private final TestDesign testDesign;
 
     private JSplitPane splitPane;
 
-    public APIORPanel(TestDesign testDesign) {
+    public StructuredDataORPanel(TestDesign testDesign) {
         this.testDesign = testDesign;
-        this.objectTree = new APIObjectTree(this);
-        this.objectTable = new APIORTable(this);
+        this.objectTree = new StructuredDataObjectTree(this);
+        this.objectTable = new StructuredDataORTable(this);
         init();
     }
 
@@ -42,16 +42,16 @@ public class APIORPanel extends JPanel {
     }
 
     void loadTableModelForSelection(Object object) {
-        if (object instanceof APIORObject) {
-            objectTable.loadObject((APIORObject) object);
+        if (object instanceof StructuredDataORObject) {
+            objectTable.loadObject((StructuredDataORObject) object);
         } else if (object instanceof ObjectGroup) {
-            objectTable.loadObject((APIORObject) ((ObjectGroup) object).getChildAt(0));
+            objectTable.loadObject((StructuredDataORObject) ((ObjectGroup) object).getChildAt(0));
         } else {
             objectTable.reset();
         }
     }
 
-    public APIObjectTree getObjectTree() {
+    public StructuredDataObjectTree getObjectTree() {
         return objectTree;
     }
 
@@ -82,7 +82,7 @@ public class APIORPanel extends JPanel {
         return objectTree.navigateToObject(objectName, pageName);
     }
 
-    public APIORTable getObjectTable() {
+    public StructuredDataORTable getObjectTable() {
         return objectTable;
     }
 

--- a/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/or/structureddata/StructuredDataORTable.java
+++ b/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/or/structureddata/StructuredDataORTable.java
@@ -1,9 +1,8 @@
-package com.ing.ide.main.mainui.components.testdesign.or.api;
+package com.ing.ide.main.mainui.components.testdesign.or.structureddata;
 
-import com.ing.datalib.or.api.APIOR;
-import com.ing.datalib.or.api.APIORObject;
-import com.ing.datalib.or.api.APIORPage;
-import com.ing.datalib.or.common.ORAttribute;
+import com.ing.datalib.or.structureddata.StructuredDataAttribute;
+import com.ing.datalib.or.structureddata.StructuredDataORObject;
+import com.ing.datalib.or.structureddata.StructuredDataORPage;
 import com.ing.datalib.or.common.ORObjectInf;
 import com.ing.datalib.or.common.ObjectGroup;
 import com.ing.ide.main.utils.Utils;
@@ -30,16 +29,17 @@ import javax.swing.table.TableColumn;
  * Table component for API Object Repository properties.
  * Shows JsonPath and Xpath attributes (2 columns: Attribute, Value).
  */
-public class APIORTable extends JPanel implements ActionListener {
+public class StructuredDataORTable extends JPanel implements ActionListener {
 
     private final XTable table;
 
-    private final APIORPanel apiOR;
+    private final StructuredDataORPanel structuredDataOR;
     private final ToolBar toolBar;
     private final PopupMenu popupMenu;
 
-    public APIORTable(APIORPanel apiOR) {
-        this.apiOR = apiOR;
+    public StructuredDataORTable(StructuredDataORPanel structuredDataOR) {
+
+        this.structuredDataOR = structuredDataOR;
         table = new XTable();
         toolBar = new ToolBar();
         popupMenu = new PopupMenu();
@@ -59,7 +59,7 @@ public class APIORTable extends JPanel implements ActionListener {
         return table;
     }
 
-    public void loadObject(APIORObject object) {
+    public void loadObject(StructuredDataORObject object) {
         table.setModel(object);
         configureColumns();
     }
@@ -176,7 +176,7 @@ public class APIORTable extends JPanel implements ActionListener {
 
     private boolean moveRowsUp(int from, int to) {
         if (from > 0) {
-            List<ORAttribute> attrs = getObject().getAttributes();
+            List<StructuredDataAttribute> attrs = getObject().getAttributes();
             for (int i = from; i <= to; i++) {
                 Collections.swap(attrs, i, i - 1);
             }
@@ -198,7 +198,7 @@ public class APIORTable extends JPanel implements ActionListener {
     }
 
     private boolean moveRowsDown(int from, int to) {
-        List<ORAttribute> attrs = getObject().getAttributes();
+        List<StructuredDataAttribute> attrs = getObject().getAttributes();
         if (to < attrs.size() - 1) {
             for (int i = to; i >= from; i--) {
                 Collections.swap(attrs, i, i + 1);
@@ -210,7 +210,7 @@ public class APIORTable extends JPanel implements ActionListener {
     }
 
     private List<ORObjectInf> getSelectedObjects() {
-        return apiOR.getObjectTree().getSelectedObjects();
+        return structuredDataOR.getObjectTree().getSelectedObjects();
     }
 
     private void clearFromSelected() {
@@ -218,7 +218,7 @@ public class APIORTable extends JPanel implements ActionListener {
             String[] attrs = getSelectedAttrs();
             for (String attr : attrs) {
                 getSelectedObjects().stream().forEach((object) -> {
-                    ((APIORObject) object).setAttributeByName(attr, "");
+                    ((StructuredDataORObject) object).setAttributeByName(attr, "");
                 });
             }
         }
@@ -227,7 +227,7 @@ public class APIORTable extends JPanel implements ActionListener {
     private void clearFromAll() {
         if (table.getSelectedRowCount() > 0) {
             String[] attrs = getSelectedAttrs();
-            for (APIORPage page : getObject().getPage().getRoot().getPages()) {
+            for (StructuredDataORPage page : getObject().getPage().getRoot().getPages()) {
                 clearFromPage(page, attrs);
             }
         }
@@ -239,9 +239,9 @@ public class APIORTable extends JPanel implements ActionListener {
         }
     }
 
-    private void clearFromPage(APIORPage page, String[] attrs) {
-        for (ObjectGroup<APIORObject> objectGroup : page.getObjectGroups()) {
-            for (APIORObject object : objectGroup.getObjects()) {
+    private void clearFromPage(StructuredDataORPage page, String[] attrs) {
+        for (ObjectGroup<StructuredDataORObject> objectGroup : page.getObjectGroups()) {
+            for (StructuredDataORObject object : objectGroup.getObjects()) {
                 for (String attr : attrs) {
                     object.setAttributeByName(attr, "");
                 }
@@ -252,7 +252,7 @@ public class APIORTable extends JPanel implements ActionListener {
     private void removeFromAll() {
         if (table.getSelectedRowCount() > 0) {
             String[] attrs = getSelectedAttrs();
-            for (APIORPage page : getObject().getPage().getRoot().getPages()) {
+            for (StructuredDataORPage page : getObject().getPage().getRoot().getPages()) {
                 removeFromPage(page, attrs);
             }
         }
@@ -263,8 +263,8 @@ public class APIORTable extends JPanel implements ActionListener {
             String[] attrs = getSelectedAttrs();
             for (String attr : attrs) {
                 getSelectedObjects().stream().forEach((object) -> {
-                    APIORObject apiObj = (APIORObject) object;
-                    ORAttribute orAttr = apiObj.getAttribute(attr);
+                    StructuredDataORObject apiObj = (StructuredDataORObject) object;
+                    StructuredDataAttribute orAttr = apiObj.getAttribute(attr);
                     if (orAttr != null) {
                         apiObj.removeAttribute(apiObj.getAttributes().indexOf(orAttr));
                     }
@@ -279,11 +279,11 @@ public class APIORTable extends JPanel implements ActionListener {
         }
     }
 
-    private void removeFromPage(APIORPage page, String[] attrs) {
-        for (ObjectGroup<APIORObject> objectGroup : page.getObjectGroups()) {
-            for (APIORObject object : objectGroup.getObjects()) {
+    private void removeFromPage(StructuredDataORPage page, String[] attrs) {
+        for (ObjectGroup<StructuredDataORObject> objectGroup : page.getObjectGroups()) {
+            for (StructuredDataORObject object : objectGroup.getObjects()) {
                 for (String attr : attrs) {
-                    ORAttribute orAttr = object.getAttribute(attr);
+                    StructuredDataAttribute orAttr = object.getAttribute(attr);
                     if (orAttr != null) {
                         object.removeAttribute(object.getAttributes().indexOf(orAttr));
                     }
@@ -297,7 +297,7 @@ public class APIORTable extends JPanel implements ActionListener {
             String[] attrs = getSelectedAttrs();
             for (String attr : attrs) {
                 getSelectedObjects().stream().forEach((object) -> {
-                    ((APIORObject) object).addOrUpdateAttribute(attr, "");
+                    ((StructuredDataORObject) object).addOrUpdateAttribute(attr, "");
                 });
             }
         }
@@ -306,7 +306,7 @@ public class APIORTable extends JPanel implements ActionListener {
     private void addToAll() {
         if (table.getSelectedRowCount() > 0) {
             String[] attrs = getSelectedAttrs();
-            for (APIORPage page : getObject().getPage().getRoot().getPages()) {
+            for (StructuredDataORPage page : getObject().getPage().getRoot().getPages()) {
                 addToPage(page, attrs);
             }
         }
@@ -318,9 +318,9 @@ public class APIORTable extends JPanel implements ActionListener {
         }
     }
 
-    private void addToPage(APIORPage page, String[] attrs) {
-        for (ObjectGroup<APIORObject> objectGroup : page.getObjectGroups()) {
-            for (APIORObject object : objectGroup.getObjects()) {
+    private void addToPage(StructuredDataORPage page, String[] attrs) {
+        for (ObjectGroup<StructuredDataORObject> objectGroup : page.getObjectGroups()) {
+            for (StructuredDataORObject object : objectGroup.getObjects()) {
                 for (String attr : attrs) {
                     object.addOrUpdateAttribute(attr, "");
                 }
@@ -330,37 +330,37 @@ public class APIORTable extends JPanel implements ActionListener {
 
     private void setPriorityToAll() {
         stopCellEditing();
-        APIORObject currObj = getObject();
-        for (APIORPage page : getObject().getPage().getRoot().getPages()) {
+        StructuredDataORObject currObj = getObject();
+        for (StructuredDataORPage page : getObject().getPage().getRoot().getPages()) {
             setPriorityToPage(page, currObj);
         }
     }
 
     private void setPriorityToSelected() {
         stopCellEditing();
-        APIORObject currObj = getObject();
+        StructuredDataORObject currObj = getObject();
         getSelectedObjects().stream().forEach((object) -> {
-            reorderAttributes(currObj.getAttributes(), ((APIORObject) object).getAttributes());
+            reorderAttributes(currObj.getAttributes(), ((StructuredDataORObject) object).getAttributes());
         });
     }
 
     private void setPriorityToPage() {
         stopCellEditing();
-        APIORObject currObj = getObject();
+        StructuredDataORObject currObj = getObject();
         setPriorityToPage(getObject().getPage(), currObj);
     }
 
-    private void setPriorityToPage(APIORPage page, APIORObject currObj) {
-        for (ObjectGroup<APIORObject> objectGroup : page.getObjectGroups()) {
-            for (APIORObject object : objectGroup.getObjects()) {
+    private void setPriorityToPage(StructuredDataORPage page, StructuredDataORObject currObj) {
+        for (ObjectGroup<StructuredDataORObject> objectGroup : page.getObjectGroups()) {
+            for (StructuredDataORObject object : objectGroup.getObjects()) {
                 reorderAttributes(currObj.getAttributes(), object.getAttributes());
             }
         }
     }
 
-    private void reorderAttributes(List<ORAttribute> source, List<ORAttribute> dest) {
+    private void reorderAttributes(List<StructuredDataAttribute> source, List<StructuredDataAttribute> dest) {
         for (int i = 0, c = 0; i < source.size(); i++) {
-            ORAttribute val = source.get(i);
+            StructuredDataAttribute val = source.get(i);
             for (int j = c; j < dest.size(); j++) {
                 if (dest.get(j).getName().equals(val.getName())) {
                     Collections.swap(dest, c++, j);
@@ -376,9 +376,9 @@ public class APIORTable extends JPanel implements ActionListener {
         }
     }
 
-    public APIORObject getObject() {
-        if (table.getModel() instanceof APIORObject) {
-            return (APIORObject) table.getModel();
+    public StructuredDataORObject getObject() {
+        if (table.getModel() instanceof StructuredDataORObject) {
+            return (StructuredDataORObject) table.getModel();
         }
         return null;
     }
@@ -404,11 +404,11 @@ public class APIORTable extends JPanel implements ActionListener {
 
             add(new javax.swing.Box.Filler(new java.awt.Dimension(0, 0), new java.awt.Dimension(0, 0), new java.awt.Dimension(32767, 32767)));
 
-            add(Utils.createButton("Add Row", "add", "Ctrl+Plus", APIORTable.this));
-            add(Utils.createButton("Delete Rows", "remove", "Ctrl+Minus", APIORTable.this));
+            add(Utils.createButton("Add Row", "add", "Ctrl+Plus", StructuredDataORTable.this));
+            add(Utils.createButton("Delete Rows", "remove", "Ctrl+Minus", StructuredDataORTable.this));
             addSeparator();
-            add(Utils.createButton("Move Rows Up", "up", "Ctrl+Up", APIORTable.this));
-            add(Utils.createButton("Move Rows Down", "down", "Ctrl+Down", APIORTable.this));
+            add(Utils.createButton("Move Rows Up", "up", "Ctrl+Up", StructuredDataORTable.this));
+            add(Utils.createButton("Move Rows Down", "down", "Ctrl+Down", StructuredDataORTable.this));
         }
 
     }
@@ -425,21 +425,21 @@ public class APIORTable extends JPanel implements ActionListener {
             JMenu clearProp = new JMenu("Clear Property");
             JMenu deleteProp = new JMenu("Remove Property");
 
-            setPriority.add(Utils.createMenuItem("Set Priority to Page", APIORTable.this));
-            setPriority.add(Utils.createMenuItem("Set Priority to All", APIORTable.this));
-            setPriority.add(Utils.createMenuItem("Set Priority to Selected", APIORTable.this));
+            setPriority.add(Utils.createMenuItem("Set Priority to Page", StructuredDataORTable.this));
+            setPriority.add(Utils.createMenuItem("Set Priority to All", StructuredDataORTable.this));
+            setPriority.add(Utils.createMenuItem("Set Priority to Selected", StructuredDataORTable.this));
             add(setPriority);
-            clearProp.add(Utils.createMenuItem("Clear from Page", APIORTable.this));
-            clearProp.add(Utils.createMenuItem("Clear from All", APIORTable.this));
-            clearProp.add(Utils.createMenuItem("Clear from Selected", APIORTable.this));
+            clearProp.add(Utils.createMenuItem("Clear from Page", StructuredDataORTable.this));
+            clearProp.add(Utils.createMenuItem("Clear from All", StructuredDataORTable.this));
+            clearProp.add(Utils.createMenuItem("Clear from Selected", StructuredDataORTable.this));
             add(clearProp);
-            deleteProp.add(Utils.createMenuItem("Remove from Page", APIORTable.this));
-            deleteProp.add(Utils.createMenuItem("Remove from All", APIORTable.this));
-            deleteProp.add(Utils.createMenuItem("Remove from Selected", APIORTable.this));
+            deleteProp.add(Utils.createMenuItem("Remove from Page", StructuredDataORTable.this));
+            deleteProp.add(Utils.createMenuItem("Remove from All", StructuredDataORTable.this));
+            deleteProp.add(Utils.createMenuItem("Remove from Selected", StructuredDataORTable.this));
             add(deleteProp);
-            addProp.add(Utils.createMenuItem("Add to Page", APIORTable.this));
-            addProp.add(Utils.createMenuItem("Add to All", APIORTable.this));
-            addProp.add(Utils.createMenuItem("Add to Selected", APIORTable.this));
+            addProp.add(Utils.createMenuItem("Add to Page", StructuredDataORTable.this));
+            addProp.add(Utils.createMenuItem("Add to All", StructuredDataORTable.this));
+            addProp.add(Utils.createMenuItem("Add to Selected", StructuredDataORTable.this));
             add(addProp);
         }
 

--- a/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/or/structureddata/StructuredDataObjectTree.java
+++ b/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/or/structureddata/StructuredDataObjectTree.java
@@ -1,8 +1,8 @@
-package com.ing.ide.main.mainui.components.testdesign.or.api;
+package com.ing.ide.main.mainui.components.testdesign.or.structureddata;
 
 import com.ing.datalib.component.Project;
 import com.ing.datalib.component.TestCase;
-import com.ing.datalib.or.api.APIORObject;
+import com.ing.datalib.or.structureddata.StructuredDataORObject;
 import com.ing.datalib.or.common.ORObjectInf;
 import com.ing.datalib.or.common.ORRootInf;
 import com.ing.ide.main.mainui.components.testdesign.or.ObjectTree;
@@ -10,13 +10,13 @@ import java.util.List;
 import javax.swing.tree.TreePath;
 
 /**
- * Tree component for API Object Repository.
+ * Tree component for Structured Data Object Repository.
  */
-public class APIObjectTree extends ObjectTree {
+public class StructuredDataObjectTree extends ObjectTree {
 
-    private final APIORPanel oRPanel;
+    private final StructuredDataORPanel oRPanel;
 
-    public APIObjectTree(APIORPanel sProxy) {
+    public StructuredDataObjectTree(StructuredDataORPanel sProxy) {
         this.oRPanel = sProxy;
     }
 
@@ -40,7 +40,7 @@ public class APIObjectTree extends ObjectTree {
 
     @Override
     public ORRootInf getOR() {
-        return oRPanel.getProject().getObjectRepository().getAPIOR();
+        return oRPanel.getProject().getObjectRepository().getStructuredDataOR();
     }
 
     @Override
@@ -52,7 +52,7 @@ public class APIObjectTree extends ObjectTree {
         super.objectRemoved(object);
     }
 
-    public APIORObject getLoadedObject() {
+    public StructuredDataORObject getLoadedObject() {
         return oRPanel.getObjectTable().getObject();
     }
 

--- a/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/testcase/TestCaseAutoSuggest.java
+++ b/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/testcase/TestCaseAutoSuggest.java
@@ -12,6 +12,7 @@ import static com.ing.datalib.component.TestStep.HEADERS.Description;
 import static com.ing.datalib.component.TestStep.HEADERS.Input;
 import static com.ing.datalib.component.TestStep.HEADERS.ObjectName;
 import static com.ing.datalib.component.TestStep.HEADERS.Reference;
+import com.ing.datalib.or.structureddata.ResolvedStructuredDataObject;
 import com.ing.datalib.or.mobile.ResolvedMobileObject;
 import com.ing.datalib.or.web.ResolvedWebObject;
 import com.ing.datalib.testdata.model.Record;
@@ -54,7 +55,7 @@ import javax.swing.Timer;
  * Auto-suggest controller for the Test Case table, providing intelligent
  * suggestions for Object, Action, Condition, and Input columns.
  *
- * Updated to support Mobile OR separation (Project + Shared) and scoped
+ * Updated to support Web, Mobile and Structured Data OR separation (Project + Shared) and scoped
  * reference tokens ("[Project]" / "[Shared]") when detecting object type.
  */
 public class TestCaseAutoSuggest {
@@ -333,6 +334,8 @@ public class TestCaseAutoSuggest {
                         return MethodInfoManager.getMethodListFor(ObjectType.PLAYWRIGHT, ObjectType.WEB, ObjectType.ANY);
                     } else if (isMobileObject(objectName, pageToken)) {
                         return MethodInfoManager.getMethodListFor(ObjectType.APP);
+                    } else if (isStructuredDataObject(objectName, pageToken)) {
+                        return MethodInfoManager.getMethodListFor(ObjectType.STRUCTUREDDATA);
                     }
             }
             return new ArrayList<>();
@@ -379,6 +382,25 @@ public class TestCaseAutoSuggest {
             ResolvedMobileObject r = (ref != null && ref.name != null && ref.scope != null)
                     ? repo.resolveMobileObject(ref, objectName)
                     : repo.resolveMobileObjectWithScope(pageToken, objectName);
+            return r != null && r.isPresent();
+        }
+        
+        /**
+         * Detect Structured Data objects via Structured Data resolver (supports scoped refs + shared)
+         * instead of directly accessing getStructuredDataOR()/pages.
+         */
+        private boolean isStructuredDataObject(String objectName, String pageToken) {
+            if (pageToken == null
+                    || pageToken.isBlank()
+                    || objectName == null
+                    || objectName.isBlank()) {
+                return false;
+            }
+            var repo = sProject.getObjectRepository();
+            ResolvedStructuredDataObject.PageRef ref = ResolvedStructuredDataObject.PageRef.parse(pageToken);
+            ResolvedStructuredDataObject r = (ref != null && ref.name != null && ref.scope != null)
+                    ? repo.resolveStructuredDataObject(ref, objectName)
+                    : repo.resolveStructuredDataObjectWithScope(pageToken, objectName);
             return r != null && r.isPresent();
         }
 

--- a/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/testcase/TestCaseTableDnD.java
+++ b/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/testcase/TestCaseTableDnD.java
@@ -2,8 +2,11 @@
 package com.ing.ide.main.mainui.components.testdesign.testcase;
 
 import com.ing.datalib.component.TestCase;
+import com.ing.datalib.component.TestStep;
 import com.ing.datalib.component.TestStep.HEADERS;
+import com.ing.datalib.or.ObjectRepository;
 import com.ing.datalib.or.common.ORPageInf;
+import com.ing.datalib.or.web.ResolvedWebObject;
 import com.ing.ide.main.mainui.components.testdesign.or.ObjectDnD;
 import com.ing.ide.main.mainui.components.testdesign.or.ObjectRepDnD;
 import com.ing.ide.main.mainui.components.testdesign.testdata.TestDataDetail;
@@ -123,7 +126,17 @@ public class TestCaseTableDnD extends TransferHandler {
                     testCase.setValueAt(objs.getPageName(val), row, HEADERS.Reference.getIndex());
                     testCase.fireTableRowsUpdated(row, row);
                 } else {
-                    testCase.addObjectStep(row, objs.getObjectName(val), objs.getPageName(val));
+                    ObjectRepository or = testCase.getProject().getObjectRepository();
+                    TestStep tempStep = new TestStep(testCase);
+                    ResolvedWebObject rwo =
+                        or.resolveWebObjectWithScope(
+                            objs.getPageName(val),
+                            objs.getObjectName(val),
+                            tempStep
+                        );
+                    if (rwo != null) {
+                        testCase.addObjectStep(row, rwo);
+                    }
                 }
                 row++;
             }

--- a/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/testcase/validation/ActionRenderer.java
+++ b/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/testcase/validation/ActionRenderer.java
@@ -3,6 +3,7 @@ package com.ing.ide.main.mainui.components.testdesign.testcase.validation;
 import com.ing.datalib.component.Scenario;
 import com.ing.datalib.component.TestStep;
 import com.ing.datalib.or.web.ResolvedWebObject;
+import com.ing.datalib.or.structureddata.ResolvedStructuredDataObject;
 import com.ing.datalib.or.mobile.ResolvedMobileObject;
 import com.ing.engine.support.methodInf.MethodInfoManager;
 import com.ing.engine.support.methodInf.ObjectType;
@@ -122,6 +123,8 @@ public class ActionRenderer extends AbstractRenderer {
                     valid = MethodInfoManager.getMethodListFor(ObjectType.PLAYWRIGHT, ObjectType.WEB).contains(action);
                 } else if (isMobileObject(step)) {
                     valid = MethodInfoManager.getMethodListFor(ObjectType.APP).contains(action);
+                } else if (isStructuredDataObject(step)) {
+                    valid = MethodInfoManager.getMethodListFor(ObjectType.STRUCTUREDDATA).contains(action);
                 }
                 break;
         }
@@ -153,6 +156,19 @@ public class ActionRenderer extends AbstractRenderer {
         ResolvedMobileObject r = (ref != null && ref.name != null && ref.scope != null)
             ? repo.resolveMobileObject(ref, objectName)
             : repo.resolveMobileObjectWithScope(pageToken, objectName);
+
+        return r != null && r.isPresent();
+    }
+
+    private boolean isStructuredDataObject(TestStep step) {
+        var repo = step.getProject().getObjectRepository();
+        String pageToken = step.getReference();
+        String objectName = step.getObject();
+
+        ResolvedStructuredDataObject.PageRef ref = ResolvedStructuredDataObject.PageRef.parse(pageToken);
+        ResolvedStructuredDataObject r = (ref != null && ref.name != null && ref.scope != null)
+            ? repo.resolveStructuredDataObject(ref, objectName)
+            : repo.resolveStructuredDataObjectWithScope(pageToken, objectName);
 
         return r != null && r.isPresent();
     }

--- a/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/testcase/validation/ObjectRenderer.java
+++ b/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/testcase/validation/ObjectRenderer.java
@@ -2,6 +2,7 @@ package com.ing.ide.main.mainui.components.testdesign.testcase.validation;
 
 import com.ing.datalib.component.TestStep;
 import com.ing.datalib.or.web.ResolvedWebObject;
+import com.ing.datalib.or.structureddata.ResolvedStructuredDataObject;
 import com.ing.datalib.or.mobile.ResolvedMobileObject;
 
 import java.awt.Color;
@@ -52,19 +53,23 @@ public class ObjectRenderer extends AbstractRenderer {
         var repo = step.getProject().getObjectRepository();
         String pageToken = step.getReference();
         String objectName = step.getObject();
+        
+        
         ResolvedWebObject.PageRef wref = ResolvedWebObject.PageRef.parse(pageToken);
-        if (wref != null && wref.name != null && wref.scope != null) {
-            if (repo.resolveWebObject(wref, objectName) != null) {
-                return true;
-            }
-        } else if (repo.resolveWebObjectWithScope(pageToken, objectName) != null) {
+        if ((wref != null && wref.name != null && wref.scope != null) && (repo.resolveWebObject(wref, objectName) != null)
+                || (repo.resolveWebObjectWithScope(pageToken, objectName) != null)) {
             return true;
         }
+        
         ResolvedMobileObject.PageRef mref = ResolvedMobileObject.PageRef.parse(pageToken);
-        if (mref != null && mref.name != null && mref.scope != null) {
-            return repo.resolveMobileObject(mref, objectName) != null;
+        if ((mref != null && mref.name != null && mref.scope != null) && (repo.resolveMobileObject(mref, objectName) != null)
+                || (repo.resolveMobileObjectWithScope(pageToken, objectName) != null )) {
+            return true;
         }
-        return repo.resolveMobileObjectWithScope(pageToken, objectName) != null;
+        
+        ResolvedStructuredDataObject.PageRef aref = ResolvedStructuredDataObject.PageRef.parse(pageToken);
+        return ((aref != null && aref.name != null && aref.scope != null) && (repo.resolveStructuredDataObject(aref, objectName) != null)
+                || (repo.resolveStructuredDataObjectWithScope(pageToken, objectName) != null ));
     }
 
     private Boolean isValidObject(Object value) {

--- a/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/testcase/validation/ObjectRenderer.java
+++ b/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/testcase/validation/ObjectRenderer.java
@@ -1,6 +1,7 @@
 package com.ing.ide.main.mainui.components.testdesign.testcase.validation;
 
 import com.ing.datalib.component.TestStep;
+import com.ing.datalib.or.ObjectRepository;
 import com.ing.datalib.or.web.ResolvedWebObject;
 import com.ing.datalib.or.structureddata.ResolvedStructuredDataObject;
 import com.ing.datalib.or.mobile.ResolvedMobileObject;
@@ -25,28 +26,35 @@ public class ObjectRenderer extends AbstractRenderer {
 
     @Override
     public void render(JComponent comp, TestStep step, Object value) {
-        if (!step.isCommented()) {
-            if (isEmpty(value)) {
-                setEmpty(comp);
-            } else if ("Execute".equals(Objects.toString(value, "").trim())) {
-                setExecute(comp);
-            } else if (step.isPageObjectStep()) {
-                if (isObjectPresent(step)) {
-                    setDefault(comp);
-                } else {
-                    setNotPresent(comp, objNotPresent);
-                }
-            } else if (isValidObject(value)) {
-                setDefault(comp);
-            } else {
-                setNotPresent(comp, objNotPresent);
-            }
-        } else {
-            setDefault(comp);
-            Color c = UIManager.getColor("ing.commentedForeground");
-            comp.setForeground(c != null ? c : Color.lightGray);
-            comp.setFont(new Font("Default", Font.ITALIC, 11));
+        setDefault(comp);
+        comp.setFont(comp.getFont().deriveFont(java.awt.Font.PLAIN));
+        comp.setEnabled(true);
+        comp.setToolTipText(null);
+
+        String objectName = Objects.toString(step.getObject(), "").trim();
+        String reference  = Objects.toString(step.getReference(), "").trim();
+
+        if (objectName.isEmpty() && reference.isEmpty()) {
+            return;
         }
+
+        if (isValidObject(objectName)) {
+            comp.setFont(comp.getFont().deriveFont(java.awt.Font.BOLD));
+            return;
+        }
+
+        if (!objectName.isEmpty() && reference.isEmpty()) {
+            setNotPresent(comp, "Reference is missing");
+            comp.setFont(comp.getFont().deriveFont(java.awt.Font.BOLD));
+            return;
+        }
+        if (!isObjectPresent(step)) {
+            setNotPresent(comp, objNotPresent);
+            comp.setFont(comp.getFont().deriveFont(java.awt.Font.BOLD));
+            return;
+        }
+
+        comp.setFont(comp.getFont().deriveFont(java.awt.Font.BOLD));
     }
 
     private Boolean isObjectPresent(TestStep step) {

--- a/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/testcase/validation/ReferenceRenderer.java
+++ b/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/testcase/validation/ReferenceRenderer.java
@@ -2,6 +2,7 @@ package com.ing.ide.main.mainui.components.testdesign.testcase.validation;
 
 import com.ing.datalib.component.TestStep;
 import com.ing.datalib.or.web.ResolvedWebObject;
+import com.ing.datalib.or.structureddata.ResolvedStructuredDataObject;
 import com.ing.datalib.or.mobile.ResolvedMobileObject;
 
 import java.awt.Color;
@@ -105,20 +106,21 @@ public class ReferenceRenderer extends AbstractRenderer {
         var repo = step.getProject().getObjectRepository();
         String pageToken = step.getReference();
         String objectName = step.getObject();
-
+        
         ResolvedWebObject.PageRef wref = ResolvedWebObject.PageRef.parse(pageToken);
-        if (wref != null && wref.name != null && wref.scope != null) {
-            if (repo.resolveWebObject(wref, objectName) != null) {
-                return true;
-            }
-        } else if (repo.resolveWebObjectWithScope(pageToken, objectName) != null) {
+        if ((wref != null && wref.name != null && wref.scope != null) && (repo.resolveWebObject(wref, objectName) != null)
+                || (repo.resolveWebObjectWithScope(pageToken, objectName) != null)) {
             return true;
         }
-
+        
         ResolvedMobileObject.PageRef mref = ResolvedMobileObject.PageRef.parse(pageToken);
-        if (mref != null && mref.name != null && mref.scope != null) {
-            return repo.resolveMobileObject(mref, objectName) != null;
+        if ((mref != null && mref.name != null && mref.scope != null) && (repo.resolveMobileObject(mref, objectName) != null)
+                || (repo.resolveMobileObjectWithScope(pageToken, objectName) != null )) {
+            return true;
         }
-        return repo.resolveMobileObjectWithScope(pageToken, objectName) != null;
+        
+        ResolvedStructuredDataObject.PageRef aref = ResolvedStructuredDataObject.PageRef.parse(pageToken);
+        return ((aref != null && aref.name != null && aref.scope != null) && (repo.resolveStructuredDataObject(aref, objectName) != null)
+                || (repo.resolveStructuredDataObjectWithScope(pageToken, objectName) != null ));
     }
 }

--- a/IDE/src/main/java/com/ing/ide/main/playwrightrecording/PlaywrightRecordingParser.java
+++ b/IDE/src/main/java/com/ing/ide/main/playwrightrecording/PlaywrightRecordingParser.java
@@ -1,9 +1,12 @@
 package com.ing.ide.main.playwrightrecording;
 
+import com.ing.datalib.or.common.ObjectGroup;
+import com.ing.datalib.or.web.WebOR;
+import com.ing.datalib.or.web.WebORObject;
+import com.ing.datalib.or.web.WebORPage;
 import com.ing.ide.main.mainui.AppMainFrame;
-import com.ing.ide.util.logging.UILogger;
+
 import java.io.File;
-import java.io.IOException;
 import java.io.PrintWriter;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -15,26 +18,11 @@ import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.parsers.ParserConfigurationException;
-import javax.xml.transform.Transformer;
-import javax.xml.transform.TransformerException;
-import javax.xml.transform.TransformerFactory;
-import javax.xml.transform.dom.DOMSource;
-import javax.xml.transform.stream.StreamResult;
 
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.w3c.dom.DOMException;
-import org.w3c.dom.Document;
-import org.w3c.dom.Element;
-import org.xml.sax.SAXException;
 
 public class PlaywrightRecordingParser {
 
@@ -52,226 +40,127 @@ public class PlaywrightRecordingParser {
         this.sMainFrame = sMainFrame;
     }
 
-    public void playwrightParser(File file) throws ParserConfigurationException, TransformerException, SAXException, IOException {
-        if (file != null && file.exists()) {
-            try {
-                filePath.put("projectPath", sMainFrame.getProject().getLocation());
-                filePath.put("importPlaywrightRecordingFilePath", file.getAbsolutePath());
-                File PlaywrightRecordingfile = new File(filePath.get("importPlaywrightRecordingFilePath"));
-                filePath.put("orFilePath", (filePath.get("projectPath") + "/OR.object"));
-                String baseName = FilenameUtils.getBaseName(filePath.get("importPlaywrightRecordingFilePath"));
-                testCase.put("fileName", StringUtils.capitalize(baseName));
-                File OrFile = new File(filePath.get("orFilePath"));
-                Element objectFrame = null;
-                testCase.put("pageName", testCase.get("fileName"));
-                testCase.put("testScenarioName", (filePath.get("projectPath") + "/TestPlan/" + testCase.get("fileName")).replace("\\", "/"));
-                File testScenario = new File(testCase.get("testScenarioName"));
-                if (!testScenario.exists()) {
-                    testScenario.mkdirs();
-                }
-                testCase.put("pageName", getPageName(testScenario, testCase.get("pageName")));
-
-                if (!OrFile.exists()) {
-                    boolean orExistFlag = false;
-                    DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
-                    DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
-                    Document doc = dBuilder.newDocument();
-                    Element rootElement = doc.createElement("Root");
-                    doc.appendChild(rootElement);
-                    rootElement.setAttribute("ref", testCase.get("fileName"));
-                    rootElement.setAttribute("type", "OR");
-                    Element page = doc.createElement("Page");
-                    rootElement.appendChild(page);
-
-                    List l = readFileInList(
-                            filePath.get("importPlaywrightRecordingFilePath"));
-
-                    Iterator<String> iterator = l.iterator();
-                    executeParse(iterator, objectFrame, testCase.get("testScenarioName"), filePath.get("orFilePath"), page, doc, orExistFlag, rootElement);
-                    allObjectMaping.clear();
-                } else {
-                    boolean orExistFlag = true;
-                    DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
-                    DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();
-                    Document doc = documentBuilder.parse(new File(filePath.get("orFilePath")));
-                    doc.getDocumentElement().normalize();
-                    Element root = doc.getDocumentElement();
-                    Element page = doc.createElement("Page");
-                    List l = readFileInList(
-                            filePath.get("importPlaywrightRecordingFilePath"));
-
-                    Iterator<String> iterator = l.iterator();
-                    executeParse(iterator, objectFrame, testCase.get("testScenarioName"), filePath.get("orFilePath"), page, doc, orExistFlag, root);
-                    allObjectMaping.clear();
-                }
-                testCase.clear();
-                attribute.clear();
-                filePath.clear();
-                ObjectNameList.clear();
-            } catch (Exception ex) {
-                Logger.getLogger(PlaywrightRecordingParser.class.getName()).log(Level.SEVERE, null, ex);
+    public void playwrightParser(File file) {
+        if (file == null || !file.exists()) {
+            return;
+        }
+        try {
+            filePath.put("projectPath", sMainFrame.getProject().getLocation());
+            filePath.put("importPlaywrightRecordingFilePath", file.getAbsolutePath());
+            String baseName = FilenameUtils.getBaseName(file.getAbsolutePath());
+            testCase.put("fileName", StringUtils.capitalize(baseName));
+            testCase.put("pageName", testCase.get("fileName"));
+            String testScenarioName = filePath.get("projectPath") + "/TestPlan/" + testCase.get("fileName");
+            testScenarioName = testScenarioName.replace("\\", "/");
+            testCase.put("testScenarioName", testScenarioName);
+            File testScenario = new File(testScenarioName);
+            if (!testScenario.exists()) {
+                testScenario.mkdirs();
             }
+            WebOR webOR = sMainFrame.getProject().getObjectRepository().getWebOR();
+            String basePageName = testCase.get("pageName");
+            String pageName = basePageName;
+            if (webOR.getPageByName(pageName) != null) {
+                int counter = 1;
+                while (webOR.getPageByName(basePageName + "_" + counter) != null) {
+                    counter++;
+                }
+                pageName = basePageName + "_" + counter;
+            }
+            testCase.put("pageName", pageName);
+            WebORPage page = webOR.addPage(pageName);
+            List<String> lines = readFileInList(filePath.get("importPlaywrightRecordingFilePath"));
+            Iterator<String> iterator = lines.iterator();
+            executeParse(iterator, page, testScenarioName);
+            page.getRoot() .getObjectRepository() .saveWebPageNow(page);
+        } catch (Exception ex) {
+            Logger.getLogger(PlaywrightRecordingParser.class.getName()).log(Level.SEVERE, null, ex);
         }
     }
 
-    private void executeParse(Iterator iterator, Element objectFrame, String testScenarioName, String orFilePath, Element page, Document doc, boolean orExistFlag, Element root) throws TransformerException {
-
+    private void executeParse(Iterator<String> iterator, WebORPage page, String testScenarioName) {
         StringBuilder stepBuilder = new StringBuilder();
         testCaseParameter();
         attributeDeclaration();
         int stepNumber = 1;
-        stepBuilder.append("Step" + "," + "ObjectName" + "," + "Description" + "," + "Action" + "," + "Input" + ","
-                + "Condition" + "," + "Reference");
-        stepBuilder.append("\n");
-        page.setAttribute("ref", testCase.get("pageName"));
-        page.setAttribute("title", "");
         int playwrightSteps = 0;
+        stepBuilder.append("Step,ObjectName,Description,Action,Input,Condition,Reference\n");
         while (iterator.hasNext()) {
             attributeDeclaration();
             testCaseParameter();
-            String line = (String) iterator.next();
+            String line = iterator.next();
             checkPageSwitch(line);
             storePageIndex(line);
             if (line.trim().startsWith("page")) {
                 pageMapping.put("currentPage", line.trim().split("\\.")[0]);
             }
-            if (!line.contains("System.out.println(") && !line.contains(pageMapping.get("currentPage") + ".onceDialog(dialog") && !line.contains(".waitForPopup(() ->")) {
-
+            if (!line.contains("System.out.println(")
+                    && !line.contains(pageMapping.get("currentPage") + ".onceDialog(dialog")
+                    && !line.contains(".waitForPopup(() ->")) {
                 if (line.trim().startsWith("page")) {
-                    playwrightSteps = playwrightSteps + 1;
+                    playwrightSteps++;
                 }
-
-                if (playwrightSteps >= 1) {
-                    if (!line.contains("}")) {
-                        int matchingAttribute = 0;
-                        testCaseMap(getAction(line), getInput(line));
-                        attributeInitialization(line);
-                        if (!testCase.get("ObjectName").equals("Browser")) {
-                            if (!allObjectMaping.isEmpty() && allObjectMaping.containsKey(testCase.get("ObjectName"))) {
-                                if (objectFrameMap.get(testCase.get("ObjectName")).equals(testCase.get("frame"))) {
-                                    HashMap<String, String> objectAttributeMap = allObjectMaping.get(testCase.get("ObjectName"));
-
-                                    Set<String> attributesKey = objectAttributeMap.keySet();
-                                    for (String allObjectAttributeKey : attributesKey) {
-                                        if (objectAttributeMap.get(allObjectAttributeKey).equals(attribute.get(allObjectAttributeKey))) {
-                                            matchingAttribute = matchingAttribute + 1;
-                                        }
-                                    }
-                                }
-                            }
-
-                            if (!testCase.get("ObjectName").equals("Browser")) {
-                                ObjectNameList.add(testCase.get("ObjectName"));
-                                int j = 0;
-                                int k = 0;
-                                for (String Locator : ObjectNameList) {
-                                    if ((Locator.trim()).equals(testCase.get("ObjectName").trim())) {
-                                        j++;
-                                    }
-                                    if (j > 1) {
-                                        k = (j - 1);
-                                    }
-                                }
-                                String locatorNumber = Integer.toString(k);
-                                if (attribute.size() != matchingAttribute || testCase.get("ObjectName").contains("Refactor_Object")) {
-                                    if (!locatorNumber.equals("0")) {
-                                        testCase.put("ObjectName", testCase.get("ObjectName") + "_" + locatorNumber);
-                                    }
-                                }
-
-                            }
-                            Map<String, String> objectAttribute = new HashMap<>();
-                            Set a = attribute.keySet();
-                            for (Object key : a) {
-                                String newKey = key.toString();
-                                objectAttribute.put(newKey, attribute.get(newKey));
-                            }
-                            objectFrameMap.put(testCase.get("ObjectName"), testCase.get("frame"));
-
-                            allObjectMaping.put(testCase.get("ObjectName"), (HashMap) objectAttribute);
-                            if (attribute.size() != matchingAttribute || testCase.get("ObjectName").contains("Refactor_Object")) {
-                                if (!testCase.get("ObjectName").equals("Browser")) {
-                                    Element objectGroup = doc.createElement("ObjectGroup");
-                                    page.appendChild(objectGroup);
-                                    objectGroup.setAttribute("ref", testCase.get("ObjectName"));
-                                    objectFrame = doc.createElement("Object");
-                                    objectGroup.appendChild(objectFrame);
-                                    objectFrame.setAttribute("frame", testCase.get("frame"));
-                                    objectFrame.setAttribute("ref", testCase.get("ObjectName"));
-
-                                    for (int p = 0; p < attribute.size(); p++) {
-                                        Element Property = doc.createElement("Property");
-                                        objectFrame.appendChild(Property);
-                                        String key = (String) attribute.keySet().toArray()[p];
-                                        Property.setAttribute("ref", key);
-                                        Property.setAttribute("value", attribute.get(key));
-                                        String prefNumber = Integer.toString(p + 1);
-                                        Property.setAttribute("pref", prefNumber);
-                                    }
-                                }
-
+                if (playwrightSteps >= 1 && !line.contains("}")) {
+                    testCaseMap(getAction(line), getInput(line));
+                    attributeInitialization(line);
+                    if (!"Browser".equals(testCase.get("ObjectName"))) {
+                        String objectName = testCase.get("ObjectName");
+                        ObjectGroup group = page.getObjectGroupByName(objectName);
+                        if (group == null) {
+                            group = new ObjectGroup(objectName, page);
+                            page.getObjectGroups().add(group);
+                        }
+                        WebORObject obj = new WebORObject(objectName, group);
+                        for (Map.Entry<String, String> entry : attribute.entrySet()) {
+                            String key = entry.getKey();
+                            String value = entry.getValue();
+                            if (value != null && !value.isEmpty()) {
+                                obj.setAttributeByName(key, value);
                             }
                         }
-                        if (stepNumber > 1) {
-                            if (!pageMapping.get("currentPage").equals(pageMapping.get("previousPage")) && !pageMapping.get("switchedPageName").equals(pageMapping.get("currentPage"))) {
-                                testCase.put("step", String.valueOf(stepNumber));
-                                String pageIndex = "@" + pageMapping.get(pageMapping.get("currentPage"));
-                                String stepAppenderString = testCase.get("step") + "," + "Browser" + "," + "" + "," + "switchToPageByIndex" + "," + pageIndex + ","
-                                        + "" + "," + "";
-                                testCase.put("stepAppender", stepAppenderString);
-                                stepBuilder.append(testCase.get("stepAppender"));
-                                stepBuilder.append("\n");
-                                testCase.put("input", "");
-                                stepNumber++;
-                            }
+                        if (!testCase.get("frame").isEmpty()) {
+                            obj.setFrame(testCase.get("frame"));
                         }
-                        if (line.trim().startsWith("page")) {
-                            pageMapping.put("previousPage", line.trim().split("\\.")[0]);
-                        }
-                        attributeDeclaration();
-                        if (!testCase.get("action").equals("Open")) {
-                            testCase.put("step", String.valueOf(stepNumber));
-
-                            String stepAppenderString = testCase.get("step") + "," + testCase.get("ObjectName") + "," + "" + "," + testCase.get("action") + "," + testCase.get("input") + ","
-                                    + testCase.get("Condition") + "," + testCase.get("pageName");
-                            testCase.put("stepAppender", stepAppenderString);
-                            stepBuilder.append(testCase.get("stepAppender"));
-                            stepBuilder.append("\n");
-                            testCase.put("input", "");
-                            stepNumber++;
-                        }
-
-                        if (testCase.get("action").equals("Open")) {
-                            testCase.put("step", String.valueOf(stepNumber));
-                            String stepAppenderValue = testCase.get("step") + "," + testCase.get("ObjectName") + "," + "" + "," + testCase.get("action") + "," + testCase.get("input") + ","
-                                    + testCase.get("Condition") + "," + "";
-                            testCase.put("stepAppender", stepAppenderValue);
-                            stepBuilder.append(testCase.get("stepAppender"));
-                            stepBuilder.append("\n");
-                            testCase.put("input", "");
-                            stepNumber++;
-                        }
-                        testCase.put("csvFileName", testCase.get("pageName"));
-                        filePath.put("csvFilePath", (testScenarioName + "/" + testCase.get("csvFileName") + ".csv"));
-                        File file = new File(filePath.get("csvFilePath"));
-                        try (PrintWriter printWriter = new PrintWriter(file)) {
-                            printWriter.write(stepBuilder.toString());
-                            printWriter.flush();
-                        } catch (Exception ex) {
-
-                        }
+                        group.getObjects().clear();
+                        group.getObjects().add(obj);
                     }
+                    testCase.put("step", String.valueOf(stepNumber));
+                    String stepAppender =
+                            testCase.get("step") + "," +
+                            testCase.get("ObjectName") + "," +
+                            "" + "," +
+                            testCase.get("action") + "," +
+                            testCase.get("input") + "," +
+                            testCase.get("Condition") + "," +
+                            testCase.get("pageName");
+                    stepBuilder.append(stepAppender).append("\n");
+                    stepNumber++;
+                    testCase.put("input", "");
                 }
             }
+            if (line.trim().startsWith("page")) {
+                pageMapping.put(
+                        "previousPage",
+                        line.trim().split("\\.")[0]
+                );
+            }
         }
-        if (orExistFlag) {
-            root.appendChild(page);
+        try {
+            testCase.put("csvFileName", testCase.get("pageName"));
+            filePath.put(
+                    "csvFilePath",
+                    testScenarioName + "/"
+                            + testCase.get("csvFileName")
+                            + ".csv"
+            );
+            File csvFile = new File(filePath.get("csvFilePath"));
+            try (PrintWriter printWriter = new PrintWriter(csvFile)) {
+                printWriter.write(stepBuilder.toString());
+                printWriter.flush();
+            }
+        } catch (Exception e) {
+            Logger.getLogger(PlaywrightRecordingParser.class.getName()).log(Level.WARNING, "Failed to write CSV", e);
         }
-        TransformerFactory transformerFactory = TransformerFactory.newInstance();
-        Transformer transformer = transformerFactory.newTransformer();
-        DOMSource source = new DOMSource(doc);
-        StreamResult result = new StreamResult(new File(orFilePath));
-        transformer.transform(source, result);
     }
 
     public void attributeDeclaration() {

--- a/Resources/Configuration/ReportTemplate/html/detailed-v2.html
+++ b/Resources/Configuration/ReportTemplate/html/detailed-v2.html
@@ -337,7 +337,7 @@
             <template x-for="browser in browsers" :key="browser">
               <option :value="browser" x-text="browser"></option>
             </template>
-            <option value="ALL" x-show="browsers.length > 1">All Browsers</option>
+            <option value="ALL" x-show="browsers.length > 1">All Browsers/Devices</option>
           </select>
           
           <!-- Theme Toggle -->
@@ -393,7 +393,7 @@
               
               <!-- Browser -->
               <div class="text-center p-4 bg-gray-50 dark:bg-gray-800 rounded-lg">
-                <div class="text-sm text-muted mb-1">Browser</div>
+                <div class="text-sm text-muted mb-1" x-text="currentDetails.browserTypeLabel"></div>
                 <div class="font-semibold" x-text="currentDetails.browser || '-'"></div>
                 <div class="text-xs text-muted" x-text="currentDetails.bversion || ''"></div>
               </div>
@@ -1101,7 +1101,7 @@
         },
         
         get currentBrowserInfo() {
-          if (this.currentView === 'ALL') return 'All Browsers';
+          if (this.currentView === 'ALL') return 'All Browsers/Devices';
           return this.currentView;
         },
         

--- a/Resources/Configuration/ReportTemplate/html/summary-v2.html
+++ b/Resources/Configuration/ReportTemplate/html/summary-v2.html
@@ -696,13 +696,12 @@
                   }
                 },
                 { 
-                  title: 'Browser', 
+                  title: 'Browser/Device', 
                   field: 'browser',
                   width: 140,
                   formatter: (cell) => {
                     const browser = cell.getValue() || '-';
                     let badgeClass = 'bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-300';
-                    
                     if (browser.toLowerCase().includes('chromium') || browser.toLowerCase().includes('chrome')) {
                       badgeClass = 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400';
                     } else if (browser.toLowerCase().includes('webkit') || browser.toLowerCase().includes('safari')) {
@@ -712,7 +711,6 @@
                     } else if (browser.toLowerCase().includes('no browser') || browser === 'NoBrowser') {
                       badgeClass = 'bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-400';
                     }
-                    
                     return `<span class="inline-flex items-center px-2.5 py-1 rounded-md text-xs font-semibold ${badgeClass}">${this.escapeHtml(browser)}</span>`;
                   }
                 },


### PR DESCRIPTION
- Existing XML files should be converted to YAML (Project and Shared)
- New Projects created should be using YAML moving forward
- Import playwright recording should be converted to YAML as well (WebOR)
- Menu options for OR should be working as expected (Add, Rename, Delete, Get Impacted Cases, Removed Unused Objects)
- Disabled Add Object for Object lvl selection (to prevent creation of objectgroup)
- Fixed faulty CCP (Cut, Copy, Paste)
- Copy to Shared replaced with Moved to Shared