### PR TITLE
Fix inconsistent add test data row listener

### DIFF
--- a/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/testdata/TestDataComponent.java
+++ b/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/testdata/TestDataComponent.java
@@ -1087,7 +1087,7 @@ public class TestDataComponent extends JPanel implements ChangeListener, ActionL
             table.setActionFor("Add", new AbstractAction() {
                 @Override
                 public void actionPerformed(ActionEvent e) {
-                    addRow();
+                    insertRowBelow();
                 }
             });
             table.setActionFor("Delete", new AbstractAction() {


### PR DESCRIPTION
Within the test data table there exists an inconsistency between the "add row" button and the command (Command + Plus on Mac OS), which this PR aims to fix. Below is an example of what happens if a row is added with the command.

Wrong output:
<img width="1249" height="127" alt="unnamed-1" src="https://github.com/user-attachments/assets/8c7afbab-500f-4cc9-b22e-b52d49cfb33e" />

Expected output:
<img width="1248" height="129" alt="unnamed" src="https://github.com/user-attachments/assets/cab973aa-03cb-4970-8953-76709fb98378" />

This PR just changes the hardcoded `addRow` call to the same function connected to button `insertRowBelow`, solving the inconsistency.