### PR TITLE
OR Migration feature from XMLtoYAML

### DIFF
--- a/Datalib/src/main/java/com/ing/datalib/component/Project.java
+++ b/Datalib/src/main/java/com/ing/datalib/component/Project.java
@@ -11,6 +11,8 @@ import com.ing.datalib.settings.ProjectSettings;
 import com.ing.datalib.util.data.FileScanner;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ing.datalib.or.mobile.MobileOR;
+import com.ing.datalib.or.web.WebOR;
 import com.ing.datalib.or.web.WebOR.ORScope;
 import java.io.File;
 import java.nio.file.Files;
@@ -567,6 +569,26 @@ public class Project {
     public void refactorObjectName(ORScope scope, String pageName, String oldName, String newName) {
         for (Scenario scenario : scenarios) {
             scenario.refactorObjectName(scope, pageName, oldName, newName);
+        }
+    }
+ 
+    /**
+     * Refactors Mobile OR object references in TestSteps.
+     * Mobile scope is mapped to Web scope because Scenarios/TestSteps
+     * are tool-agnostic and only care about PROJECT vs SHARED.
+     */
+    public void refactorMobileObjectName(MobileOR.ORScope scope, String pageName, String oldName, String newName) {
+        for (Scenario scenario : scenarios) {
+            WebOR.ORScope webScope =
+            (scope == MobileOR.ORScope.SHARED)
+                ? WebOR.ORScope.SHARED
+                : WebOR.ORScope.PROJECT;
+            scenario.refactorObjectName(
+                webScope,
+                pageName,
+                oldName,
+                newName
+            );
         }
     }
 

--- a/Datalib/src/main/java/com/ing/datalib/component/Project.java
+++ b/Datalib/src/main/java/com/ing/datalib/component/Project.java
@@ -1,32 +1,34 @@
 
 package com.ing.datalib.component;
 
+import java.io.File;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import static java.util.stream.Collectors.toList;
+import java.util.stream.Stream;
+
+import javax.swing.table.DefaultTableModel;
+import javax.swing.table.TableModel;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.ing.datalib.component.utils.FileUtils;
 import static com.ing.datalib.component.utils.FileUtils.DIR_FILTER;
 import com.ing.datalib.model.DataItem;
 import com.ing.datalib.model.Meta;
 import com.ing.datalib.model.ProjectInfo;
 import com.ing.datalib.or.ObjectRepository;
-import com.ing.datalib.settings.ProjectSettings;
-import com.ing.datalib.util.data.FileScanner;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.ing.datalib.or.mobile.MobileOR;
 import com.ing.datalib.or.web.WebOR;
 import com.ing.datalib.or.web.WebOR.ORScope;
-import java.io.File;
-import java.nio.file.Files;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.LinkedHashSet;
-import java.util.Set;
-import java.util.Objects;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-import static java.util.stream.Collectors.toList;
-import java.util.stream.Stream;
-import javax.swing.table.DefaultTableModel;
-import javax.swing.table.TableModel;
+import com.ing.datalib.settings.ProjectSettings;
+import com.ing.datalib.util.data.FileScanner;
 
 /**
  * Represents an automation project and acts as the central entry point for loading, managing,
@@ -546,13 +548,13 @@ public class Project {
     }
     
     public void refactorObjectName(String pageName, String oldName, String newName) {
-        for (Scenario scenario : scenarios) {
+        for (Scenario scenario : getAllScenarios()) {
             scenario.refactorObjectName(pageName, oldName, newName);
         }
     }
 
     public void refactorObjectName(String oldpageName, String oldObjName, String newPageName, String newObjName) {
-        for (Scenario scenario : scenarios) {
+        for (Scenario scenario : getAllScenarios()) {
             scenario.refactorObjectName(oldpageName, oldObjName, newPageName, newObjName);
         }
     }
@@ -567,7 +569,7 @@ public class Project {
      * @param newName  new object name to apply
      */
     public void refactorObjectName(ORScope scope, String pageName, String oldName, String newName) {
-        for (Scenario scenario : scenarios) {
+        for (Scenario scenario : getAllScenarios()) {
             scenario.refactorObjectName(scope, pageName, oldName, newName);
         }
     }
@@ -578,7 +580,7 @@ public class Project {
      * are tool-agnostic and only care about PROJECT vs SHARED.
      */
     public void refactorMobileObjectName(MobileOR.ORScope scope, String pageName, String oldName, String newName) {
-        for (Scenario scenario : scenarios) {
+        for (Scenario scenario : getAllScenarios()) {
             WebOR.ORScope webScope =
             (scope == MobileOR.ORScope.SHARED)
                 ? WebOR.ORScope.SHARED
@@ -593,7 +595,7 @@ public class Project {
     }
 
     public void refactorPageName(String oldPageName, String newPageName) {
-        for (Scenario scenario : scenarios) {
+        for (Scenario scenario : getAllScenarios()) {
             scenario.refactorPageName(oldPageName, newPageName);
         }
     }
@@ -622,7 +624,7 @@ public class Project {
     public void refactorPageName(ORScope scope, String oldPageName, String newPageName) {
         String oldScoped = scope == ORScope.SHARED ? "[Shared] " + oldPageName : "[Project] " + oldPageName;
         String newScoped = scope == ORScope.SHARED ? "[Shared] " + newPageName : "[Project] " + newPageName;
-        for (Scenario scenario : scenarios) {
+        for (Scenario scenario : getAllScenarios()) {
             scenario.refactorPageName(oldPageName, newPageName);
             scenario.refactorPageName(oldScoped, newScoped);
         }
@@ -656,13 +658,37 @@ public class Project {
                     ? "[Shared] " + pageName
                     : "[Project] " + pageName;
         }
+        // Search in TestPlan scenarios
         for (Scenario scenario : scenarios) {
             impacted.addAll(scenario.getImpactedObjectTestCases(pageName, objectName));
             if (scopedPageName != null) {
                 impacted.addAll(scenario.getImpactedObjectTestCases(scopedPageName, objectName));
             }
         }
-        return new ArrayList<>(impacted);
+        // Search in ReusableComponents scenarios
+        for (Scenario scenario : reusableScenarios) {
+            impacted.addAll(scenario.getImpactedObjectTestCases(pageName, objectName));
+            if (scopedPageName != null) {
+                impacted.addAll(scenario.getImpactedObjectTestCases(scopedPageName, objectName));
+            }
+        }
+        // Sort by type (Test Plan first), then by scenario name, then by test case name
+        List<TestCase> sortedList = new ArrayList<>(impacted);
+        sortedList.sort((tc1, tc2) -> {
+            // First compare by source type (TEST_PLAN comes before REUSABLE_COMPONENTS)
+            int sourceCompare = tc1.getScenario().getSource().compareTo(tc2.getScenario().getSource());
+            if (sourceCompare != 0) {
+                return sourceCompare;
+            }
+            // Then compare by scenario name
+            int scenarioCompare = tc1.getScenario().getName().compareToIgnoreCase(tc2.getScenario().getName());
+            if (scenarioCompare != 0) {
+                return scenarioCompare;
+            }
+            // Finally compare by test case name
+            return tc1.getName().compareToIgnoreCase(tc2.getName());
+        });
+        return sortedList;
     }
 
     public List<TestCase> getImpactedTestCaseTestCases(String scenarioName, String testCaseName) {

--- a/Datalib/src/main/java/com/ing/datalib/component/TestCase.java
+++ b/Datalib/src/main/java/com/ing/datalib/component/TestCase.java
@@ -4,6 +4,7 @@ package com.ing.datalib.component;
 import com.ing.datalib.component.TestStep.HEADERS;
 import com.ing.datalib.component.utils.FileUtils;
 import com.ing.datalib.component.utils.SaveListener;
+import com.ing.datalib.or.mobile.ResolvedMobileObject;
 import com.ing.datalib.or.web.ResolvedWebObject;
 import com.ing.datalib.or.web.WebOR.ORScope;
 import java.io.File;
@@ -53,6 +54,10 @@ public class TestCase extends DataModel {
     private TestCase parentTestCase = null;
     
     private Boolean exitParamLoop = false;
+    
+    private int migratedReferencesCount = 0;
+    
+    private boolean migrationChecked = false;
 
     public TestCase(Scenario scenario, String name) {
         this.scenario = scenario;
@@ -77,6 +82,18 @@ public class TestCase extends DataModel {
 
     public List<TestStep> getTestSteps() {
         return testSteps;
+    }
+    
+    /**
+     * Returns the number of references that were migrated to explicit scope prefixes during load.
+     * This count is reset after retrieval to avoid duplicate notifications.
+     * 
+     * @return The number of migrated references
+     */
+    public int getMigratedReferencesCount() {
+        int count = migratedReferencesCount;
+        migratedReferencesCount = 0; // Reset after retrieval
+        return count;
     }
 
     @Override
@@ -277,6 +294,10 @@ public class TestCase extends DataModel {
     public void loadTestCaseTableModel() {
         if (testSteps.isEmpty()) {
             loadSteps();
+        } else if (!migrationChecked) {
+            // Check for migration even if steps are already loaded
+            checkAndMigrateReferences();
+            migrationChecked = true;
         }
     }
 
@@ -294,15 +315,122 @@ public class TestCase extends DataModel {
 
     private void loadSteps() {
         List<CSVRecord> records = FileUtils.getRecords(new File(getLocation()));
+        migratedReferencesCount = 0;
+        
         if (!records.isEmpty()) {
             for (CSVRecord record : records) {
-                testSteps.add(new TestStep(this, record));
+                TestStep step = new TestStep(this, record);
+                
+                // Auto-migrate unprefixed references to explicit [Project]/[Shared] format
+                String ref = step.getReference();
+                if (ref != null && !ref.trim().isEmpty() && 
+                    !ref.startsWith("[Project] ") && !ref.startsWith("[Shared] ") &&
+                    step.isPageObjectStep()) {
+                    
+                    String migratedRef = resolveAndAddPrefix(step);
+                    if (migratedRef != null && !migratedRef.equals(ref)) {
+                        step.setReference(migratedRef);
+                        migratedReferencesCount++;
+                    }
+                }
+                
+                testSteps.add(step);
             }
             setSaved(true);
+            
+            // Auto-save if migration happened to persist explicit prefixes to CSV
+            if (migratedReferencesCount > 0) {
+                setSaved(false);
+                save();
+                Logger.getLogger(TestCase.class.getName()).log(Level.INFO, 
+                    "Migrated {0} object reference(s) to explicit scope prefixes in: {1}", 
+                    new Object[]{migratedReferencesCount, getName()});
+            }
         } else {
             testSteps.add(new TestStep(this));
         }
+        migrationChecked = true;
         super.clearUndoRedo();
+    }
+    
+    /**
+     * Checks and migrates unprefixed references for test steps already loaded in memory.
+     * This is called when test steps are already loaded but migration hasn't been checked yet.
+     */
+    private void checkAndMigrateReferences() {
+        migratedReferencesCount = 0;
+        
+        for (TestStep step : testSteps) {
+            String ref = step.getReference();
+            if (ref != null && !ref.trim().isEmpty() && 
+                !ref.startsWith("[Project] ") && !ref.startsWith("[Shared] ") &&
+                step.isPageObjectStep()) {
+                
+                String migratedRef = resolveAndAddPrefix(step);
+                if (migratedRef != null && !migratedRef.equals(ref)) {
+                    step.setReference(migratedRef);
+                    migratedReferencesCount++;
+                }
+            }
+        }
+        
+        // Auto-save if migration happened
+        if (migratedReferencesCount > 0) {
+            setSaved(false);
+            save();
+            Logger.getLogger(TestCase.class.getName()).log(Level.INFO, 
+                "Migrated {0} object reference(s) to explicit scope prefixes in: {1}", 
+                new Object[]{migratedReferencesCount, getName()});
+        }
+    }
+    
+    /**
+     * Resolves an unprefixed reference and adds the appropriate [Project] or [Shared] prefix.
+     * Uses Project-first resolution priority matching runtime behavior.
+     * 
+     * @param step The test step containing the reference to resolve
+     * @return The reference with explicit scope prefix, or null if unresolvable
+     */
+    private String resolveAndAddPrefix(TestStep step) {
+        try {
+            var repo = getProject().getObjectRepository();
+            if (repo == null) {
+                return null;
+            }
+            
+            String ref = step.getReference();
+            String objectName = step.getObject();
+            
+            // Try resolving as web object (Project scope first, then Shared)
+            var wref = ResolvedWebObject.PageRef.parse(ref);
+            var wres = repo.resolveWebObject(wref, objectName);
+            
+            if (wres != null) {
+                if (wres.isFromShared()) {
+                    return "[Shared] " + wres.getPageName();
+                } else if (wres.isFromProject()) {
+                    return "[Project] " + wres.getPageName();
+                }
+            }
+            
+            // Try resolving as mobile object (Project scope first, then Shared)
+            var mref = ResolvedMobileObject.PageRef.parse(ref);
+            var mres = repo.resolveMobileObject(mref, objectName);
+            
+            if (mres != null) {
+                if (mres.isFromShared()) {
+                    return "[Shared] " + mres.getPageName();
+                } else if (mres.isFromProject()) {
+                    return "[Project] " + mres.getPageName();
+                }
+            }
+            
+            // Unable to resolve - leave reference as-is (may be invalid or dynamic)
+            return null;
+        } catch (Exception e) {
+            // If resolution fails, return null to leave reference unchanged
+            return null;
+        }
     }
 
     public void save() {
@@ -614,6 +742,7 @@ public class TestCase extends DataModel {
     public void refactorObjectName(String oldpageName, String oldObjName, String newPageName, String newObjName) {
         Boolean clearOnExit = getTestSteps().isEmpty();
         loadTableModel();
+        boolean changesMade = false;
 
         for (TestStep testStep : testSteps) {
             String ref = normalizePageRef(Objects.toString(testStep.getReference(), ""));
@@ -621,11 +750,14 @@ public class TestCase extends DataModel {
             if (ref.equals(oldpageName) && obj.equals(oldObjName)) {
                 testStep.setObject(newObjName);
                 testStep.setReference(newPageName);
+                changesMade = true;
             }
         }
 
-        if (clearOnExit) {
+        if (changesMade) {
             save();
+        }
+        if (clearOnExit) {
             getTestSteps().clear();
         }
     }
@@ -642,16 +774,20 @@ public class TestCase extends DataModel {
     public void refactorObjectName(ORScope scope, String pageName, String oldName, String newName) {
         Boolean clearOnExit = getTestSteps().isEmpty();
         loadTableModel();
+        boolean changesMade = false;
         for (TestStep testStep : testSteps) {
             String refRaw = Objects.toString(testStep.getReference(), "");
             String obj    = Objects.toString(testStep.getObject(), "");
             boolean scopedMatch = matchesScope(refRaw, scope) && normalizePageRef(refRaw).equals(pageName);
             if (scopedMatch && obj.equals(oldName)) {
                 testStep.setObject(newName);
+                changesMade = true;
             }
         }
-        if (clearOnExit) {
+        if (changesMade) {
             save();
+        }
+        if (clearOnExit) {
             getTestSteps().clear();
         }
     }

--- a/Datalib/src/main/java/com/ing/datalib/component/TestCase.java
+++ b/Datalib/src/main/java/com/ing/datalib/component/TestCase.java
@@ -4,6 +4,7 @@ package com.ing.datalib.component;
 import com.ing.datalib.component.TestStep.HEADERS;
 import com.ing.datalib.component.utils.FileUtils;
 import com.ing.datalib.component.utils.SaveListener;
+import com.ing.datalib.or.web.ResolvedWebObject;
 import com.ing.datalib.or.web.WebOR.ORScope;
 import java.io.File;
 import java.io.FileWriter;
@@ -213,6 +214,11 @@ public class TestCase extends DataModel {
 
     public void addObjectStep(int index, String objectName, String pageName) {
         TestStep step = new TestStep(this).asObjectStep(objectName, pageName);
+        addStep(index, step);
+    }
+
+    public void addObjectStep(int index, ResolvedWebObject rwo) {
+        TestStep step = new TestStep(this).asObjectStep(rwo);
         addStep(index, step);
     }
 

--- a/Datalib/src/main/java/com/ing/datalib/component/TestStep.java
+++ b/Datalib/src/main/java/com/ing/datalib/component/TestStep.java
@@ -1,6 +1,8 @@
 
 package com.ing.datalib.component;
 
+import com.ing.datalib.or.mobile.ResolvedMobileObject;
+import com.ing.datalib.or.web.ResolvedWebObject;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -203,6 +205,28 @@ public class TestStep {
     public TestStep asObjectStep(String objectName, String pageName) {
         setObject(objectName);
         setReference(pageName);
+        return this;
+    }
+
+    public TestStep asObjectStep(ResolvedWebObject rwo) {
+        setObject(rwo.getObjectName());
+        setReference(
+            new ResolvedWebObject.PageRef(
+                rwo.getPageName(),
+                rwo.getScope()
+            ).qualified()
+        );
+        return this;
+    }
+
+    public TestStep asObjectStep(ResolvedMobileObject rmo) {
+        setObject(rmo.getObjectName());
+        setReference(
+            new ResolvedMobileObject.PageRef(
+                rmo.getPageName(),
+                rmo.getScope()
+            ).qualified()
+        );
         return this;
     }
 

--- a/Datalib/src/main/java/com/ing/datalib/or/ObjectRepository.java
+++ b/Datalib/src/main/java/com/ing/datalib/or/ObjectRepository.java
@@ -930,11 +930,6 @@ public class ObjectRepository {
         return generateUniqueName(baseName, name -> or.getPageByName(name) != null);
     }
 
-    private String generateUniqueGroupName(WebORPage page, String baseName) {
-        if (page == null) return baseName;
-        return generateUniqueName(baseName, name -> page.getObjectGroupByName(name) != null);
-    }
-
     /**
      * Ensures a page exists in the given OR; creates one if missing.
      */
@@ -1032,6 +1027,14 @@ public class ObjectRepository {
         return uniqueName;
     }
     
+    /**
+     * Moved a WebOR object into a shared page (creating the page if needed)
+     * using a unique object group name.
+     *
+     * @param source          resolved web object
+     * @param targetPageName  target page in shared OR
+     * @return new object name
+     */
     public String moveWebObject(ResolvedWebObject source, String targetPageName) {
         if (source == null) return null;
         WebOR sharedOR = getWebSharedOR();
@@ -1041,34 +1044,33 @@ public class ObjectRepository {
         ObjectGroup<WebORObject> originalGroup = source.getGroup();
         if (originalGroup == null) return null;
         String originalName = originalGroup.getName();
-        if (targetPage.getObjectGroupByName(originalName) != null) {
-            return null;
+        String baseName = originalName.replaceAll("_\\d+$", "");
+        String finalName = baseName;
+        if (targetPage.getObjectGroupByName(finalName) != null) {
+            int index = 1;
+            do {
+                finalName = baseName + "_" + index++;
+            } while (targetPage.getObjectGroupByName(finalName) != null);
         }
-        ORPageInf sourcePage = originalGroup.getParent();
-        if (sourcePage != null) {
-            sourcePage.getObjectGroups().remove(originalGroup);
-            sourcePage.getRoot().setSaved(false);
-            if (useYamlFormat && sourcePage instanceof WebORPage) {
-                saveWebPageNow((WebORPage) sourcePage);
-            }
-        }
-        originalGroup.setParent(targetPage);
-        targetPage.getObjectGroups().add(originalGroup);
+        ObjectGroup<WebORObject> newGroup =
+            cloneGroupIntoPage(originalGroup, targetPage, finalName);
+        targetPage.getObjectGroups().add(newGroup);
         sharedOR.setSaved(false);
         if (useYamlFormat) {
             saveWebPageNow(targetPage);
         }
         LOG.info(
             "Moved Web Object '" + originalName +
-            "' to SHARED page '" + targetPageName + "'"
+            "' to SHARED as '" + finalName + "'"
         );
-        return originalName;
+
+        return finalName;
     }
 
     /**
      * Copies a project MobileOR page into the shared Mobile OR using a unique name.
      * @param sourcePageName project page to copy from
-     * @param targetPageName desired shared page name (will uniquify if needed)
+     * @param targetPageName desired shared page name
      * @return actual created page name in shared OR, or null on failure
      */
     public String copyMobilePage(String sourcePageName, String targetPageName) {
@@ -1123,6 +1125,13 @@ public class ObjectRepository {
         return uniqueName;
     }
     
+     /**
+     * Moves a MobileOR object into a target shared Mobile page (creates page if needed)
+     * using a unique object group name.
+     * @param source resolved mobile object (from project OR)
+     * @param targetPageName target page name in shared Mobile OR
+     * @return new object name created in shared OR, or null on failure
+     */
     public String moveMobileObject(ResolvedMobileObject source, String targetPageName) {
         if (source == null) return null;
         MobileOR sharedOR = getMobileSharedOR();
@@ -1132,39 +1141,30 @@ public class ObjectRepository {
         ObjectGroup<MobileORObject> originalGroup = source.getGroup();
         if (originalGroup == null) return null;
         String originalName = originalGroup.getName();
-        if (targetPage.getObjectGroupByName(originalName) != null) {
-            return null;
+        String baseName = originalName.replaceAll("_\\d+$", "");
+        String finalName = baseName;
+        if (targetPage.getObjectGroupByName(finalName) != null) {
+            int index = 1;
+            do {
+                finalName = baseName + "_" + index++;
+            } while (targetPage.getObjectGroupByName(finalName) != null);
         }
-        ORPageInf sourcePage = originalGroup.getParent();
-        if (sourcePage != null) {
-            sourcePage.getObjectGroups().remove(originalGroup);
-            sourcePage.getRoot().setSaved(false);
-
-            if (useYamlFormat && sourcePage instanceof MobileORPage) {
-                saveMobilePageNow((MobileORPage) sourcePage);
-            }
-        }
-        originalGroup.setParent(targetPage);
-        targetPage.getObjectGroups().add(originalGroup);
+        ObjectGroup<MobileORObject> newGroup = cloneMobileGroupIntoPage(originalGroup, targetPage, finalName);
+        targetPage.getObjectGroups().add(newGroup);
         sharedOR.setSaved(false);
         if (useYamlFormat) {
             saveMobilePageNow(targetPage);
         }
         LOG.info(
-            "Moved Mobile Object Group '" + originalName +
-            "' to SHARED page '" + targetPageName + "'"
+            "Moved Mobile Object '" + originalName +
+            "' to SHARED as '" + finalName + "'"
         );
-        return originalName;
+        return finalName;
     }
 
     private String generateUniquePageName(MobileOR mor, String baseName) {
         if (mor == null) return baseName;
         return generateUniqueName(baseName, name -> mor.getPageByName(name) != null);
-    }
-
-    private String generateUniqueMobileGroupName(MobileORPage page, String baseName) {
-        if (page == null) return baseName;
-        return generateUniqueName(baseName, name -> page.getObjectGroupByName(name) != null);
     }
 
     private MobileORPage getOrCreateMobilePage(MobileOR mor, String pageName) {

--- a/Datalib/src/main/java/com/ing/datalib/or/ObjectRepository.java
+++ b/Datalib/src/main/java/com/ing/datalib/or/ObjectRepository.java
@@ -2,6 +2,7 @@
 package com.ing.datalib.or;
 
 import com.ing.datalib.component.Project;
+import com.ing.datalib.component.TestStep;
 import com.ing.datalib.or.structureddata.StructuredData;
 import com.ing.datalib.or.common.ORPageInf;
 import com.ing.datalib.or.common.ObjectGroup;
@@ -21,6 +22,8 @@ import com.ing.datalib.or.structureddata.ResolvedStructuredDataObject;
 import com.ing.datalib.or.mobile.ResolvedMobileObject;
 import com.ing.datalib.or.web.ResolvedWebObject;
 import com.ing.datalib.or.web.WebOR.ORScope;
+import static com.ing.datalib.or.web.WebOR.ORScope.PROJECT;
+import static com.ing.datalib.or.web.WebOR.ORScope.SHARED;
 import com.ing.datalib.or.web.WebORObject;
 import com.ing.datalib.or.web.WebORPage;
 import java.io.File;
@@ -41,7 +44,6 @@ import java.util.logging.Logger;
  */
 public class ObjectRepository {
     private static final XmlMapper XML_MAPPER = new XmlMapper();
-    private static final ObjectMapper YAML_MAPPER = createYamlMapper();
     private static final Logger LOG = Logger.getLogger(ObjectRepository.class.getName());
     private final Project sProject;
     private WebOR webSharedOR;
@@ -51,20 +53,16 @@ public class ObjectRepository {
     private StructuredData structuredDataProjectOR;
     private StructuredData structuredDataSharedOR;
     
-    private final Set<String> sharedUsageProjects = new HashSet<>();
+    private final Set<String> webSharedUsageProjects = new HashSet<>();
+    private final Set<String> mobileSharedUsageProjects = new HashSet<>();
+    private List<String> webSharedProjectsFromXml = List.of();
+    private List<String> mobileSharedProjectsFromXml = List.of();
     
     // YAML support
     private boolean useYamlFormat = true; // Default to YAML for new projects
     private YamlORReader yamlReader;
     private YamlORWriter yamlWriter;
     
-    private static ObjectMapper createYamlMapper() {
-        YAMLFactory factory = new YAMLFactory();
-        factory.disable(YAMLGenerator.Feature.WRITE_DOC_START_MARKER);
-        factory.enable(YAMLGenerator.Feature.MINIMIZE_QUOTES);
-        return new ObjectMapper(factory);
-    }
-
     /**
      * Creates an ObjectRepository for the given project and loads all OR files
      * (project WebOR, shared WebOR, and MobileOR), initializing defaults when missing.
@@ -82,196 +80,61 @@ public class ObjectRepository {
      */
     private void init() {
         try {
-            // Initialize YAML support
-            yamlReader = new YamlORReader();
+            yamlReader = new YamlORReader(this);
             yamlWriter = new YamlORWriter();
-            
-            File orRepLocation = new File(getORRepLocation());
-            
-            // Determine format once for PROJECT ORs only
-            // Check if YAML or XML files exist for project ORs
-            boolean hasYamlFiles = yamlReader.webORExists(orRepLocation) 
-                                || yamlReader.mobileORExists(orRepLocation) 
-                                || yamlReader.structuredDataORExists(orRepLocation);
-            boolean hasXmlFiles = new File(getORLocation()).exists() 
-                               || new File(getMORLocation()).exists() 
-                               || new File(getStructuredDataORLocation()).exists();
-            
-            // Set format once for entire project
-            if (hasYamlFiles) {
+
+            boolean projectYamlExists = hasYamlOR();
+            boolean sharedYamlExists  = hasSharedYamlOR();
+            boolean xmlExists = hasAnyXmlOR();
+
+            if (xmlExists) {
+                loadXmlObjectRepositories();
+                convertXmlOrsToYamlAndArchive();
+                loadYamlObjectRepositories();
                 useYamlFormat = true;
-                LOG.info("Using YAML format for project Object Repositories");
-            } else if (hasXmlFiles) {
-                useYamlFormat = false;
-                LOG.info("Using XML format for project Object Repositories (legacy)");
-            } else {
-                // New project - default to YAML
+            }
+            
+            else if (projectYamlExists || sharedYamlExists) {
+                loadYamlObjectRepositories();
                 useYamlFormat = true;
-                LOG.info("New project - using YAML format for Object Repositories");
             }
             
-            // === SHARED ORs (always XML) ===
-            File sharedFile = new File(getSharedORLocation());
-            if (sharedFile.exists()) {
-                webSharedOR = XML_MAPPER.readValue(sharedFile, WebOR.class);
-                webSharedOR.setName("Shared Web Objects");
-            } else {
-                webSharedOR = new WebOR("Shared Web Objects");
-            }
-            
-            File sharedmorFile = new File(getSharedMORLocation());
-            if (sharedmorFile.exists()) {
-                mobileSharedOR = XML_MAPPER.readValue(sharedmorFile, MobileOR.class);
-                mobileSharedOR.setName("Shared Mobile Objects");
-            } else {
-                mobileSharedOR = new MobileOR("Shared Mobile Objects");
-            }
-            
-            // === PROJECT ORs (YAML or XML based on detection) ===
-            // Load Web Project OR
-            if (useYamlFormat && yamlReader.webORExists(orRepLocation)) {
-                webProjectOR = yamlReader.readWebOR(orRepLocation);
-                webProjectOR.setName(sProject.getName());
-            } else if (!useYamlFormat && new File(getORLocation()).exists()) {
-                webProjectOR = XML_MAPPER.readValue(new File(getORLocation()), WebOR.class);
-                webProjectOR.setName(sProject.getName());
-            } else {
-                webProjectOR = new WebOR(sProject.getName());
-            }
-            // Set ObjectRepository reference immediately to prevent directory creation
-            if (webProjectOR != null) {
+            else {
+                webProjectOR = new WebOR();
+                webProjectOR.setScope(WebOR.ORScope.PROJECT);
                 webProjectOR.setObjectRepository(this);
-                webProjectOR.setScope(ORScope.PROJECT);
-            }
-            
-            // Load Mobile Project OR
-            if (useYamlFormat && yamlReader.mobileORExists(orRepLocation)) {
-                mobileProjectOR = yamlReader.readMobileOR(orRepLocation);
-                mobileProjectOR.setName(sProject.getName());
-            } else if (!useYamlFormat && new File(getMORLocation()).exists()) {
-                mobileProjectOR = XML_MAPPER.readValue(new File(getMORLocation()), MobileOR.class);
-                mobileProjectOR.setName(sProject.getName());
-            } else {
-                mobileProjectOR = new MobileOR(sProject.getName());
-            }
-            // Set ObjectRepository reference immediately
-            if (mobileProjectOR != null) {
-                mobileProjectOR.setObjectRepository(this);
-                mobileProjectOR.setScope(MobileOR.ORScope.PROJECT);
-            }
-            
-            // Load Structured Data Project OR
-            if (useYamlFormat && yamlReader.structuredDataORExists(orRepLocation)) {
-                structuredDataProjectOR = yamlReader.readStructuredDataOR(orRepLocation);
-                structuredDataProjectOR.setName(sProject.getName());
-            } else if (!useYamlFormat && new File(getStructuredDataORLocation()).exists()) {
-                structuredDataProjectOR = XML_MAPPER.readValue(new File(getStructuredDataORLocation()), StructuredData.class);
-                structuredDataProjectOR.setName(sProject.getName());
-            } else {
-                structuredDataProjectOR = new StructuredData(sProject.getName());
-            }
-
-            // Set ObjectRepository reference immediately
-            if (structuredDataProjectOR != null) {
-                structuredDataProjectOR.setObjectRepository(this);
-            }
-
-            // Set remaining properties for shared and project ORs
-            if (webSharedOR != null) {
-                webSharedOR.setObjectRepository(this);
-                webSharedOR.setSaved(true);
-                webSharedOR.setRepLocationOverride(getSharedORRepLocation());
-                webSharedOR.setScope(ORScope.SHARED);
-            }
-            if (webProjectOR != null) {
-                webProjectOR.setSaved(true);
-            }
-            if (mobileSharedOR != null) {
-                mobileSharedOR.setObjectRepository(this);
-                mobileSharedOR.setSaved(true);
-                mobileSharedOR.setRepLocationOverride(getSharedMORRepLocation());
-                mobileSharedOR.setScope(MobileOR.ORScope.SHARED);
+                webProjectOR.setName(sProject.getName());
                 
-            }
-            if (mobileProjectOR != null) {
-                mobileProjectOR.setSaved(true);
-            }
-            if (structuredDataProjectOR != null) {
+                mobileProjectOR = new MobileOR();
+                mobileProjectOR.setScope(MobileOR.ORScope.PROJECT);
+                mobileProjectOR.setObjectRepository(this);
+                mobileProjectOR.setName(sProject.getName());
+                
+                structuredDataProjectOR = new StructuredData();
                 structuredDataProjectOR.setObjectRepository(this);
-                structuredDataProjectOR.setSaved(true);
-            }
-
-            LOG.log(Level.INFO, "Shared WebOR loaded: {0}", (webSharedOR != null));
-            LOG.log(Level.INFO, "Project WebOR loaded: {0}", (webProjectOR != null));
-            LOG.log(Level.INFO, "Shared MobileOR loaded: {0}", (mobileSharedOR != null));
-            LOG.log(Level.INFO, "Project MobileOR loaded: {0}", (mobileProjectOR != null));
-            
-            // Try YAML format first (modern format)
-            if (yamlReader.webORExists(orRepLocation)) {
-                LOG.info("Loading Web OR from YAML format");
-                webProjectOR = yamlReader.readWebOR(orRepLocation);
-                webProjectOR.setName(sProject.getName());
-                useYamlFormat = true;
-            } else if (new File(getORLocation()).exists()) {
-                // Fall back to XML format (legacy)
-                LOG.info("Loading Web OR from XML format");
-                webProjectOR = XML_MAPPER.readValue(new File(getORLocation()), WebOR.class);
-                webProjectOR.setName(sProject.getName());
-                useYamlFormat = false; // Use XML format for legacy projects
-            } else {
-                webProjectOR = new WebOR(sProject.getName());
-                // useYamlFormat stays true for new projects
-            }
-            
-            // Try YAML format first for Mobile OR
-            if (yamlReader.mobileORExists(orRepLocation)) {
-                LOG.info("Loading Mobile OR from YAML format");
-                mobileProjectOR = yamlReader.readMobileOR(orRepLocation);
-                mobileProjectOR.setName(sProject.getName());
-                useYamlFormat = true;
-            } else if (new File(getMORLocation()).exists()) {
-                // Fall back to XML format (legacy)
-                LOG.info("Loading Mobile OR from XML format");
-                mobileProjectOR = XML_MAPPER.readValue(new File(getMORLocation()), MobileOR.class);
-                mobileProjectOR.setName(sProject.getName());
-                useYamlFormat = false; // Use XML format for legacy projects
-            } else {
-                mobileProjectOR = new MobileOR(sProject.getName());
-                // useYamlFormat stays true for new projects
-            }
-
-            // Try YAML format first for Structured Data OR
-            if (yamlReader.structuredDataORExists(orRepLocation)) {
-                LOG.info("Loading Structured Data OR from YAML format");
-                structuredDataProjectOR = yamlReader.readStructuredDataOR(orRepLocation);
                 structuredDataProjectOR.setName(sProject.getName());
                 useYamlFormat = true;
-            } else if (new File(getStructuredDataORLocation()).exists()) {
-                // Fall back to XML format (legacy)
-                LOG.info("Loading Structured Data OR from XML format");
-                structuredDataProjectOR = XML_MAPPER.readValue(new File(getStructuredDataORLocation()), StructuredData.class);
-                structuredDataProjectOR.setName(sProject.getName());
-                useYamlFormat = false; // Use XML format for legacy projects
-            } else {
-                structuredDataProjectOR = new StructuredData(sProject.getName());
-                // useYamlFormat stays true for new projects
+                
+                if (webSharedOR == null && !sharedYamlExists) {
+                    webSharedOR = new WebOR("Shared Web Objects");
+                    webSharedOR.setScope(WebOR.ORScope.SHARED);
+                    webSharedOR.setObjectRepository(this);
+                    webSharedOR.setSaved(true);
+                }
+                if (mobileSharedOR == null && !sharedYamlExists) {
+                    mobileSharedOR = new MobileOR("Shared Mobile Objects");
+                    mobileSharedOR.setScope(MobileOR.ORScope.SHARED);
+                    mobileSharedOR.setObjectRepository(this);
+                    mobileSharedOR.setSaved(true);
+                }
             }
-
-            webProjectOR.setObjectRepository(this);
-            webProjectOR.setSaved(true);
-            mobileProjectOR.setObjectRepository(this);
-            structuredDataProjectOR.setObjectRepository(this);
-        
-        } catch (IOException ex) {
-            Logger.getLogger(ObjectRepository.class.getName()).log(Level.SEVERE, null, ex);
+        } catch (IOException e) {
+            LOG.log(Level.SEVERE, "Failed to initialize ObjectRepository", e);
         }
     }
 
     public String getORLocation() {
         return sProject.getLocation() + File.separator + "OR.object";
-    }
-    public String getSharedORLocation() {
-        return "Shared" + File.separator + "SharedWebObjects" + File.separator + "SharedOR.object";
     }
     public String getIORLocation() {
         return sProject.getLocation() + File.separator + "IOR.object";
@@ -282,26 +145,27 @@ public class ObjectRepository {
     public String getStructuredDataORLocation() {
         return sProject.getLocation() + File.separator + "StructuredDataOR.object";
     }
+    public String getSharedORLocation() {
+        return "Shared" + File.separator + "SharedWebObjects" + File.separator + "SharedOR.object";
+    }
     public String getSharedMORLocation() {
         return "Shared" + File.separator + "SharedMobileObjects" + File.separator + "SharedMOR.object";
     }
     public String getORRepLocation() {
         return sProject.getLocation() + File.separator + "ObjectRepository";
     }
-    public String getSharedORRepLocation() {
-        return "Shared" + File.separator + "SharedWebObjects" + File.separator + "SharedObjectRepository";
-    }
     public String getIORRepLocation() {
         return sProject.getLocation() + File.separator + "ImageObjectRepository";
-    }
-    public String getMORRepLocation() {
-        return sProject.getLocation() + File.separator + "MobileObjectRepository";
     }
     public String getStructuredDataORRepLocation() {
         return sProject.getLocation() + File.separator + "StructuredDataObjectRepository";
     }
-    public String getSharedMORRepLocation() {
-        return "Shared" + File.separator + "SharedMobileObjects" + File.separator + "MobileObjectRepository";
+    public String getSharedORRepLocation() {
+        File projectDir = new File(sProject.getLocation());   
+        File projectsRoot = projectDir.getParentFile();       
+        File ingeniousRoot = projectsRoot.getParentFile();    
+        File sharedOR = new File(ingeniousRoot,"Shared" + File.separator + "SharedObjectRepository");
+        return sharedOR.getAbsolutePath();
     }
     public Project getsProject() {
         return sProject;
@@ -331,95 +195,65 @@ public class ObjectRepository {
      */
     public void save() {
         try {
-            List<String> existingProjects = (webSharedOR != null) ? webSharedOR.getSharedProjects() : java.util.List.of();
-            LinkedHashSet<String> mergedProjects = new LinkedHashSet<>();
-            if (existingProjects != null) mergedProjects.addAll(existingProjects);
-            mergedProjects.addAll(sharedUsageProjects);
-            boolean projectsChanged = false;
+            boolean webProjectsChanged = false;
             if (webSharedOR != null) {
-                ArrayList<String> mergedList = new ArrayList<>(mergedProjects);
+                LinkedHashSet<String> webMerged = new LinkedHashSet<>();
+                webMerged.addAll(webSharedProjectsFromXml);
+                webMerged.addAll(webSharedUsageProjects);
+                File sharedRoot = new File(getSharedORRepLocation());
+                File webMetaFile = new File(sharedRoot, "webor-projectsdata.yaml");
+                webMerged.addAll(yamlWriter.readExistingProjects(webMetaFile));
                 List<String> current = webSharedOR.getSharedProjects();
-                projectsChanged = (current == null) || !new LinkedHashSet<>(current).equals(mergedProjects);
-                if (projectsChanged) {
-                    webSharedOR.setSharedProjects(mergedList);
+                webProjectsChanged = current == null || !new LinkedHashSet<>(current).equals(webMerged);
+                if (webProjectsChanged) {
+                    webSharedOR.setSharedProjects(
+                        new ArrayList<>(webMerged)
+                    );
                 }
             }
-            List<String> mExisting = (mobileSharedOR != null) ? mobileSharedOR.getSharedProjects() : java.util.List.of();
-            LinkedHashSet<String> mMerged = new LinkedHashSet<>();
-            if (mExisting != null) mMerged.addAll(mExisting);
-            mMerged.addAll(sharedUsageProjects);
-            boolean mProjectsChanged = false;
+            
+            boolean mobileProjectsChanged = false;
             if (mobileSharedOR != null) {
-                ArrayList<String> mList = new ArrayList<>(mMerged);
-                List<String> mCurrent = mobileSharedOR.getSharedProjects();
-                mProjectsChanged = (mCurrent == null) || !new LinkedHashSet<>(mCurrent).equals(mMerged);
-                if (mProjectsChanged) {
-                    mobileSharedOR.setSharedProjects(mList);
+                LinkedHashSet<String> mobileMerged = new LinkedHashSet<>();
+                mobileMerged.addAll(mobileSharedProjectsFromXml);
+                mobileMerged.addAll(mobileSharedUsageProjects);
+                File sharedRoot = new File(getSharedORRepLocation());
+                File mobileMetaFile = new File(sharedRoot, "mobileor-projectsdata.yaml");
+                mobileMerged.addAll(yamlWriter.readExistingProjects(mobileMetaFile));
+                List<String> current = mobileSharedOR.getSharedProjects();
+                mobileProjectsChanged = current == null || !new LinkedHashSet<>(current).equals(mobileMerged);
+                if (mobileProjectsChanged) {
+                    mobileSharedOR.setSharedProjects(
+                        new ArrayList<>(mobileMerged)
+                    );
                 }
             }
-            
-            // === SHARED ORs (always XML) ===
-            if (webSharedOR != null && (!webSharedOR.isSaved() || projectsChanged)) {
-                File sharedORFile = new File(getSharedORLocation());
-                sharedORFile.getParentFile().mkdirs();
-                XML_MAPPER.writerWithDefaultPrettyPrinter()
-                    .writeValue(sharedORFile, webSharedOR);
-                webSharedOR.setSaved(true);
-            }
-            if (mobileSharedOR != null && (!mobileSharedOR.isSaved() || mProjectsChanged)) {
-                File sharedMORFile = new File(getSharedMORLocation());
-                sharedMORFile.getParentFile().mkdirs();
-                XML_MAPPER.writerWithDefaultPrettyPrinter()
-                        .writeValue(sharedMORFile, mobileSharedOR);
-                mobileSharedOR.setSaved(true);
-            }
-            
-            // === PROJECT ORs (YAML or XML based on format) ===
+
             if (useYamlFormat) {
-                // Save in YAML format
-                if (webProjectOR != null && !webProjectOR.isSaved()) {
-                    File orRepLocation = new File(getORRepLocation());
-                    yamlWriter.writeWebOR(webProjectOR, orRepLocation);
-                    webProjectOR.setSaved(true);
+                File sharedRoot = new File(getSharedORRepLocation());
+                if (webSharedOR != null && (!webSharedOR.isSaved() || webProjectsChanged)) {
+                    yamlWriter.writeWebOR(webSharedOR, sharedRoot);
+                    if (webSharedOR.getSharedProjects() != null &&
+                        !webSharedOR.getSharedProjects().isEmpty()) {
+                        yamlWriter.writeSharedMetadata(webSharedOR,sharedRoot);
+                    }
+                    webSharedOR.setSaved(true);
                 }
-                if (mobileProjectOR != null && !mobileProjectOR.isSaved()) {
-                    File morRepLocation = new File(getMORRepLocation());
-                    yamlWriter.writeMobileOR(mobileProjectOR, morRepLocation);
-                    mobileProjectOR.setSaved(true);
+
+                if (mobileSharedOR != null && (!mobileSharedOR.isSaved() || mobileProjectsChanged)) {
+                    yamlWriter.writeMobileOR(mobileSharedOR, sharedRoot);
+                    if (mobileSharedOR.getSharedProjects() != null &&
+                        !mobileSharedOR.getSharedProjects().isEmpty()) {
+                        yamlWriter.writeSharedMetadata(mobileSharedOR,sharedRoot);
+                    }
+                    mobileSharedOR.setSaved(true);
                 }
-                if (structuredDataProjectOR != null && !structuredDataProjectOR.isSaved()) {
-                    File structuredDataRepLocation = new File(getStructuredDataORRepLocation());
-                    yamlWriter.writeStructuredDataOR(structuredDataProjectOR, structuredDataRepLocation);
-                    structuredDataProjectOR.setSaved(true);
-                }
+                saveAsYaml();
                 LOG.info("Saved project ORs in YAML format");
-            } else {
-                // Save in XML format (legacy)
-                if (webProjectOR != null && !webProjectOR.isSaved()) {
-                    File orFile = new File(getORLocation());
-                    orFile.getParentFile().mkdirs();
-                    XML_MAPPER.writerWithDefaultPrettyPrinter()
-                        .writeValue(orFile, webProjectOR);
-                    webProjectOR.setSaved(true);
-                }
-                if (mobileProjectOR != null && !mobileProjectOR.isSaved()) {
-                    File morFile = new File(getMORLocation());
-                    morFile.getParentFile().mkdirs();
-                    XML_MAPPER.writerWithDefaultPrettyPrinter()
-                            .writeValue(morFile, mobileProjectOR);
-                    mobileProjectOR.setSaved(true);
-                }
-                if (structuredDataProjectOR != null && !structuredDataProjectOR.isSaved()) {
-                    File structuredDataORFile = new File(getStructuredDataORLocation());
-                    structuredDataORFile.getParentFile().mkdirs();
-                    XML_MAPPER.writerWithDefaultPrettyPrinter()
-                            .writeValue(structuredDataORFile, structuredDataProjectOR);
-                    structuredDataProjectOR.setSaved(true);
-                }
-                LOG.info("Saved project ORs in XML format");
             }
         } catch (IOException ex) {
-            Logger.getLogger(ObjectRepository.class.getName()).log(Level.SEVERE, null, ex);
+            Logger.getLogger(ObjectRepository.class.getName())
+                  .log(Level.SEVERE, "Failed to save Object Repository", ex);
         }
     }
     
@@ -434,6 +268,8 @@ public class ObjectRepository {
             yamlWriter.writeMobileOR(mobileProjectOR, orRepLocation);
             yamlWriter.writeStructuredDataOR(structuredDataProjectOR, orRepLocation);
             webProjectOR.setSaved(true);
+            mobileProjectOR.setSaved(true);
+            structuredDataProjectOR.setSaved(true);
             useYamlFormat = true;
             LOG.info("Saved Object Repository in YAML format");
         } catch (IOException ex) {
@@ -445,23 +281,256 @@ public class ObjectRepository {
      * Convert existing XML-based OR to YAML format.
      * This creates YAML files while preserving the original XML files.
      */
-    public void convertToYaml() {
-        try {
-            File orRepLocation = new File(getORRepLocation());
-            yamlWriter.convertFromXml(webProjectOR, mobileProjectOR, orRepLocation);
-            useYamlFormat = true;
-            LOG.info("Converted Object Repository to YAML format");
-        } catch (IOException ex) {
-            LOG.log(Level.SEVERE, "Error converting Object Repository to YAML", ex);
+    private boolean hasProjectXmlOR() {
+        return new File(getORLocation()).exists() || new File(getMORLocation()).exists();
+    }
+
+    private boolean hasSharedXmlOR() {
+        return new File(getSharedORLocation()).exists() || new File(getSharedMORLocation()).exists();
+    }
+
+    private boolean hasAnyXmlOR() {
+        return hasProjectXmlOR() || hasSharedXmlOR();
+    }
+
+    private boolean hasYamlOR() {
+        File webPages = new File(getORRepLocation(), "Web");
+        File mobilePages = new File(getORRepLocation(), "Mobile");
+        File structuredDataPages = new File(getORRepLocation(), "StructuredData");
+        return (webPages.exists() && webPages.isDirectory()) || (mobilePages.exists() && mobilePages.isDirectory()) || (structuredDataPages.exists() && structuredDataPages.isDirectory());
+    }
+
+    private boolean hasSharedYamlOR() {
+        File sharedWeb = new File(getSharedORRepLocation(), "Web");
+        File sharedMobile = new File(getSharedORRepLocation(), "Mobile");
+        File sharedStructuredDataPages = new File(getORRepLocation(), "StructuredData");
+        return (sharedWeb.exists() && sharedWeb.isDirectory()) || (sharedMobile.exists() && sharedMobile.isDirectory()) || (sharedStructuredDataPages.exists() && sharedStructuredDataPages.isDirectory());
+    }
+    
+    private void convertXmlOrsToYamlAndArchive() throws IOException {
+        LOG.info("Legacy XML ORs detected. Converting to YAML...");
+        XmlToYamlORConverter converter = new XmlToYamlORConverter(yamlWriter);
+
+        File projectYamlRoot = new File(getORRepLocation());
+        File sharedYamlRoot  = new File(getSharedORRepLocation());
+
+        converter.convertAll(
+            webProjectOR,
+            webSharedOR,
+            mobileProjectOR,
+            mobileSharedOR,
+            projectYamlRoot,
+            sharedYamlRoot
+        );
+
+        archiveProjectXmlORs();
+        archiveSharedXmlORs();
+        cleanupLegacySharedXmlFolders();
+        useYamlFormat = true;
+
+        LOG.info("XML OR migration complete. YAML is now active.");
+    }
+
+    private void archiveProjectXmlORs() {
+        File archiveDir = new File(sProject.getLocation(), "ProjectXMLOR");
+        archiveDir.mkdirs();
+        moveXmlToBak(getORLocation(), archiveDir);
+        moveXmlToBak(getMORLocation(), archiveDir);
+    }
+    
+    private void archiveSharedXmlORs() {
+        File archiveDir = new File("Shared" + File.separator + "SharedXMLOR");
+        archiveDir.mkdirs();
+        moveXmlToBak(getSharedORLocation(), archiveDir);
+        moveXmlToBak(getSharedMORLocation(), archiveDir);
+    }
+
+        private void moveXmlToBak(String xmlPath, File targetDir) {
+        if (xmlPath == null) return;
+        File xmlFile = new File(xmlPath);
+        if (!xmlFile.exists()) return;
+        File bakFile = new File(targetDir, xmlFile.getName() + ".bak");
+        if (xmlFile.renameTo(bakFile)) {
+            LOG.info(() -> "Archived XML OR: " + bakFile.getAbsolutePath());
+        } else {
+            LOG.warning(() -> "Failed to archive XML OR: " + xmlFile.getAbsolutePath());
+        }
+    }
+
+    private void deleteDirectoryRecursively(File dir) {
+        if (dir == null || !dir.exists()) {
+            return;
+        }
+        File[] contents = dir.listFiles();
+        if (contents != null) {
+            for (File file : contents) {
+                if (file.isDirectory()) {
+                    deleteDirectoryRecursively(file);
+                } else {
+                    file.delete();
+                }
+            }
+        }
+        boolean deleted = dir.delete();
+        if (deleted) {
+            LOG.info(() -> "Deleted legacy XML directory: " + dir.getAbsolutePath());
+        } else {
+            LOG.warning(() -> "Failed to delete legacy XML directory: " + dir.getAbsolutePath());
+        }
+    }
+
+    private void cleanupLegacySharedXmlFolders() {
+        File sharedWebXmlDir = new File("Shared" + File.separator + "SharedWebObjects");
+        File sharedMobileXmlDir = new File("Shared" + File.separator + "SharedMobileObjects");
+        deleteDirectoryRecursively(sharedWebXmlDir);
+        deleteDirectoryRecursively(sharedMobileXmlDir);
+    }
+
+    private void loadYamlObjectRepositories() throws IOException {
+        File projectRoot = new File(getORRepLocation());
+        
+        webProjectOR = yamlReader.readWebOR(projectRoot);
+        if (webProjectOR != null) {
+            webProjectOR.setObjectRepository(this);
+            webProjectOR.setScope(WebOR.ORScope.PROJECT);
+            webProjectOR.setName(sProject.getName());
+            normalizeWebOR(webProjectOR);
+        }
+
+        mobileProjectOR = yamlReader.readMobileOR(projectRoot);
+        if (mobileProjectOR != null) {
+            mobileProjectOR.setObjectRepository(this);
+            mobileProjectOR.setScope(MobileOR.ORScope.PROJECT);
+            mobileProjectOR.setName(sProject.getName());
+            normalizeMobileOR(mobileProjectOR);
+        }
+
+        structuredDataProjectOR = yamlReader.readStructuredDataOR(projectRoot);
+        if (structuredDataProjectOR != null) {
+            structuredDataProjectOR.setObjectRepository(this);
+            structuredDataProjectOR.setName(sProject.getName());
+            normalizestructuredDataOR(structuredDataProjectOR);
+        }
+
+        File sharedRoot = new File(getSharedORRepLocation());
+        
+        if (sharedRoot.exists() && sharedRoot.isDirectory()) {
+
+            webSharedOR = yamlReader.readWebOR(sharedRoot);
+            if (webSharedOR != null) {
+                webSharedOR.setObjectRepository(this);
+                webSharedOR.setScope(WebOR.ORScope.SHARED);
+                webSharedOR.setName("Shared Web Objects");
+                normalizeWebOR(webSharedOR);
+            }
+
+            mobileSharedOR = yamlReader.readMobileOR(sharedRoot);
+            if (mobileSharedOR != null) {
+                mobileSharedOR.setObjectRepository(this);
+                mobileSharedOR.setScope(MobileOR.ORScope.SHARED);
+                mobileSharedOR.setName("Shared Mobile Objects");
+                normalizeMobileOR(mobileSharedOR);
+            }
         }
     }
     
-    /**
-     * Set whether to use YAML format for saving.
-     */
-    public void setUsingYamlFormat(boolean useYaml) {
-        this.useYamlFormat = useYaml;
+    /*
+    * Loads legacy XML-based Object Repositories into memory.
+    *
+    * This method is ONLY used during XML → YAML migration.
+    * It must NOT be called once YAML ORs exist.
+    */
+    private void loadXmlObjectRepositories() throws IOException {
+        LOG.info("Loading legacy XML Object Repositories for migration...");
+        File projectWebXml = new File(getORLocation());
+        if (projectWebXml.exists()) {
+            webProjectOR = XML_MAPPER.readValue(projectWebXml, WebOR.class);
+            webProjectOR.setObjectRepository(this);
+            LOG.info("Loaded PROJECT Web XML OR");
+        }
+
+        File projectMobileXml = new File(getMORLocation());
+        if (projectMobileXml.exists()) {
+            mobileProjectOR = XML_MAPPER.readValue(projectMobileXml, MobileOR.class);
+            mobileProjectOR.setObjectRepository(this);
+            LOG.info("Loaded PROJECT Mobile XML OR");
+        }
+
+        File sharedWebXml = new File(getSharedORLocation());
+        if (sharedWebXml.exists()) {
+            webSharedOR = XML_MAPPER.readValue(sharedWebXml, WebOR.class);
+            webSharedOR.setObjectRepository(this);
+            webSharedOR.setScope(WebOR.ORScope.SHARED);
+            LOG.info("Loaded SHARED Web XML OR");
+        }
+
+        File sharedMobileXml = new File(getSharedMORLocation());
+        if (sharedMobileXml.exists()) {
+            mobileSharedOR = XML_MAPPER.readValue(sharedMobileXml, MobileOR.class);
+            mobileSharedOR.setObjectRepository(this);
+            mobileSharedOR.setScope(MobileOR.ORScope.SHARED);
+            LOG.info("Loaded SHARED Mobile XML OR");
+        }
+
+        if (webSharedOR != null && webSharedOR.getSharedProjects() != null) {
+             webSharedProjectsFromXml = new ArrayList<>(webSharedOR.getSharedProjects());
+         }
+
+         if (mobileSharedOR != null && mobileSharedOR.getSharedProjects() != null) {
+             mobileSharedProjectsFromXml = new ArrayList<>(mobileSharedOR.getSharedProjects());
+         }
     }
+
+    private void normalizeWebOR(WebOR webOR) {
+         if (webOR == null) return;
+
+         for (WebORPage page : webOR.getPages()) {
+             page.setRoot(webOR);
+
+             for (ObjectGroup<WebORObject> group : page.getObjectGroups()) {
+                 group.setParent(page);
+
+                 for (WebORObject obj : group.getObjects()) {
+                     obj.setParent(group);
+                 }
+             }
+         }
+         webOR.setSaved(true);
+     }
+
+    private void normalizeMobileOR(MobileOR mobileOR) {
+         if (mobileOR == null) return;
+
+         for (MobileORPage page : mobileOR.getPages()) {
+             page.setRoot(mobileOR);
+
+             for (ObjectGroup<MobileORObject> group : page.getObjectGroups()) {
+                 group.setParent(page);
+
+                 for (MobileORObject obj : group.getObjects()) {
+                     obj.setParent(group);
+                 }
+             }
+         }
+         mobileOR.setSaved(true);
+     }
+
+    private void normalizestructuredDataOR(StructuredData apiOR) {
+         if (apiOR == null) return;
+
+         for (StructuredDataORPage page : apiOR.getPages()) {
+             page.setRoot(apiOR);
+
+             for (ObjectGroup<StructuredDataORObject> group : page.getObjectGroups()) {
+                 group.setParent(page);
+
+                 for (StructuredDataORObject obj : group.getObjects()) {
+                     obj.setParent(group);
+                 }
+             }
+         }
+         apiOR.setSaved(true);
+     }
 
     /**
      * Checks whether the given object exists in either PROJECT or SHARED scope.
@@ -485,25 +554,74 @@ public class ObjectRepository {
      * @param group   object group containing the object
      * @param newName new object name
      */
-    public void renameObject(ObjectGroup<WebORObject> group, String newName) {
+    public void renameObject(ObjectGroup group, String newName) {
         if (group == null || newName == null || newName.isBlank()) return;
+
         var parentPage = group.getParent();
         if (parentPage == null) return;
+
         String oldName = group.getName();
         if (oldName.equals(newName)) return;
-        boolean inProject = (webProjectOR != null) &&
-            (webProjectOR.getPageByName(parentPage.getName()) == parentPage);
-        boolean inShared  = !inProject && (webSharedOR != null) &&
-            (webSharedOR.getPageByName(parentPage.getName()) == parentPage);
-        if (inProject && webProjectOR != null) {
+
+        boolean webProject =
+            webProjectOR != null &&
+            webProjectOR.getPageByName(parentPage.getName()) == parentPage;
+
+        boolean webShared =
+            webSharedOR != null &&
+            webSharedOR.getPageByName(parentPage.getName()) == parentPage;
+
+        if (webProject) {
             webProjectOR.setSaved(false);
-            sProject.refactorObjectName(WebOR.ORScope.PROJECT, parentPage.getName(), oldName, newName);
-        } else if (inShared && webSharedOR != null) {
+            sProject.refactorObjectName(
+                WebOR.ORScope.PROJECT,
+                parentPage.getName(),
+                oldName,
+                newName
+            );
+            return;
+        }
+
+        if (webShared) {
             webSharedOR.setSaved(false);
-            markSharedUsage();
-            sProject.refactorObjectName(WebOR.ORScope.SHARED, parentPage.getName(), oldName, newName);
-        } else {
-            sProject.refactorObjectName(parentPage.getName(), oldName, newName);
+            markSharedUsage("WebOR");
+            sProject.refactorObjectName(
+                WebOR.ORScope.SHARED,
+                parentPage.getName(),
+                oldName,
+                newName
+            );
+            return;
+        }
+
+        boolean mobileProject =
+            mobileProjectOR != null &&
+            mobileProjectOR.getPageByName(parentPage.getName()) == parentPage;
+
+        boolean mobileShared =
+            mobileSharedOR != null &&
+            mobileSharedOR.getPageByName(parentPage.getName()) == parentPage;
+
+        if (mobileProject) {
+            mobileProjectOR.setSaved(false);
+            sProject.refactorMobileObjectName(
+                MobileOR.ORScope.PROJECT,
+                parentPage.getName(),
+                oldName,
+                newName
+            );
+            return;
+        }
+
+        if (mobileShared) {
+            mobileSharedOR.setSaved(false);
+            markSharedUsage("MobileOR");
+            sProject.refactorMobileObjectName(
+                MobileOR.ORScope.SHARED,
+                parentPage.getName(),
+                oldName,
+                newName
+            );
         }
     }
     
@@ -516,10 +634,13 @@ public class ObjectRepository {
      */
     public void renamePage(ORPageInf page, String newName) {
         if (page == null || newName == null || newName.isBlank()) return;
+
         String oldName = page.getName();
         if (oldName.equals(newName)) return;
+
         boolean renamed = false;
         ORScope scopeRenamed = null;
+
         if (webProjectOR != null) {
             var p = webProjectOR.getPageByName(oldName);
             if (p == page) {
@@ -531,8 +652,13 @@ public class ObjectRepository {
                 webProjectOR.setSaved(false);
                 renamed = true;
                 scopeRenamed = ORScope.PROJECT;
+
+                if (useYamlFormat) {
+                    renameWebPageYaml(oldName, newName, scopeRenamed);
+                }
             }
         }
+
         if (!renamed && webSharedOR != null) {
             var s = webSharedOR.getPageByName(oldName);
             if (s == page) {
@@ -544,8 +670,13 @@ public class ObjectRepository {
                 webSharedOR.setSaved(false);
                 renamed = true;
                 scopeRenamed = ORScope.SHARED;
+
+                if (useYamlFormat) {
+                    renameWebPageYaml(oldName, newName, scopeRenamed);
+                }
             }
         }
+
         if (renamed) {
             sProject.refactorPageName(scopeRenamed, oldName, newName);
         } else {
@@ -553,38 +684,55 @@ public class ObjectRepository {
         }
     }
 
-    public void renamePage(com.ing.datalib.or.mobile.MobileORPage page, String newName) {
+    public void renamePage(MobileORPage page, String newName) {
         if (page == null || newName == null || newName.isBlank()) return;
+
         String oldName = page.getName();
         if (oldName.equals(newName)) return;
+
         boolean renamed = false;
-        com.ing.datalib.or.mobile.MobileOR.ORScope mScope = null;
+        MobileOR.ORScope mScope = null;
+
         if (mobileProjectOR != null) {
             var p = mobileProjectOR.getPageByName(oldName);
             if (p == page) {
                 var existsSameScope = mobileProjectOR.getPageByName(newName);
                 if (existsSameScope != null && existsSameScope != page) return;
+
                 p.setName(newName);
                 mobileProjectOR.setSaved(false);
                 renamed = true;
-                mScope = com.ing.datalib.or.mobile.MobileOR.ORScope.PROJECT;
+                mScope = MobileOR.ORScope.PROJECT;
+
+                if (useYamlFormat) {
+                    renameMobilePageYaml(oldName, newName, mScope);
+                }
             }
         }
+
         if (!renamed && mobileSharedOR != null) {
             var s = mobileSharedOR.getPageByName(oldName);
             if (s == page) {
                 var existsSameScope = mobileSharedOR.getPageByName(newName);
                 if (existsSameScope != null && existsSameScope != page) return;
+
                 s.setName(newName);
                 mobileSharedOR.setSaved(false);
                 renamed = true;
-                mScope = com.ing.datalib.or.mobile.MobileOR.ORScope.SHARED;
+                mScope = MobileOR.ORScope.SHARED;
+
+                if (useYamlFormat) {
+                    renameMobilePageYaml(oldName, newName, mScope);
+                }
             }
         }
+
         if (renamed) {
-            var webLikeScope = (mScope == com.ing.datalib.or.mobile.MobileOR.ORScope.PROJECT)
-                    ? com.ing.datalib.or.web.WebOR.ORScope.PROJECT
-                    : com.ing.datalib.or.web.WebOR.ORScope.SHARED;
+            var webLikeScope =
+                (mScope == MobileOR.ORScope.PROJECT)
+                    ? WebOR.ORScope.PROJECT
+                    : WebOR.ORScope.SHARED;
+
             sProject.refactorPageName(webLikeScope, oldName, newName);
         } else {
             sProject.refactorPageName(oldName, newName);
@@ -597,57 +745,44 @@ public class ObjectRepository {
      */
     public ResolvedWebObject resolveWebObject(ResolvedWebObject.PageRef pageRef, String objectName) {
         if (pageRef == null || objectName == null) return null;
-        if (pageRef.scope == WebOR.ORScope.PROJECT) {
-            var g = getFrom(webProjectOR, pageRef.name, objectName);
-            if (g != null) {
-                String actualPageName = g.getParent() != null ? g.getParent().getName() : pageRef.name;
-                return new ResolvedWebObject(WebOR.ORScope.PROJECT, actualPageName, objectName, g);
-            }
-            return null;
+        if (pageRef.scope != null) {
+            return resolveWebObjectInScope(pageRef.scope,pageRef.name,objectName);
         }
-        if (pageRef.scope == WebOR.ORScope.SHARED) {
-            var g = getFrom(webSharedOR, pageRef.name, objectName);
-            if (g != null) {
-                markSharedUsage();
-                String actualPageName = g.getParent() != null ? g.getParent().getName() : pageRef.name;
-                return new ResolvedWebObject(WebOR.ORScope.SHARED, actualPageName, objectName, g);
-            }
-            return null;
+        return resolveWebObjectWithScope(pageRef.name, objectName);
+    }
+    
+    private ResolvedWebObject resolveWebObjectInScope(ORScope scope,String pageName, String objectName) {
+        WebOR or = (scope == ORScope.PROJECT) ? webProjectOR : webSharedOR;
+        ObjectGroup g = getFrom(or, pageName, objectName);
+        if (g == null) return null;
+        if (scope == ORScope.SHARED) {
+            markSharedUsage("WebOR");
         }
-        var proj = getFrom(webProjectOR, pageRef.name, objectName);
-        if (proj != null) {
-            String actualPageName = proj.getParent() != null ? proj.getParent().getName() : pageRef.name;
-            return new ResolvedWebObject(WebOR.ORScope.PROJECT, actualPageName, objectName, proj);
-        }
-        var shared = getFrom(webSharedOR, pageRef.name, objectName);
-        if (shared != null) {
-            markSharedUsage();
-            String actualPageName = shared.getParent() != null ? shared.getParent().getName() : pageRef.name;
-            return new ResolvedWebObject(WebOR.ORScope.SHARED, actualPageName, objectName, shared);
-        }
-        return null;
+        String actualPage = g.getParent() != null ? g.getParent().getName() : pageName;
+        return new ResolvedWebObject(scope, actualPage, objectName, g);
     }
 
     public ResolvedMobileObject resolveMobileObject(ResolvedMobileObject.PageRef pageRef, String objectName) {
         if (pageRef == null || objectName == null) return null;
-        if (pageRef.scope == ORScope.PROJECT) {
-            var g = getFrom(mobileProjectOR, pageRef.name, objectName);
-            if (g != null) {
-                String actualPageName = g.getParent() != null ? g.getParent().getName() : pageRef.name;
-                return new ResolvedMobileObject(ORScope.PROJECT, actualPageName, objectName, g);
-            }
-            return null;
-        }
-        if (pageRef.scope == ORScope.SHARED) {
-            var g = getFrom(mobileSharedOR, pageRef.name, objectName);
-            if (g != null) {
-                markSharedUsage();
-                String actualPageName = g.getParent() != null ? g.getParent().getName() : pageRef.name;
-                return new ResolvedMobileObject(ORScope.SHARED, actualPageName, objectName, g);
-            }
-            return null;
+        if (pageRef.scope != null) {
+            return resolveMobileObjectInScope(
+                    pageRef.scope,
+                    pageRef.name,
+                    objectName
+            );
         }
         return resolveMobileObjectWithScope(pageRef.name, objectName);
+    }
+    
+    private ResolvedMobileObject resolveMobileObjectInScope(ORScope scope, String pageName, String objectName) {
+        MobileOR or = (scope == ORScope.PROJECT) ? mobileProjectOR : mobileSharedOR;
+        ObjectGroup g = getFrom(or, pageName, objectName);
+        if (g == null) return null;
+        if (scope == ORScope.SHARED) {
+            markSharedUsage("MobileOR");
+        }
+        String actualPage = g.getParent() != null ? g.getParent().getName() : pageName;
+        return new ResolvedMobileObject(scope, actualPage, objectName, g);
     }
     
     public ResolvedStructuredDataObject resolveStructuredDataObject(ResolvedStructuredDataObject.PageRef pageRef, String objectName) {
@@ -663,7 +798,7 @@ public class ObjectRepository {
         if (pageRef.scope == ORScope.SHARED) {
             var g = getFrom(structuredDataSharedOR, pageRef.name, objectName);
             if (g != null) {
-                markSharedUsage();
+                markSharedUsage("StructuredDataOR");
                 String actualPageName = g.getParent() != null ? g.getParent().getName() : pageRef.name;
                 return new ResolvedStructuredDataObject(ORScope.SHARED, actualPageName, objectName, g);
             }
@@ -680,16 +815,24 @@ public class ObjectRepository {
      * @return resolved WebOR object with scope metadata
      */
     public ResolvedWebObject resolveWebObjectWithScope(String pageName, String objectName) {
+        ResolvedWebObject proj = resolveWebObjectInScope(ORScope.PROJECT, pageName, objectName);
+        if (proj != null) return proj;
+        return resolveWebObjectInScope(ORScope.SHARED, pageName, objectName);
+    }
+
+    public ResolvedWebObject resolveWebObjectWithScope(String pageName, String objectName,TestStep step) {
         var proj = getFrom(webProjectOR, pageName, objectName);
         if (proj != null) {
-            String actualPageName = proj.getParent() != null ? proj.getParent().getName() : pageName;
-            return new ResolvedWebObject(ORScope.PROJECT, actualPageName, objectName, proj);
+            return new ResolvedWebObject(PROJECT, pageName, objectName, proj);
         }
         var shared = getFrom(webSharedOR, pageName, objectName);
         if (shared != null) {
-            markSharedUsage();
-            String actualPageName = shared.getParent() != null ? shared.getParent().getName() : pageName;
-            return new ResolvedWebObject(ORScope.SHARED, actualPageName, objectName, shared);
+            if (step != null &&
+                step.getReference().startsWith("[Project] ")) {
+                step.setReference("[Shared] " + pageName);
+                step.getTestCase().setSaved(false);
+            }
+            return new ResolvedWebObject(SHARED, pageName, objectName, shared);
         }
         return null;
     }
@@ -701,20 +844,11 @@ public class ObjectRepository {
     * @param objectName object group name
     * @return resolved MobileOR object with scope metadata
     */
-   public ResolvedMobileObject resolveMobileObjectWithScope(String pageName, String objectName) {
-       var proj = getFrom(mobileProjectOR, pageName, objectName);
-       if (proj != null) {
-           String actualPageName = proj.getParent() != null ? proj.getParent().getName() : pageName;
-           return new ResolvedMobileObject(ORScope.PROJECT, actualPageName, objectName, proj);
-       }
-       var shared = getFrom(mobileSharedOR, pageName, objectName);
-       if (shared != null) {
-           markSharedUsage();
-           String actualPageName = shared.getParent() != null ? shared.getParent().getName() : pageName;
-           return new ResolvedMobileObject(ORScope.SHARED, actualPageName, objectName, shared);
-       }
-       return null;
-   }
+    public ResolvedMobileObject resolveMobileObjectWithScope(String pageName, String objectName) {
+        ResolvedMobileObject proj = resolveMobileObjectInScope(ORScope.PROJECT, pageName, objectName);
+        if (proj != null) return proj;
+        return resolveMobileObjectInScope(ORScope.SHARED, pageName, objectName);
+    }
    
    /**
     * Resolves a StructuredDataOR object by searching project scope first, then shared scope.
@@ -731,7 +865,7 @@ public class ObjectRepository {
        }
        var shared = getFrom(structuredDataSharedOR, pageName, objectName);
        if (shared != null) {
-           markSharedUsage();
+           markSharedUsage("StructuredDataOR");
            String actualPageName = shared.getParent() != null ? shared.getParent().getName() : pageName;
            return new ResolvedStructuredDataObject(ORScope.SHARED, actualPageName, objectName, shared);
        }
@@ -849,6 +983,9 @@ public class ObjectRepository {
         WebORPage targetPage = getOrCreatePage(sharedOR, uniqueTargetName);
         copyAllGroups(sourcePage, targetPage);
         sharedOR.setSaved(false);
+        if (useYamlFormat) {
+            saveWebPageNow(targetPage);
+        }
         LOG.info(() -> "Copied Web Page '" + sourcePageName + "' to SHARED page '" + uniqueTargetName + "' successfully.");
         return uniqueTargetName;
     }
@@ -869,13 +1006,57 @@ public class ObjectRepository {
         if (targetPage == null) return null;
         ObjectGroup<WebORObject> originalGroup = source.getGroup();
         if (originalGroup == null) return null;
-        String baseName   = originalGroup.getName();
-        String uniqueName = generateUniqueGroupName(targetPage, baseName);
+        String originalName = originalGroup.getName();
+        String baseName = originalName.replaceAll("_Copy_\\d+$", "");
+        String uniqueName;
+        int index = 1;
+        do {
+            uniqueName = baseName + "_Copy_" + index++;
+        } while (targetPage.getObjectGroupByName(uniqueName) != null);
         ObjectGroup<WebORObject> newGroup = cloneGroupIntoPage(originalGroup, targetPage, uniqueName);
         targetPage.getObjectGroups().add(newGroup);
         sharedOR.setSaved(false);
-        LOG.info(() -> "Copied Web Object '" + baseName + "' to SHARED as '" + uniqueName + "'");
+        if (useYamlFormat) {
+            saveWebPageNow(targetPage);
+        }
+        LOG.info(
+            "Copied Web Object '" + originalName +
+            "' to SHARED as '" + uniqueName + "'"
+        );
         return uniqueName;
+    }
+    
+    public String moveWebObject(ResolvedWebObject source, String targetPageName) {
+        if (source == null) return null;
+        WebOR sharedOR = getWebSharedOR();
+        if (sharedOR == null) return null;
+        WebORPage targetPage = getOrCreatePage(sharedOR, targetPageName);
+        if (targetPage == null) return null;
+        ObjectGroup<WebORObject> originalGroup = source.getGroup();
+        if (originalGroup == null) return null;
+        String originalName = originalGroup.getName();
+        if (targetPage.getObjectGroupByName(originalName) != null) {
+            return null;
+        }
+        ORPageInf sourcePage = originalGroup.getParent();
+        if (sourcePage != null) {
+            sourcePage.getObjectGroups().remove(originalGroup);
+            sourcePage.getRoot().setSaved(false);
+            if (useYamlFormat && sourcePage instanceof WebORPage) {
+                saveWebPageNow((WebORPage) sourcePage);
+            }
+        }
+        originalGroup.setParent(targetPage);
+        targetPage.getObjectGroups().add(originalGroup);
+        sharedOR.setSaved(false);
+        if (useYamlFormat) {
+            saveWebPageNow(targetPage);
+        }
+        LOG.info(
+            "Moved Web Object '" + originalName +
+            "' to SHARED page '" + targetPageName + "'"
+        );
+        return originalName;
     }
 
     /**
@@ -894,8 +1075,10 @@ public class ObjectRepository {
         MobileORPage targetPage = getOrCreateMobilePage(sharedMOR, uniqueTargetName);
         copyAllMobileGroups(sourcePage, targetPage);
         sharedMOR.setSaved(false);
-        LOG.info(() -> "Copied Mobile Page '" + sourcePageName
-                + "' to SHARED page '" + uniqueTargetName + "' successfully.");
+        if (useYamlFormat) {
+            saveMobilePageNow(targetPage);
+        }
+        LOG.info(() -> "Copied Mobile Page '" + sourcePageName + "' to SHARED page '" + uniqueTargetName + "' successfully.");
         return uniqueTargetName;
     }
 
@@ -914,13 +1097,58 @@ public class ObjectRepository {
         if (targetPage == null) return null;
         ObjectGroup<MobileORObject> originalGroup = source.getGroup();
         if (originalGroup == null) return null;
-        String baseName   = originalGroup.getName();
-        String uniqueName = generateUniqueMobileGroupName(targetPage, baseName);
+        String originalName = originalGroup.getName();
+        String baseName = originalName.replaceAll("_Copy_\\d+$", "");
+        String uniqueName;
+        int index = 1;
+        do {
+            uniqueName = baseName + "_Copy_" + index++;
+        } while (targetPage.getObjectGroupByName(uniqueName) != null);
         ObjectGroup<MobileORObject> newGroup = cloneMobileGroupIntoPage(originalGroup, targetPage, uniqueName);
         targetPage.getObjectGroups().add(newGroup);
         sharedMOR.setSaved(false);
-        LOG.info(() -> "Copied Mobile Object '" + baseName + "' to SHARED as '" + uniqueName + "'");
+        if (useYamlFormat) {
+            saveMobilePageNow(targetPage);
+        }
+        LOG.info(
+            "Copied Mobile Object '" + originalName +
+            "' to SHARED as '" + uniqueName + "'"
+        );
         return uniqueName;
+    }
+    
+    public String moveMobileObject(ResolvedMobileObject source, String targetPageName) {
+        if (source == null) return null;
+        MobileOR sharedOR = getMobileSharedOR();
+        if (sharedOR == null) return null;
+        MobileORPage targetPage = getOrCreateMobilePage(sharedOR, targetPageName);
+        if (targetPage == null) return null;
+        ObjectGroup<MobileORObject> originalGroup = source.getGroup();
+        if (originalGroup == null) return null;
+        String originalName = originalGroup.getName();
+        if (targetPage.getObjectGroupByName(originalName) != null) {
+            return null;
+        }
+        ORPageInf sourcePage = originalGroup.getParent();
+        if (sourcePage != null) {
+            sourcePage.getObjectGroups().remove(originalGroup);
+            sourcePage.getRoot().setSaved(false);
+
+            if (useYamlFormat && sourcePage instanceof MobileORPage) {
+                saveMobilePageNow((MobileORPage) sourcePage);
+            }
+        }
+        originalGroup.setParent(targetPage);
+        targetPage.getObjectGroups().add(originalGroup);
+        sharedOR.setSaved(false);
+        if (useYamlFormat) {
+            saveMobilePageNow(targetPage);
+        }
+        LOG.info(
+            "Moved Mobile Object Group '" + originalName +
+            "' to SHARED page '" + targetPageName + "'"
+        );
+        return originalName;
     }
 
     private String generateUniquePageName(MobileOR mor, String baseName) {
@@ -964,9 +1192,15 @@ public class ObjectRepository {
      * Marks that the current project has used a shared object,
      * updating shared OR metadata.
      */
-    private void markSharedUsage() {
-        if (sProject != null && sProject.getName() != null && !sProject.getName().isBlank()) {
-            sharedUsageProjects.add(sProject.getName());
+    private void markSharedUsage(String orType) {
+        if (sProject == null || sProject.getName() == null) {
+            return;
+        }
+
+        if ("WebOR".equals(orType)) {
+            webSharedUsageProjects.add(sProject.getName());
+        } else if ("MobileOR".equals(orType)) {
+            mobileSharedUsageProjects.add(sProject.getName());
         }
     }
     
@@ -988,7 +1222,7 @@ public class ObjectRepository {
     public void setUseYamlFormat(boolean useYaml) {
         this.useYamlFormat = useYaml;
         if (useYaml && yamlReader == null) {
-            yamlReader = new YamlORReader();
+            yamlReader = new YamlORReader(this);
             yamlWriter = new YamlORWriter();
         }
     }
@@ -1000,19 +1234,25 @@ public class ObjectRepository {
      * @param page the page to save
      */
     public void saveWebPageNow(WebORPage page) {
-        if (useYamlFormat && yamlWriter != null) {
-            try {
-                File orRepLocation = new File(getORRepLocation());
-                File webPagesDir = new File(orRepLocation, "Web/pages");
-                if (!webPagesDir.exists()) {
-                    webPagesDir.mkdirs();
-                }
-                yamlWriter.writeWebPage(page, webPagesDir);
-            } catch (IOException e) {
-                LOG.log(Level.SEVERE, "Failed to save Web page: " + page.getName(), e);
+        if (!useYamlFormat || yamlWriter == null || page == null) return;
+        try {
+            File repoRoot =
+                (page.getRoot().getScope() == WebOR.ORScope.SHARED)
+                    ? new File(getSharedORRepLocation())
+                    : new File(getORRepLocation());
+            File webPagesDir = new File(repoRoot, "Web");
+            if (!webPagesDir.exists()) {
+                webPagesDir.mkdirs();
             }
+            yamlWriter.writeWebPage(page, webPagesDir);
+            page.getRoot().setSaved(true);
+        } catch (IOException e) {
+            LOG.log(
+                Level.SEVERE,
+                "Failed to save Web page: " + page.getName(),
+                e
+            );
         }
-        // XML format doesn't need per-page saves
     }
     
     /**
@@ -1022,19 +1262,25 @@ public class ObjectRepository {
      * @param page the page to save
      */
     public void saveMobilePageNow(MobileORPage page) {
-        if (useYamlFormat && yamlWriter != null) {
-            try {
-                File morRepLocation = new File(getMORRepLocation());
-                File mobilePagesDir = new File(morRepLocation, "Mobile/pages");
-                if (!mobilePagesDir.exists()) {
-                    mobilePagesDir.mkdirs();
-                }
-                yamlWriter.writeMobilePage(page, mobilePagesDir);
-            } catch (IOException e) {
-                LOG.log(Level.SEVERE, "Failed to save Mobile page: " + page.getName(), e);
+        if (!useYamlFormat || yamlWriter == null || page == null) return;
+        try {
+            File repoRoot =
+                (page.getRoot().getScope() == MobileOR.ORScope.SHARED)
+                    ? new File(getSharedORRepLocation())
+                    : new File(getORRepLocation());
+            File mobilePagesDir = new File(repoRoot, "Mobile");
+            if (!mobilePagesDir.exists()) {
+                mobilePagesDir.mkdirs();
             }
+            yamlWriter.writeMobilePage(page, mobilePagesDir);
+            page.getRoot().setSaved(true);
+        } catch (IOException e) {
+            LOG.log(
+                Level.SEVERE,
+                "Failed to save Mobile page: " + page.getName(),
+                e
+            );
         }
-        // XML format doesn't need per-page saves
     }
     
     /**
@@ -1066,15 +1312,24 @@ public class ObjectRepository {
      * @param newName new page name
      * @return true if renamed successfully, false otherwise
      */
-    public boolean renameWebPageYaml(String oldName, String newName) {
+    public boolean renameWebPageYaml(String oldName, String newName, WebOR.ORScope scope) {
         if (!useYamlFormat || yamlWriter == null) {
-            return true; // XML mode - no-op
+            return true;
+        }
+        if (oldName == null || newName == null || oldName.equals(newName)) {
+            return true;
         }
         try {
-            File orRepLocation = new File(getORRepLocation());
-            return yamlWriter.renameWebPage(oldName, newName, orRepLocation);
+            File repoRoot =
+                (scope == WebOR.ORScope.SHARED)
+                    ? new File(getSharedORRepLocation())
+                    : new File(getORRepLocation());
+            return yamlWriter.renameWebPage(oldName, newName, repoRoot);
+
         } catch (Exception e) {
-            LOG.log(Level.SEVERE, "Failed to rename Web page from " + oldName + " to " + newName, e);
+            LOG.log(Level.SEVERE,
+                "Failed to rename Web page [" + scope + "] from " +
+                oldName + " to " + newName, e);
             return false;
         }
     }
@@ -1086,12 +1341,18 @@ public class ObjectRepository {
      * @param newName new page name
      * @return true if renamed successfully, false otherwise
      */
-    public boolean renameMobilePageYaml(String oldName, String newName) {
+    public boolean renameMobilePageYaml(String oldName, String newName, MobileOR.ORScope scope) {
         if (!useYamlFormat || yamlWriter == null) {
             return true; // XML mode - no-op
         }
+        if (oldName == null || newName == null || oldName.equals(newName)) {
+            return true;
+        }
         try {
-            File morRepLocation = new File(getMORRepLocation());
+            File morRepLocation =
+                (scope == MobileOR.ORScope.SHARED)
+                    ? new File(getSharedORRepLocation())
+                    : new File(getORRepLocation());
             return yamlWriter.renameMobilePage(oldName, newName, morRepLocation);
         } catch (Exception e) {
             LOG.log(Level.SEVERE, "Failed to rename Mobile page from " + oldName + " to " + newName, e);
@@ -1115,6 +1376,54 @@ public class ObjectRepository {
             return yamlWriter.renameStructuredDataPage(oldName, newName, structuredDataRepLocation);
         } catch (Exception e) {
             LOG.log(Level.SEVERE, "Failed to rename Structured Data page from " + oldName + " to " + newName, e);
+            return false;
+        }
+    }
+    
+    public boolean deleteWebPageYaml(String pageName) {
+        if (!useYamlFormat || yamlWriter == null) {
+            return true; // XML mode - no-op
+        }
+        if (pageName == null || pageName.isBlank()) {
+            return true;
+        }
+        try {
+            File orRepLocation = new File(getORRepLocation());
+            return yamlWriter.deleteWebPage(pageName, orRepLocation);
+        } catch (Exception e) {
+            LOG.log(Level.SEVERE, "Failed to delete Web page YAML: " + pageName, e);
+            return false;
+        }
+    }
+    
+    public boolean deleteMobilePageYaml(String pageName) {
+        if (!useYamlFormat || yamlWriter == null) {
+            return true; // XML mode - no-op
+        }
+        if (pageName == null || pageName.isBlank()) {
+            return true;
+        }
+        try {
+            File morRepLocation = new File(getORRepLocation());
+            return yamlWriter.deleteMobilePage(pageName, morRepLocation);
+        } catch (Exception e) {
+            LOG.log(Level.SEVERE, "Failed to delete Mobile page YAML: " + pageName, e);
+            return false;
+        }
+    }
+    
+    public boolean deleteStructuredDataPageYaml(String pageName) {
+        if (!useYamlFormat || yamlWriter == null) {
+            return true; // XML mode - no-op
+        }
+        if (pageName == null || pageName.isBlank()) {
+            return true;
+        }
+        try {
+            File apiorRepLocation = new File(getORRepLocation());
+            return yamlWriter.deleteStructuredDataPage(pageName, apiorRepLocation);
+        } catch (Exception e) {
+            LOG.log(Level.SEVERE, "Failed to delete Structured Data page YAML: " + pageName, e);
             return false;
         }
     }

--- a/Datalib/src/main/java/com/ing/datalib/or/ObjectRepository.java
+++ b/Datalib/src/main/java/com/ing/datalib/or/ObjectRepository.java
@@ -161,11 +161,17 @@ public class ObjectRepository {
         return sProject.getLocation() + File.separator + "StructuredDataObjectRepository";
     }
     public String getSharedORRepLocation() {
-        File projectDir = new File(sProject.getLocation());   
-        File projectsRoot = projectDir.getParentFile();       
-        File ingeniousRoot = projectsRoot.getParentFile();    
-        File sharedOR = new File(ingeniousRoot,"Shared" + File.separator + "SharedObjectRepository");
-        return sharedOR.getAbsolutePath();
+        // Use the application root (where Run.command/Run.bat is located) for Shared OR
+        // This ensures Shared OR is always at <AppRoot>/Shared/SharedObjectRepository
+        // regardless of where individual projects are located
+        try {
+            String appRoot = new File(System.getProperty("user.dir")).getCanonicalPath();
+            return appRoot + File.separator + "Shared" + File.separator + "SharedObjectRepository";
+        } catch (IOException ex) {
+            LOG.log(Level.WARNING, "Failed to get canonical path for Shared OR location", ex);
+            // Fallback to non-canonical path
+            return System.getProperty("user.dir") + File.separator + "Shared" + File.separator + "SharedObjectRepository";
+        }
     }
     public Project getsProject() {
         return sProject;
@@ -913,7 +919,7 @@ public class ObjectRepository {
         String candidate = baseName;
         int counter = 1;
         while (exists.test(candidate)) {
-            candidate = baseName + " (" + counter + ")";
+            candidate = baseName + "_" + counter;
             counter++;
         }
         return candidate;

--- a/Datalib/src/main/java/com/ing/datalib/or/ObjectRepository.java
+++ b/Datalib/src/main/java/com/ing/datalib/or/ObjectRepository.java
@@ -1,31 +1,5 @@
-
 package com.ing.datalib.or;
 
-import com.ing.datalib.component.Project;
-import com.ing.datalib.component.TestStep;
-import com.ing.datalib.or.structureddata.StructuredData;
-import com.ing.datalib.or.common.ORPageInf;
-import com.ing.datalib.or.common.ObjectGroup;
-import com.ing.datalib.or.mobile.MobileOR;
-import com.ing.datalib.or.mobile.MobileORObject;
-import com.ing.datalib.or.mobile.MobileORPage;
-import com.ing.datalib.or.web.WebOR;
-import com.ing.datalib.or.yaml.YamlORReader;
-import com.ing.datalib.or.yaml.YamlORWriter;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.xml.XmlMapper;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
-import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
-import com.ing.datalib.or.structureddata.StructuredDataORObject;
-import com.ing.datalib.or.structureddata.StructuredDataORPage;
-import com.ing.datalib.or.structureddata.ResolvedStructuredDataObject;
-import com.ing.datalib.or.mobile.ResolvedMobileObject;
-import com.ing.datalib.or.web.ResolvedWebObject;
-import com.ing.datalib.or.web.WebOR.ORScope;
-import static com.ing.datalib.or.web.WebOR.ORScope.PROJECT;
-import static com.ing.datalib.or.web.WebOR.ORScope.SHARED;
-import com.ing.datalib.or.web.WebORObject;
-import com.ing.datalib.or.web.WebORPage;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -36,6 +10,29 @@ import java.util.Set;
 import java.util.function.Predicate;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import com.ing.datalib.component.Project;
+import com.ing.datalib.component.TestStep;
+import com.ing.datalib.or.common.ORPageInf;
+import com.ing.datalib.or.common.ObjectGroup;
+import com.ing.datalib.or.mobile.MobileOR;
+import com.ing.datalib.or.mobile.MobileORObject;
+import com.ing.datalib.or.mobile.MobileORPage;
+import com.ing.datalib.or.mobile.ResolvedMobileObject;
+import com.ing.datalib.or.structureddata.ResolvedStructuredDataObject;
+import com.ing.datalib.or.structureddata.StructuredData;
+import com.ing.datalib.or.structureddata.StructuredDataORObject;
+import com.ing.datalib.or.structureddata.StructuredDataORPage;
+import com.ing.datalib.or.web.ResolvedWebObject;
+import com.ing.datalib.or.web.WebOR;
+import com.ing.datalib.or.web.WebOR.ORScope;
+import static com.ing.datalib.or.web.WebOR.ORScope.PROJECT;
+import static com.ing.datalib.or.web.WebOR.ORScope.SHARED;
+import com.ing.datalib.or.web.WebORObject;
+import com.ing.datalib.or.web.WebORPage;
+import com.ing.datalib.or.yaml.YamlORReader;
+import com.ing.datalib.or.yaml.YamlORWriter;
 
 /**
  * Manages all Object Repository types (Web Project OR, Web Shared OR, Mobile OR)
@@ -992,6 +989,79 @@ public class ObjectRepository {
     }
 
     /**
+     * Moves an entire WebOR page from project to shared.
+     * Moves all objects on the page and updates all test case references.
+     *
+     * @param sourcePageName project page to move
+     * @param targetPageName desired shared page name
+     * @return actual created page name in shared OR, or null on failure
+     */
+    public String moveWebPage(String sourcePageName, String targetPageName) {
+        WebOR projectOR = getWebOR();
+        WebOR sharedOR = getWebSharedOR();
+        if (projectOR == null || sharedOR == null) return null;
+        
+        WebORPage sourcePage = projectOR.getPageByName(sourcePageName);
+        if (sourcePage == null) return null;
+        
+        // Use the same name (no uniqueness needed for page move)
+        String actualTargetName = targetPageName;
+        
+        // Check if target page already exists in shared OR
+        WebORPage existingTargetPage = sharedOR.getPageByName(actualTargetName);
+        if (existingTargetPage != null) {
+            // Target page exists - merge objects into it
+            List<ObjectGroup<WebORObject>> objectsToMove = new ArrayList<>(sourcePage.getObjectGroups());
+            
+            for (ObjectGroup<WebORObject> group : objectsToMove) {
+                String objectName = group.getName();
+                
+                // Skip if object already exists in target page
+                if (existingTargetPage.getObjectGroupByName(objectName) != null) {
+                    LOG.warning("Object '" + objectName + "' already exists in shared page '" + actualTargetName + "', skipping");
+                    continue;
+                }
+                
+                // Move this object
+                ResolvedWebObject resolved = new ResolvedWebObject(
+                    WebOR.ORScope.PROJECT, 
+                    sourcePageName, 
+                    objectName, 
+                    group
+                );
+                moveWebObject(resolved, actualTargetName);
+            }
+        } else {
+            // Target page doesn't exist - move entire page
+            List<ObjectGroup<WebORObject>> objectsToMove = new ArrayList<>(sourcePage.getObjectGroups());
+            
+            for (ObjectGroup<WebORObject> group : objectsToMove) {
+                // Move each object (this will create the target page on first iteration)
+                String objectName = group.getName();
+                ResolvedWebObject resolved = new ResolvedWebObject(
+                    WebOR.ORScope.PROJECT,
+                    sourcePageName,
+                    objectName,
+                    group
+                );
+                String movedName = moveWebObject(resolved, actualTargetName);
+                if (movedName == null) {
+                    LOG.warning("Failed to move object '" + group.getName() + "' to shared page '" + actualTargetName + "'");
+                }
+            }
+        }
+        
+        // Remove source page if now empty
+        if (sourcePage.getObjectGroups().isEmpty()) {
+            sourcePage.removeFromParent();
+            projectOR.setSaved(false);
+        }
+        
+        LOG.info("Moved Web Page '" + sourcePageName + "' to SHARED page '" + actualTargetName + "'");
+        return actualTargetName;
+    }
+    
+    /**
      * Copies a WebOR object into a shared page (creating the page if needed)
      * using a unique object group name.
      *
@@ -1028,12 +1098,12 @@ public class ObjectRepository {
     }
     
     /**
-     * Moved a WebOR object into a shared page (creating the page if needed)
-     * using a unique object group name.
+     * Moves a WebOR object from project to shared page.
+     * Actually moves the object (removes from source, adds to target) instead of cloning.
      *
      * @param source          resolved web object
      * @param targetPageName  target page in shared OR
-     * @return new object name
+     * @return original object name if successful, null if object already exists in target
      */
     public String moveWebObject(ResolvedWebObject source, String targetPageName) {
         if (source == null) return null;
@@ -1044,27 +1114,48 @@ public class ObjectRepository {
         ObjectGroup<WebORObject> originalGroup = source.getGroup();
         if (originalGroup == null) return null;
         String originalName = originalGroup.getName();
-        String baseName = originalName.replaceAll("_\\d+$", "");
-        String finalName = baseName;
-        if (targetPage.getObjectGroupByName(finalName) != null) {
-            int index = 1;
-            do {
-                finalName = baseName + "_" + index++;
-            } while (targetPage.getObjectGroupByName(finalName) != null);
+        
+        // Fail if object with same name already exists in target
+        if (targetPage.getObjectGroupByName(originalName) != null) {
+            return null;
         }
-        ObjectGroup<WebORObject> newGroup =
-            cloneGroupIntoPage(originalGroup, targetPage, finalName);
-        targetPage.getObjectGroups().add(newGroup);
+        
+        // Remove from source page first (actual move!)
+        ORPageInf sourcePage = originalGroup.getParent();
+        if (sourcePage != null) {
+            sourcePage.getObjectGroups().remove(originalGroup);
+            sourcePage.getRoot().setSaved(false);
+            if (useYamlFormat && sourcePage instanceof WebORPage) {
+                saveWebPageNow((WebORPage) sourcePage);
+            }
+        }
+        
+        // Move the same group to target (not a clone)
+        originalGroup.setParent(targetPage);
+        targetPage.getObjectGroups().add(originalGroup);
         sharedOR.setSaved(false);
         if (useYamlFormat) {
             saveWebPageNow(targetPage);
         }
+        
+        // Update all test case references from PROJECT to SHARED scope
+        // Change page reference from unprefixed or "[Project] page" to "[Shared] page"
+        if (sourcePage != null) {
+            String sourcePageName = sourcePage.getName();
+            String targetScopedPage = "[Shared] " + targetPage.getName();
+            
+            // Update unprefixed references: "PageName" -> "[Shared] PageName"
+            sProject.refactorObjectName(sourcePageName, originalName, targetScopedPage, originalName);
+            
+            // Update [Project] prefixed references: "[Project] PageName" -> "[Shared] PageName"
+            sProject.refactorObjectName("[Project] " + sourcePageName, originalName, targetScopedPage, originalName);
+        }
+        
         LOG.info(
             "Moved Web Object '" + originalName +
-            "' to SHARED as '" + finalName + "'"
+            "' to SHARED page '" + targetPageName + "'"
         );
-
-        return finalName;
+        return originalName;
     }
 
     /**
@@ -1125,12 +1216,12 @@ public class ObjectRepository {
         return uniqueName;
     }
     
-     /**
-     * Moves a MobileOR object into a target shared Mobile page (creates page if needed)
-     * using a unique object group name.
+    /**
+     * Moves a MobileOR object from project to shared page.
+     * Actually moves the object (removes from source, adds to target) instead of cloning.
      * @param source resolved mobile object (from project OR)
      * @param targetPageName target page name in shared Mobile OR
-     * @return new object name created in shared OR, or null on failure
+     * @return original object name if successful, null if object already exists in target
      */
     public String moveMobileObject(ResolvedMobileObject source, String targetPageName) {
         if (source == null) return null;
@@ -1141,27 +1232,123 @@ public class ObjectRepository {
         ObjectGroup<MobileORObject> originalGroup = source.getGroup();
         if (originalGroup == null) return null;
         String originalName = originalGroup.getName();
-        String baseName = originalName.replaceAll("_\\d+$", "");
-        String finalName = baseName;
-        if (targetPage.getObjectGroupByName(finalName) != null) {
-            int index = 1;
-            do {
-                finalName = baseName + "_" + index++;
-            } while (targetPage.getObjectGroupByName(finalName) != null);
+        
+        // Fail if object with same name already exists in target
+        if (targetPage.getObjectGroupByName(originalName) != null) {
+            return null;
         }
-        ObjectGroup<MobileORObject> newGroup = cloneMobileGroupIntoPage(originalGroup, targetPage, finalName);
-        targetPage.getObjectGroups().add(newGroup);
+        
+        // Remove from source page first (actual move!)
+        ORPageInf sourcePage = originalGroup.getParent();
+        if (sourcePage != null) {
+            sourcePage.getObjectGroups().remove(originalGroup);
+            sourcePage.getRoot().setSaved(false);
+            if (useYamlFormat && sourcePage instanceof MobileORPage) {
+                saveMobilePageNow((MobileORPage) sourcePage);
+            }
+        }
+        
+        // Move the same group to target (not a clone)
+        originalGroup.setParent(targetPage);
+        targetPage.getObjectGroups().add(originalGroup);
         sharedOR.setSaved(false);
         if (useYamlFormat) {
             saveMobilePageNow(targetPage);
         }
+        
+        // Update all test case references from PROJECT to SHARED scope
+        // Change page reference from unprefixed or "[Project] page" to "[Shared] page"
+        if (sourcePage != null) {
+            String sourcePageName = sourcePage.getName();
+            String targetScopedPage = "[Shared] " + targetPage.getName();
+            
+            // Update unprefixed references: "PageName" -> "[Shared] PageName"
+            sProject.refactorObjectName(sourcePageName, originalName, targetScopedPage, originalName);
+            
+            // Update [Project] prefixed references: "[Project] PageName" -> "[Shared] PageName"
+            sProject.refactorObjectName("[Project] " + sourcePageName, originalName, targetScopedPage, originalName);
+        }
+        
         LOG.info(
-            "Moved Mobile Object '" + originalName +
-            "' to SHARED as '" + finalName + "'"
+            "Moved Mobile Object Group '" + originalName +
+            "' to SHARED page '" + targetPageName + "'"
         );
-        return finalName;
+        return originalName;
     }
 
+    /**
+     * Moves an entire MobileOR page from project to shared.
+     * Moves all objects on the page and updates all test case references.
+     *
+     * @param sourcePageName project page to move
+     * @param targetPageName desired shared page name
+     * @return actual created page name in shared OR, or null on failure
+     */
+    public String moveMobilePage(String sourcePageName, String targetPageName) {
+        MobileOR projectOR = getMobileOR();
+        MobileOR sharedOR = getMobileSharedOR();
+        if (projectOR == null || sharedOR == null) return null;
+        
+        MobileORPage sourcePage = projectOR.getPageByName(sourcePageName);
+        if (sourcePage == null) return null;
+        
+        // Use the same name (no uniqueness needed for page move)
+        String actualTargetName = targetPageName;
+        
+        // Check if target page already exists in shared OR
+        MobileORPage existingTargetPage = sharedOR.getPageByName(actualTargetName);
+        if (existingTargetPage != null) {
+            // Target page exists - merge objects into it
+            List<ObjectGroup<MobileORObject>> objectsToMove = new ArrayList<>(sourcePage.getObjectGroups());
+            
+            for (ObjectGroup<MobileORObject> group : objectsToMove) {
+                String objectName = group.getName();
+                
+                // Skip if object already exists in target page
+                if (existingTargetPage.getObjectGroupByName(objectName) != null) {
+                    LOG.warning("Mobile Object '" + objectName + "' already exists in shared page '" + actualTargetName + "', skipping");
+                    continue;
+                }
+                
+                // Move this object
+                ResolvedMobileObject resolved = new ResolvedMobileObject(
+                    WebOR.ORScope.PROJECT,
+                    sourcePageName,
+                    objectName,
+                    group
+                );
+                moveMobileObject(resolved, actualTargetName);
+            }
+        } else {
+            // Target page doesn't exist - move entire page
+            List<ObjectGroup<MobileORObject>> objectsToMove = new ArrayList<>(sourcePage.getObjectGroups());
+            
+            for (ObjectGroup<MobileORObject> group : objectsToMove) {
+                // Move each object (this will create the target page on first iteration)
+                String objectName = group.getName();
+                ResolvedMobileObject resolved = new ResolvedMobileObject(
+                    WebOR.ORScope.PROJECT,
+                    sourcePageName,
+                    objectName,
+                    group
+                );
+                String movedName = moveMobileObject(resolved, actualTargetName);
+                if (movedName == null) {
+                    LOG.warning("Failed to move mobile object '" + group.getName() + "' to shared page '" + actualTargetName + "'");
+                }
+            }
+        }
+        
+        // Remove source page if now empty
+        if (sourcePage.getObjectGroups().isEmpty()) {
+            sourcePage.removeFromParent();
+            projectOR.setSaved(false);
+        }
+        
+        LOG.info("Moved Mobile Page '" + sourcePageName + "' to SHARED page '" + actualTargetName + "'");
+        return actualTargetName;
+    }
+    
     private String generateUniquePageName(MobileOR mor, String baseName) {
         if (mor == null) return baseName;
         return generateUniqueName(baseName, name -> mor.getPageByName(name) != null);
@@ -1386,7 +1573,7 @@ public class ObjectRepository {
         }
     }
     
-    public boolean deleteWebPageYaml(String pageName) {
+    public boolean deleteWebPageYaml(String pageName, WebOR.ORScope scope) {
         if (!useYamlFormat || yamlWriter == null) {
             return true; // XML mode - no-op
         }
@@ -1394,7 +1581,9 @@ public class ObjectRepository {
             return true;
         }
         try {
-            File orRepLocation = new File(getORRepLocation());
+            File orRepLocation = (scope == WebOR.ORScope.SHARED) 
+                ? new File(getSharedORRepLocation()) 
+                : new File(getORRepLocation());
             return yamlWriter.deleteWebPage(pageName, orRepLocation);
         } catch (Exception e) {
             LOG.log(Level.SEVERE, "Failed to delete Web page YAML: " + pageName, e);
@@ -1402,7 +1591,7 @@ public class ObjectRepository {
         }
     }
     
-    public boolean deleteMobilePageYaml(String pageName) {
+    public boolean deleteMobilePageYaml(String pageName, MobileOR.ORScope scope) {
         if (!useYamlFormat || yamlWriter == null) {
             return true; // XML mode - no-op
         }
@@ -1410,7 +1599,9 @@ public class ObjectRepository {
             return true;
         }
         try {
-            File morRepLocation = new File(getORRepLocation());
+            File morRepLocation = (scope == MobileOR.ORScope.SHARED) 
+                ? new File(getSharedORRepLocation()) 
+                : new File(getORRepLocation());
             return yamlWriter.deleteMobilePage(pageName, morRepLocation);
         } catch (Exception e) {
             LOG.log(Level.SEVERE, "Failed to delete Mobile page YAML: " + pageName, e);

--- a/Datalib/src/main/java/com/ing/datalib/or/XmlToYamlORConverter.java
+++ b/Datalib/src/main/java/com/ing/datalib/or/XmlToYamlORConverter.java
@@ -1,0 +1,110 @@
+
+package com.ing.datalib.or;
+
+import com.ing.datalib.or.mobile.MobileOR;
+import com.ing.datalib.or.mobile.MobileORPage;
+import com.ing.datalib.or.web.WebOR;
+import com.ing.datalib.or.web.WebORPage;
+import com.ing.datalib.or.yaml.YamlORWriter;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.logging.Logger;
+
+/**
+ * Converts in-memory XML Object Repositories to YAML.
+ *
+ * Scope is determined by WHICH OR is passed:
+ * - Project OR → ObjectRepository
+ * - Shared OR  → Shared
+ *
+ * Pages do not carry scope.
+ */
+public class XmlToYamlORConverter {
+
+    private static final Logger LOG = Logger.getLogger(XmlToYamlORConverter.class.getName());
+
+    private final YamlORWriter yamlWriter;
+
+    public XmlToYamlORConverter(YamlORWriter yamlWriter) {
+        this.yamlWriter = yamlWriter;
+    }
+
+    /**
+     * Convert all ORs to YAML with correct folder separation.
+     */
+    public void convertAll(
+            WebOR projectWeb,
+            WebOR sharedWeb,
+            MobileOR projectMobile,
+            MobileOR sharedMobile,
+            File projectRoot,
+            File sharedRoot) throws IOException {
+
+        writeProjectWeb(projectWeb, projectRoot);
+        writeSharedWeb(sharedWeb, sharedRoot);
+
+        writeProjectMobile(projectMobile, projectRoot);
+        writeSharedMobile(sharedMobile, sharedRoot);
+    }
+
+    private void writeProjectWeb(WebOR projectOR, File projectRoot)
+            throws IOException {
+
+        if (projectOR == null) return;
+
+        File pagesDir = new File(projectRoot, "Web");
+        pagesDir.mkdirs();
+
+        LOG.info("Writing PROJECT Web OR to " + pagesDir.getAbsolutePath());
+
+        for (WebORPage page : projectOR.getPages()) {
+            yamlWriter.writeWebPage(page, pagesDir);
+        }
+    }
+
+    private void writeProjectMobile(MobileOR projectOR, File projectRoot)
+            throws IOException {
+
+        if (projectOR == null) return;
+
+        File pagesDir = new File(projectRoot, "Mobile");
+        pagesDir.mkdirs();
+
+        LOG.info("Writing PROJECT Mobile OR to " + pagesDir.getAbsolutePath());
+
+        for (MobileORPage page : projectOR.getPages()) {
+            yamlWriter.writeMobilePage(page, pagesDir);
+        }
+    }
+
+    private void writeSharedWeb(WebOR sharedOR, File sharedRoot)
+            throws IOException {
+
+        if (sharedOR == null) return;
+
+        File pagesDir = new File(sharedRoot, "Web");
+        pagesDir.mkdirs();
+
+        LOG.info("Writing SHARED Web OR to " + pagesDir.getAbsolutePath());
+
+        for (WebORPage page : sharedOR.getPages()) {
+            yamlWriter.writeWebPage(page, pagesDir);
+        }
+    }
+
+    private void writeSharedMobile(MobileOR sharedOR, File sharedRoot)
+            throws IOException {
+
+        if (sharedOR == null) return;
+
+        File pagesDir = new File(sharedRoot, "Mobile");
+        pagesDir.mkdirs();
+
+        LOG.info("Writing SHARED Mobile OR to " + pagesDir.getAbsolutePath());
+
+        for (MobileORPage page : sharedOR.getPages()) {
+            yamlWriter.writeMobilePage(page, pagesDir);
+        }
+    }
+}

--- a/Datalib/src/main/java/com/ing/datalib/or/mobile/MobileOR.java
+++ b/Datalib/src/main/java/com/ing/datalib/or/mobile/MobileOR.java
@@ -103,6 +103,9 @@ public class MobileOR implements ORRootInf<MobileORPage> {
         this.pages = pages;
         for (MobileORPage page : pages) {
             page.setRoot(this);
+            if (page.getSource() == null) {
+                page.setSource(isShared() ? ORScope.SHARED : ORScope.PROJECT);
+            }
         }
     }
 
@@ -250,7 +253,7 @@ public class MobileOR implements ORRootInf<MobileORPage> {
     public String getRepLocation() {
         return repLocationOverride != null
                 ? repLocationOverride
-                : getObjectRepository().getMORRepLocation();
+                : getObjectRepository().getORRepLocation();
     }
 
     @JsonIgnore
@@ -282,6 +285,6 @@ public class MobileOR implements ORRootInf<MobileORPage> {
     }
     
     public void setSharedProjects(List<String> projects) {
-        this.projects = (projects == null) ? new ArrayList<>() : projects;
+        this.projects = projects;
     }
 }

--- a/Datalib/src/main/java/com/ing/datalib/or/mobile/MobileORObject.java
+++ b/Datalib/src/main/java/com/ing/datalib/or/mobile/MobileORObject.java
@@ -76,10 +76,11 @@ public class MobileORObject extends UndoRedoModel implements ORObjectInf {
         changeSave();
         if (group.getObjects().size() == 1) {
             group.removeFromParent();
-        } else {
-            group.getObjects().remove(this);
-            FileUtils.deleteFile(getRepLocation());
         }
+        group.getObjects().remove(this);
+        if (!group.getParent().getRoot().getObjectRepository().isUsingYamlFormat()) {
+            FileUtils.deleteFile(getRepLocation());
+        } 
     }
 
     @Override
@@ -311,30 +312,21 @@ public class MobileORObject extends UndoRedoModel implements ORObjectInf {
         return String.class;
     }
 
+    @JsonIgnore
     @Override
     public Boolean rename(String newName) {
-        Boolean flag = true;
         if (getParent().getChildCount() == 1) {
-            flag = getParent().rename(newName);
+            getParent().rename(newName);
         }
-        if (flag && getParent().getObjectByName(newName) == null) {
-            // Check if using YAML format
-            if (getParent().getParent().getRoot().getObjectRepository().isUsingYamlFormat()) {
-                // For YAML format, objects are stored within the page YAML file
-                // Just update the name and mark as needing save
-                setName(newName);
-                changeSave();
-                return true;
-            } else {
-                // Use original XML folder-based rename
-                if (FileUtils.renameFile(getRepLocation(), newName)) {
-                    setName(newName);
-                    changeSave();
-                    return true;
-                }
-            }
+        if (newName == null || newName.isBlank()) {
+            return false;
         }
-        return false;
+        if (getParent().getObjectByName(newName) != null) {
+            return false;
+        }
+        setName(newName);
+        changeSave();
+        return true;
     }
 
     @JsonIgnore

--- a/Datalib/src/main/java/com/ing/datalib/or/mobile/MobileORPage.java
+++ b/Datalib/src/main/java/com/ing/datalib/or/mobile/MobileORPage.java
@@ -90,7 +90,11 @@ public class MobileORPage implements ORPageInf<MobileORObject, MobileOR> {
     public void removeFromParent() {
         root.setSaved(false);
         root.getPages().remove(this);
-        FileUtils.deleteFile(getRepLocation());
+        if (root.getObjectRepository().isUsingYamlFormat()) {
+            root.getObjectRepository().deleteMobilePageYaml(getName());
+        } else {
+            FileUtils.deleteFile(getRepLocation());
+        }
     }
 
     @JsonIgnore
@@ -256,28 +260,10 @@ public class MobileORPage implements ORPageInf<MobileORObject, MobileOR> {
 
     @Override
     public Boolean rename(String newName) {
-        if (getParent().getPageByName(newName) == null) {
-            String oldName = getName();
-            // Check if using YAML format
-            if (getRoot().getObjectRepository().isUsingYamlFormat()) {
-                // Rename the YAML file
-                if (getRoot().getObjectRepository().renameMobilePageYaml(oldName, newName)) {
-                    getRoot().getObjectRepository().renamePage(this, newName);
-                    setName(newName);
-                    getParent().setSaved(false);
-                    return true;
-                }
-            } else {
-                // Use original XML folder-based rename
-                if (FileUtils.renameFile(getRepLocation(), newName)) {
-                    getRoot().getObjectRepository().renamePage(this, newName);
-                    setName(newName);
-                    getParent().setSaved(false);
-                    return true;
-                }
-            }
-        }
-        return false;
+        getRoot()
+            .getObjectRepository()
+            .renamePage(this, newName);
+        return true;
     }
 
     @JsonIgnore

--- a/Datalib/src/main/java/com/ing/datalib/or/mobile/MobileORPage.java
+++ b/Datalib/src/main/java/com/ing/datalib/or/mobile/MobileORPage.java
@@ -1,22 +1,24 @@
 
 package com.ing.datalib.or.mobile;
 
-import com.ing.datalib.component.utils.FileUtils;
-import com.ing.datalib.or.common.ORPageInf;
-import com.ing.datalib.or.common.ORUtils;
-import com.ing.datalib.or.common.ObjectGroup;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
-import com.ing.datalib.or.mobile.MobileOR.ORScope;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.List;
+
 import javax.swing.tree.TreeNode;
 import javax.swing.tree.TreePath;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import com.ing.datalib.component.utils.FileUtils;
+import com.ing.datalib.or.common.ORPageInf;
+import com.ing.datalib.or.common.ORUtils;
+import com.ing.datalib.or.common.ObjectGroup;
+import com.ing.datalib.or.mobile.MobileOR.ORScope;
 
 /**
  * Represents a single mobile object inside a MobileOR page, containing a collection of
@@ -91,7 +93,7 @@ public class MobileORPage implements ORPageInf<MobileORObject, MobileOR> {
         root.setSaved(false);
         root.getPages().remove(this);
         if (root.getObjectRepository().isUsingYamlFormat()) {
-            root.getObjectRepository().deleteMobilePageYaml(getName());
+            root.getObjectRepository().deleteMobilePageYaml(getName(), root.getScope());
         } else {
             FileUtils.deleteFile(getRepLocation());
         }

--- a/Datalib/src/main/java/com/ing/datalib/or/web/WebOR.java
+++ b/Datalib/src/main/java/com/ing/datalib/or/web/WebOR.java
@@ -296,6 +296,6 @@ public class WebOR implements ORRootInf<WebORPage> {
     }
 
     public void setSharedProjects(List<String> projects) {
-        this.projects = (projects == null) ? new ArrayList<>() : projects;
+        this.projects = projects;
     }
 }

--- a/Datalib/src/main/java/com/ing/datalib/or/web/WebORObject.java
+++ b/Datalib/src/main/java/com/ing/datalib/or/web/WebORObject.java
@@ -109,7 +109,9 @@ public class WebORObject extends UndoRedoModel implements ORObjectInf {
             group.removeFromParent();
         }
         group.getObjects().remove(this);
-        FileUtils.deleteFile(getRepLocation());
+        if (!group.getParent().getRoot().getObjectRepository().isUsingYamlFormat()) {
+            FileUtils.deleteFile(getRepLocation());
+        } 
     }
 
     @JsonIgnore
@@ -352,28 +354,18 @@ public class WebORObject extends UndoRedoModel implements ORObjectInf {
     @JsonIgnore
     @Override
     public Boolean rename(String newName) {
-        Boolean flag = true;
         if (getParent().getChildCount() == 1) {
-            flag = getParent().rename(newName);
+            getParent().rename(newName);
         }
-        if (flag && getParent().getObjectByName(newName) == null) {
-            // Check if using YAML format
-            if (getParent().getParent().getRoot().getObjectRepository().isUsingYamlFormat()) {
-                // For YAML format, objects are stored within the page YAML file
-                // Just update the name and mark as needing save
-                setName(newName);
-                changeSave();
-                return true;
-            } else {
-                // Use original XML folder-based rename
-                if (FileUtils.renameFile(getRepLocation(), newName)) {
-                    setName(newName);
-                    changeSave();
-                    return true;
-                }
-            }
+        if (newName == null || newName.isBlank()) {
+            return false;
         }
-        return false;
+        if (getParent().getObjectByName(newName) != null) {
+            return false;
+        }
+        setName(newName);
+        changeSave();
+        return true;
     }
 
     @JsonIgnore

--- a/Datalib/src/main/java/com/ing/datalib/or/web/WebORPage.java
+++ b/Datalib/src/main/java/com/ing/datalib/or/web/WebORPage.java
@@ -90,7 +90,11 @@ public class WebORPage implements ORPageInf<WebORObject, WebOR> {
     public void removeFromParent() {
         root.setSaved(false);
         root.getPages().remove(this);
-        FileUtils.deleteFile(getRepLocation());
+        if (root.getObjectRepository().isUsingYamlFormat()) {
+            root.getObjectRepository().deleteWebPageYaml(getName());
+        } else {
+            FileUtils.deleteFile(getRepLocation());
+        }
     }
 
     @JsonIgnore
@@ -255,28 +259,10 @@ public class WebORPage implements ORPageInf<WebORObject, WebOR> {
 
     @Override
     public Boolean rename(String newName) {
-        if (getParent().getPageByName(newName) == null) {
-            String oldName = getName();
-            // Check if using YAML format
-            if (getRoot().getObjectRepository().isUsingYamlFormat()) {
-                // Rename the YAML file
-                if (getRoot().getObjectRepository().renameWebPageYaml(oldName, newName)) {
-                    getRoot().getObjectRepository().renamePage(this, newName);
-                    setName(newName);
-                    getParent().setSaved(false);
-                    return true;
-                }
-            } else {
-                // Use original XML folder-based rename
-                if (FileUtils.renameFile(getRepLocation(), newName)) {
-                    getRoot().getObjectRepository().renamePage(this, newName);
-                    setName(newName);
-                    getParent().setSaved(false);
-                    return true;
-                }
-            }
-        }
-        return false;
+        getRoot()
+            .getObjectRepository()
+            .renamePage(this, newName);
+        return true;
     }
 
     @JsonIgnore

--- a/Datalib/src/main/java/com/ing/datalib/or/web/WebORPage.java
+++ b/Datalib/src/main/java/com/ing/datalib/or/web/WebORPage.java
@@ -1,22 +1,24 @@
 
 package com.ing.datalib.or.web;
 
-import com.ing.datalib.component.utils.FileUtils;
-import com.ing.datalib.or.common.ORPageInf;
-import com.ing.datalib.or.common.ORUtils;
-import com.ing.datalib.or.common.ObjectGroup;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.List;
+
 import javax.swing.tree.TreeNode;
 import javax.swing.tree.TreePath;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import com.ing.datalib.component.utils.FileUtils;
+import com.ing.datalib.or.common.ORPageInf;
+import com.ing.datalib.or.common.ORUtils;
+import com.ing.datalib.or.common.ObjectGroup;
 
 /**
  * Represents a page in the Web Object Repository (WebOR), containing object groups
@@ -91,7 +93,7 @@ public class WebORPage implements ORPageInf<WebORObject, WebOR> {
         root.setSaved(false);
         root.getPages().remove(this);
         if (root.getObjectRepository().isUsingYamlFormat()) {
-            root.getObjectRepository().deleteWebPageYaml(getName());
+            root.getObjectRepository().deleteWebPageYaml(getName(), root.getScope());
         } else {
             FileUtils.deleteFile(getRepLocation());
         }

--- a/Datalib/src/main/java/com/ing/datalib/or/yaml/YamlMobilePageDefinition.java
+++ b/Datalib/src/main/java/com/ing/datalib/or/yaml/YamlMobilePageDefinition.java
@@ -33,7 +33,7 @@ import java.util.Map;
  * </pre>
  */
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-@JsonPropertyOrder({"page", "packageName", "description", "platform", "tags", "elements"})
+@JsonPropertyOrder({"page", "scope", "packageName", "description", "platform", "tags", "elements"})
 public class YamlMobilePageDefinition {
     
     private String page;
@@ -42,6 +42,7 @@ public class YamlMobilePageDefinition {
     private String platform;     // "android" | "ios" | "both"
     private List<String> tags;
     private Map<String, YamlMobileElementDefinition> elements = new LinkedHashMap<>();
+    private MobileOR.ORScope scope;
     
     public YamlMobilePageDefinition() {
     }
@@ -58,6 +59,14 @@ public class YamlMobilePageDefinition {
 
     public void setPage(String page) {
         this.page = page;
+    }
+
+    public MobileOR.ORScope getScope() {
+        return scope;
+    }
+
+    public void setScope(MobileOR.ORScope scope) {
+        this.scope = scope;
     }
 
     public String getPackageName() {
@@ -110,6 +119,10 @@ public class YamlMobilePageDefinition {
         yaml.setPage(page.getName());
         yaml.setPackageName(page.getPackageName());
         
+        if (page.getRoot() != null) {
+            yaml.setScope(page.getRoot().getScope());
+        }
+        
         // Iterate through object groups and objects using Lists
         for (ObjectGroup<MobileORObject> group : page.getObjectGroups()) {
             for (MobileORObject obj : group.getObjects()) {
@@ -127,6 +140,11 @@ public class YamlMobilePageDefinition {
      */
     public MobileORPage toMobileORPage(MobileOR root) {
         MobileORPage page = new MobileORPage(this.page, root);
+        
+        if (this.scope != null && root != null && this.scope != root.getScope()) { 
+            throw new IllegalStateException("Scope mismatch: YAML mobile page '" + page + "' declares scope " + scope + " but is loaded under OR scope " + root.getScope());
+        }
+        
         if (this.packageName != null && !this.packageName.isEmpty()) {
             page.setPackageName(this.packageName);
         }

--- a/Datalib/src/main/java/com/ing/datalib/or/yaml/YamlORReader.java
+++ b/Datalib/src/main/java/com/ing/datalib/or/yaml/YamlORReader.java
@@ -4,6 +4,7 @@ import com.ing.datalib.or.structureddata.StructuredData;
 import com.ing.datalib.or.structureddata.StructuredDataORPage;
 import com.ing.datalib.or.mobile.MobileOR;
 import com.ing.datalib.or.mobile.MobileORPage;
+import com.ing.datalib.or.ObjectRepository;
 import com.ing.datalib.or.web.WebOR;
 import com.ing.datalib.or.web.WebORPage;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -44,6 +45,8 @@ public class YamlORReader {
     
     private final ObjectMapper yamlMapper;
     
+    private ObjectRepository objectRepository;
+    
     public YamlORReader() {
         YAMLFactory factory = new YAMLFactory();
         factory.disable(YAMLGenerator.Feature.WRITE_DOC_START_MARKER);
@@ -52,11 +55,18 @@ public class YamlORReader {
         this.yamlMapper.findAndRegisterModules();
     }
     
+    public YamlORReader(ObjectRepository objectRepository) {
+        this.objectRepository = objectRepository;
+        YAMLFactory factory = new YAMLFactory();
+        factory.disable(YAMLGenerator.Feature.WRITE_DOC_START_MARKER);
+        this.yamlMapper = new ObjectMapper(factory);
+        this.yamlMapper.findAndRegisterModules();
+    }
     /**
      * Check if a YAML-based Web OR exists.
      */
     public boolean webORExists(File orLocation) {
-        File webPagesDir = new File(orLocation, "Web/pages");
+        File webPagesDir = new File(orLocation, "Web");
         return webPagesDir.exists() && webPagesDir.isDirectory();
     }
     
@@ -64,7 +74,7 @@ public class YamlORReader {
      * Check if a YAML-based Mobile OR exists.
      */
     public boolean mobileORExists(File orLocation) {
-        File mobilePagesDir = new File(orLocation, "Mobile/pages");
+        File mobilePagesDir = new File(orLocation, "Mobile");
         return mobilePagesDir.exists() && mobilePagesDir.isDirectory();
     }
     
@@ -84,7 +94,13 @@ public class YamlORReader {
      */
     public WebOR readWebOR(File orLocation) throws IOException {
         WebOR webOR = new WebOR();
-        File webPagesDir = new File(orLocation, "Web/pages");
+        File webPagesDir = new File(orLocation, "Web");
+        
+        if (orLocation.getPath().contains(File.separator + "Shared" + File.separator)) {
+            webOR.setScope(WebOR.ORScope.SHARED);
+        } else {
+            webOR.setScope(WebOR.ORScope.PROJECT);
+        }
         
         if (!webPagesDir.exists()) {
             LOGGER.info("No Web OR YAML directory found at: " + webPagesDir.getAbsolutePath());
@@ -116,7 +132,13 @@ public class YamlORReader {
      */
     public MobileOR readMobileOR(File orLocation) throws IOException {
         MobileOR mobileOR = new MobileOR();
-        File mobilePagesDir = new File(orLocation, "Mobile/pages");
+        File mobilePagesDir = new File(orLocation, "Mobile");
+        
+        if (orLocation.getPath().contains(File.separator + "Shared" + File.separator)) {
+            mobileOR.setScope(MobileOR.ORScope.SHARED);
+        } else {
+            mobileOR.setScope(MobileOR.ORScope.PROJECT);
+        }
         
         if (!mobilePagesDir.exists()) {
             LOGGER.info("No Mobile OR YAML directory found at: " + mobilePagesDir.getAbsolutePath());

--- a/Datalib/src/main/java/com/ing/datalib/or/yaml/YamlORWriter.java
+++ b/Datalib/src/main/java/com/ing/datalib/or/yaml/YamlORWriter.java
@@ -13,8 +13,13 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.logging.Level;
+import java.util.Map;
+import java.util.Set;
 import java.util.logging.Logger;
 
 /**
@@ -62,11 +67,11 @@ public class YamlORWriter {
      * @param orLocation The ObjectRepository directory
      */
     public void writeWebOR(WebOR webOR, File orLocation) throws IOException {
-        File webPagesDir = new File(orLocation, "Web/pages");
+        File webPagesDir = new File(orLocation, "Web");
         ensureDirectory(webPagesDir);
         
         List<WebORPage> pages = webOR.getPages();
-        LOGGER.info("Writing " + pages.size() + " Web pages to YAML");
+        LOGGER.info(() -> "Writing " + pages.size() + " Web pages to YAML");
         
         for (WebORPage page : pages) {
             writeWebPage(page, webPagesDir);
@@ -80,11 +85,11 @@ public class YamlORWriter {
      * @param orLocation The ObjectRepository directory
      */
     public void writeMobileOR(MobileOR mobileOR, File orLocation) throws IOException {
-        File mobilePagesDir = new File(orLocation, "Mobile/pages");
+        File mobilePagesDir = new File(orLocation, "Mobile");
         ensureDirectory(mobilePagesDir);
         
         List<MobileORPage> pages = mobileOR.getPages();
-        LOGGER.info("Writing " + pages.size() + " Mobile pages to YAML");
+        LOGGER.info(() -> "Writing " + pages.size() + " Mobile pages to YAML");
         
         for (MobileORPage page : pages) {
             writeMobilePage(page, mobilePagesDir);
@@ -117,7 +122,7 @@ public class YamlORWriter {
         File yamlFile = new File(pagesDir, sanitizeFileName(page.getName()) + ".yaml");
         
         yamlMapper.writeValue(yamlFile, pageDef);
-        LOGGER.fine("Wrote Web page: " + yamlFile.getName());
+        LOGGER.fine(() -> "Wrote Web page: " + yamlFile.getName());
     }
     
     /**
@@ -128,7 +133,7 @@ public class YamlORWriter {
         File yamlFile = new File(pagesDir, sanitizeFileName(page.getName()) + ".yaml");
         
         yamlMapper.writeValue(yamlFile, pageDef);
-        LOGGER.fine("Wrote Mobile page: " + yamlFile.getName());
+        LOGGER.fine(() -> "Wrote Mobile page: " + yamlFile.getName());
     }
     
     /**
@@ -146,13 +151,13 @@ public class YamlORWriter {
      * Delete a Web page YAML file.
      */
     public boolean deleteWebPage(String pageName, File orLocation) {
-        File webPagesDir = new File(orLocation, "Web/pages");
+        File webPagesDir = new File(orLocation, "Web");
         File yamlFile = new File(webPagesDir, sanitizeFileName(pageName) + ".yaml");
         
         if (yamlFile.exists()) {
             boolean deleted = yamlFile.delete();
             if (deleted) {
-                LOGGER.info("Deleted Web page YAML: " + pageName);
+                LOGGER.info(() -> "Deleted Web page YAML: " + pageName);
             }
             return deleted;
         }
@@ -163,13 +168,13 @@ public class YamlORWriter {
      * Delete a Mobile page YAML file.
      */
     public boolean deleteMobilePage(String pageName, File orLocation) {
-        File mobilePagesDir = new File(orLocation, "Mobile/pages");
+        File mobilePagesDir = new File(orLocation, "Mobile");
         File yamlFile = new File(mobilePagesDir, sanitizeFileName(pageName) + ".yaml");
         
         if (yamlFile.exists()) {
             boolean deleted = yamlFile.delete();
             if (deleted) {
-                LOGGER.info("Deleted Mobile page YAML: " + pageName);
+                LOGGER.info(() -> "Deleted Mobile page YAML: " + pageName);
             }
             return deleted;
         }
@@ -202,14 +207,14 @@ public class YamlORWriter {
      * @return true if rename was successful
      */
     public boolean renameWebPage(String oldName, String newName, File orLocation) {
-        File webPagesDir = new File(orLocation, "Web/pages");
+        File webPagesDir = new File(orLocation, "Web");
         File oldFile = new File(webPagesDir, sanitizeFileName(oldName) + ".yaml");
         File newFile = new File(webPagesDir, sanitizeFileName(newName) + ".yaml");
         
         if (oldFile.exists() && !newFile.exists()) {
             boolean renamed = oldFile.renameTo(newFile);
             if (renamed) {
-                LOGGER.info("Renamed Web page YAML: " + oldName + " -> " + newName);
+                LOGGER.info(() -> "Renamed Web page YAML: " + oldName + " -> " + newName);
             }
             return renamed;
         }
@@ -225,14 +230,14 @@ public class YamlORWriter {
      * @return true if rename was successful
      */
     public boolean renameMobilePage(String oldName, String newName, File orLocation) {
-        File mobilePagesDir = new File(orLocation, "Mobile/pages");
+        File mobilePagesDir = new File(orLocation, "Mobile");
         File oldFile = new File(mobilePagesDir, sanitizeFileName(oldName) + ".yaml");
         File newFile = new File(mobilePagesDir, sanitizeFileName(newName) + ".yaml");
         
         if (oldFile.exists() && !newFile.exists()) {
             boolean renamed = oldFile.renameTo(newFile);
             if (renamed) {
-                LOGGER.info("Renamed Mobile page YAML: " + oldName + " -> " + newName);
+                LOGGER.info(() -> "Renamed Mobile page YAML: " + oldName + " -> " + newName);
             }
             return renamed;
         }
@@ -274,12 +279,14 @@ public class YamlORWriter {
         
         if (webOR != null && !webOR.getPages().isEmpty()) {
             writeWebOR(webOR, orLocation);
-            LOGGER.info("Converted " + webOR.getPages().size() + " Web pages to YAML");
+            writeSharedMetadata(webOR, orLocation);
+            LOGGER.info(() -> "Converted " + webOR.getPages().size() + " Web pages to YAML");
         }
         
         if (mobileOR != null && !mobileOR.getPages().isEmpty()) {
             writeMobileOR(mobileOR, orLocation);
-            LOGGER.info("Converted " + mobileOR.getPages().size() + " Mobile pages to YAML");
+            writeSharedMetadata(mobileOR, orLocation);
+            LOGGER.info(() -> "Converted " + mobileOR.getPages().size() + " Mobile pages to YAML");
         }
     }
     
@@ -312,5 +319,72 @@ public class YamlORWriter {
      */
     public ObjectMapper getYamlMapper() {
         return yamlMapper;
+    }
+
+    private void writeSharedMetadataInternal(String orType, List<String> newProjects, String fileName, File sharedRoot) throws IOException {
+        if (newProjects == null || newProjects.isEmpty()) {
+            return;
+        }
+        File metadataFile = new File(sharedRoot, fileName);
+
+        Set<String> mergedProjects = new LinkedHashSet<>();
+        mergedProjects.addAll(readExistingProjects(metadataFile));
+        mergedProjects.addAll(newProjects);
+
+        Map<String, Object> metadata = new LinkedHashMap<>();
+        metadata.put("type", orType);
+        metadata.put("scope", "SHARED");
+        metadata.put("projects", new ArrayList<>(mergedProjects));
+
+        yamlMapper.writeValue(metadataFile, metadata);
+    }
+
+    public boolean sharedMetadataExists(String fileName, File sharedRoot) {
+        return new File(sharedRoot, fileName).exists();
+    }
+    
+    @SuppressWarnings("unchecked")
+    public List<String> readExistingProjects(File metadataFile) {
+        if (metadataFile == null || !metadataFile.exists()) {
+            return List.of();
+        }
+        try {
+            Map<String, Object> data = yamlMapper.readValue(metadataFile, Map.class);
+            Object projectsObj = data.get("projects");
+            if (projectsObj instanceof List<?>) {
+                List<String> result = new ArrayList<>();
+                for (Object o : (List<?>) projectsObj) {
+                    if (o != null) {
+                        result.add(o.toString().trim());
+                    }
+                }
+                return result;
+            }
+        } catch (Exception e) {
+        }
+        return List.of();
+    }
+    public void writeSharedMetadata(WebOR webSharedOR, File sharedRoot) throws IOException {
+        if (webSharedOR == null || !webSharedOR.isShared()) {
+            return;
+        }
+        writeSharedMetadataInternal(
+            "WebOR",
+            webSharedOR.getSharedProjects(),
+            "webor-projectsdata.yaml",
+            sharedRoot
+        );
+    }
+
+    public void writeSharedMetadata(MobileOR mobileSharedOR, File sharedRoot) throws IOException {
+        if (mobileSharedOR == null || !mobileSharedOR.isShared()) {
+            return;
+        }
+        writeSharedMetadataInternal(
+            "MobileOR",
+            mobileSharedOR.getSharedProjects(),
+            "mobileor-projectsdata.yaml",
+            sharedRoot
+        );
     }
 }

--- a/Datalib/src/main/java/com/ing/datalib/or/yaml/YamlPageDefinition.java
+++ b/Datalib/src/main/java/com/ing/datalib/or/yaml/YamlPageDefinition.java
@@ -30,7 +30,7 @@ import java.util.Map;
  * </pre>
  */
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-@JsonPropertyOrder({"page", "description", "urlPattern", "tags", "elements"})
+@JsonPropertyOrder({"page", "scope", "description", "urlPattern", "tags", "elements"})
 public class YamlPageDefinition {
     
     private String page;
@@ -38,6 +38,7 @@ public class YamlPageDefinition {
     private String urlPattern;
     private List<String> tags;
     private Map<String, YamlElementDefinition> elements = new LinkedHashMap<>();
+    private WebOR.ORScope scope;
     
     public YamlPageDefinition() {
     }
@@ -54,6 +55,14 @@ public class YamlPageDefinition {
 
     public void setPage(String page) {
         this.page = page;
+    }
+
+    public WebOR.ORScope getScope() {
+        return scope;
+    }
+
+    public void setScope(WebOR.ORScope scope) {
+        this.scope = scope;
     }
 
     public String getDescription() {
@@ -97,6 +106,10 @@ public class YamlPageDefinition {
         YamlPageDefinition yaml = new YamlPageDefinition();
         yaml.setPage(page.getName());
         
+        if (page.getRoot() != null) {
+            yaml.setScope(page.getRoot().getScope());
+        }
+        
         // Iterate through object groups and objects using Lists
         for (ObjectGroup<WebORObject> group : page.getObjectGroups()) {
             for (WebORObject obj : group.getObjects()) {
@@ -114,6 +127,10 @@ public class YamlPageDefinition {
      */
     public WebORPage toWebORPage(WebOR root) {
         WebORPage page = new WebORPage(this.page, root);
+        
+        if (this.scope != null && root != null && this.scope != root.getScope()) { 
+            throw new IllegalStateException("Scope mismatch: YAML page '" + page + "' declares scope " + scope + " but is loaded under OR scope " + root.getScope());
+        }
         
         // Convert each element to WebORObject using direct list manipulation
         // to avoid calling factory methods that require ObjectRepository

--- a/Datalib/src/test/java/com/ing/datalib/or/yaml/YamlORTest.java
+++ b/Datalib/src/test/java/com/ing/datalib/or/yaml/YamlORTest.java
@@ -203,7 +203,7 @@ public class YamlORTest {
         writer.writeWebOR(webOR, tempDir.toFile());
         
         // Verify file exists
-        File yamlFile = new File(tempDir.toFile(), "Web/pages/HomePage.yaml");
+        File yamlFile = new File(tempDir.toFile(), "Web/HomePage.yaml");
         assertThat(yamlFile).exists();
         
         // Read back
@@ -233,7 +233,7 @@ public class YamlORTest {
         writer.writeMobileOR(mobileOR, tempDir.toFile());
         
         // Verify file exists
-        File yamlFile = new File(tempDir.toFile(), "Mobile/pages/LoginScreen.yaml");
+        File yamlFile = new File(tempDir.toFile(), "Mobile/LoginScreen.yaml");
         assertThat(yamlFile).exists();
         
         // Read back

--- a/Engine/src/main/java/com/ing/engine/core/CommandControl.java
+++ b/Engine/src/main/java/com/ing/engine/core/CommandControl.java
@@ -115,7 +115,11 @@ public abstract class CommandControl {
                 if (!curr.Action.startsWith("img")) {
                     if (canIFindElement()) {
 
+                        // SObject is only initialized for Playwright/Web (when webDriver == null)
+                        if (SObject != null) {
                             structuredData = SObject.findElement(ObjectName, Reference);
+                        }
+                        
                         if (structuredData!= null) {
                             StructuredDataObject.Action = this.Action;
                             

--- a/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/or/ObjectPopupMenu.java
+++ b/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/or/ObjectPopupMenu.java
@@ -4,17 +4,15 @@ package com.ing.ide.main.mainui.components.testdesign.or;
 import com.ing.datalib.or.common.ORObjectInf;
 import com.ing.datalib.or.common.ORPageInf;
 import com.ing.datalib.or.common.ORRootInf;
-import com.ing.datalib.or.common.ObjectGroup;
-import com.ing.ide.main.utils.dnd.TransferActionListener;
+import com.ing.ide.main.mainui.components.testdesign.or.clipboard.ORClipboardManager;
+import com.ing.ide.main.mainui.components.testdesign.or.clipboard.ORObjectClipboard;
 import com.ing.ide.main.utils.keys.Keystroke;
 import com.ing.ide.util.Canvas;
 import java.awt.event.ActionListener;
 import java.awt.event.KeyEvent;
-import javax.swing.Action;
 import javax.swing.JMenuItem;
 import javax.swing.JPopupMenu;
 import javax.swing.KeyStroke;
-import javax.swing.TransferHandler;
 
 /**
  * Context (right-click) popup menu for Object Repository (OR) tree nodes in the Test Design UI.
@@ -42,7 +40,7 @@ public class ObjectPopupMenu extends JPopupMenu {
     private JMenuItem renameObject;
     private JMenuItem deleteObject;
     private JMenuItem removeUnusedObject;
-    private JMenuItem copyToShared;
+    private JMenuItem moveToShared;
 
     private JMenuItem openPageDump;
 
@@ -54,6 +52,8 @@ public class ObjectPopupMenu extends JPopupMenu {
     private JMenuItem sort;
 
     private final ActionListener listener;
+    
+    private Object currentSelection;
 
     public ObjectPopupMenu(ActionListener listener) {
         this.listener = listener;
@@ -65,63 +65,66 @@ public class ObjectPopupMenu extends JPopupMenu {
         add(renamePage = create("Rename Page", Keystroke.RENAME));
         add(deletePage = create("Delete Page", Keystroke.DELETE));
         addSeparator();
+        
         add(renameObjectGroup = create("Rename Object Group", Keystroke.RENAME));
         add(deleteObjectGroup = create("Delete Object Group", Keystroke.DELETE));
         addSeparator();
+        
         add(addObject = create("Add Object", Keystroke.NEW));
         add(renameObject = create("Rename Object", Keystroke.RENAME));
         add(deleteObject = create("Delete Object", Keystroke.DELETE));
         add(removeUnusedObject = create("Remove Unused Object",Keystroke.REMOVE_OBJECT));
         addSeparator();
-        copyToShared = create("Copy to Shared", null);
-        add(copyToShared);
-
-
+        
+        moveToShared = create("Move to Shared", null);
+        moveToShared.setActionCommand("Move to Shared");
+        moveToShared.addActionListener(listener);
+        add(moveToShared);
         add(openPageDump = create("Open Page Dump", null));
         add(impactAnalysis = create("Get Impacted TestCases", null));
-
         addSeparator();
 
         setCCP();
         addSeparator();
+        
         add(sort = create("Sort", null));
         sort.setIcon(Canvas.EmptyIcon);
     }
 
     public void togglePopupMenu(Object selected) {
-        copyToShared.setEnabled(false);
+        this.currentSelection = selected;
+        copy.setEnabled(false);
+        cut.setEnabled(false);
+        paste.setEnabled((currentSelection instanceof ORPageInf || currentSelection instanceof ORObjectInf)&& ORClipboardManager.hasData());
 
         if (selected instanceof ORRootInf) {
             forRoot();
             return;
         } else if (selected instanceof ORPageInf) {
             forPage();
-        } else if (selected instanceof ObjectGroup) {
-            forObjectGroup();
         } else if (selected instanceof ORObjectInf) {
             forObject();
         }
-        copyToShared.setEnabled(!isSharedSelection(selected));
-        removeUnusedObject.setEnabled(!isSharedSelection(selected));
+        moveToShared.setEnabled(!isSharedSelection(currentSelection));
     }
 
     private void forPage() {
+        addPage.setEnabled(false);
         renamePage.setEnabled(true);
         deletePage.setEnabled(true);
 
-        addPage.setEnabled(false);
         renameObjectGroup.setEnabled(false);
         deleteObjectGroup.setEnabled(false);
 
         addObject.setEnabled(true);
         renameObject.setEnabled(false);
         deleteObject.setEnabled(false);
-        removeUnusedObject.setEnabled(true);
+        removeUnusedObject.setEnabled(!isSharedSelection(currentSelection));
         
         impactAnalysis.setEnabled(false);
 
         copy.setEnabled(true);
-        cut.setEnabled(true);
+        cut.setEnabled(isSameOR(currentSelection));
         paste.setEnabled(true);
 
         sort.setEnabled(true);
@@ -138,14 +141,15 @@ public class ObjectPopupMenu extends JPopupMenu {
         addObject.setEnabled(true);
         renameObject.setEnabled(false);
         deleteObject.setEnabled(false);
+        removeUnusedObject.setEnabled(false);
 
         impactAnalysis.setEnabled(true);
 
         copy.setEnabled(true);
-        cut.setEnabled(true);
+        cut.setEnabled(isSameOR(currentSelection));
         paste.setEnabled(true);
 
-        sort.setEnabled(false);
+        sort.setEnabled(true);
     }
 
     private void forObject() {
@@ -156,23 +160,24 @@ public class ObjectPopupMenu extends JPopupMenu {
         renameObjectGroup.setEnabled(false);
         deleteObjectGroup.setEnabled(false);
 
-        addObject.setEnabled(true);
+        addObject.setEnabled(false);
         renameObject.setEnabled(true);
         deleteObject.setEnabled(true);
+        removeUnusedObject.setEnabled(false);
 
         impactAnalysis.setEnabled(true);
 
         copy.setEnabled(true);
-        cut.setEnabled(true);
+        cut.setEnabled(isSameOR(currentSelection));
         paste.setEnabled(true);
 
         sort.setEnabled(false);
     }
 
     private void forRoot() {
+        boolean hasClipboard = ORClipboardManager.hasData();
+        
         addPage.setEnabled(true);
-        removeUnusedObject.setEnabled(false);
-
         renamePage.setEnabled(false);
         deletePage.setEnabled(false);
 
@@ -182,13 +187,12 @@ public class ObjectPopupMenu extends JPopupMenu {
         addObject.setEnabled(false);
         renameObject.setEnabled(false);
         deleteObject.setEnabled(false);
+        removeUnusedObject.setEnabled(false);
 
         impactAnalysis.setEnabled(false);
 
-        copy.setEnabled(false);
-        cut.setEnabled(false);
-        paste.setEnabled(false);
-
+        cut.setEnabled(isSameOR(currentSelection));
+        paste.setEnabled( hasClipboard && ORClipboardManager.get().getType() == ORObjectClipboard.Type.PAGE);
         sort.setEnabled(true);
     }
 
@@ -201,26 +205,25 @@ public class ObjectPopupMenu extends JPopupMenu {
     }
 
     private void setCCP() {
-        TransferActionListener actionListener = new TransferActionListener();
         cut = new JMenuItem("Cut");
-        cut.setActionCommand((String) TransferHandler.getCutAction().getValue(Action.NAME));
-        cut.addActionListener(actionListener);
+        cut.setActionCommand("Cut");           // for Pages 
         cut.setAccelerator(Keystroke.CUT);
         cut.setMnemonic(KeyEvent.VK_T);
+        cut.addActionListener(listener);
         add(cut);
 
         copy = new JMenuItem("Copy");
-        copy.setActionCommand((String) TransferHandler.getCopyAction().getValue(Action.NAME));
-        copy.addActionListener(actionListener);
+        copy.setActionCommand("Copy");         // for Pages
         copy.setAccelerator(Keystroke.COPY);
         copy.setMnemonic(KeyEvent.VK_C);
+        copy.addActionListener(listener);
         add(copy);
 
         paste = new JMenuItem("Paste");
-        paste.setActionCommand((String) TransferHandler.getPasteAction().getValue(Action.NAME));
-        paste.addActionListener(actionListener);
+        paste.setActionCommand("Paste");       // for Pages
         paste.setAccelerator(Keystroke.PASTE);
         paste.setMnemonic(KeyEvent.VK_P);
+        paste.addActionListener(listener);
         add(paste);
     }
 
@@ -230,9 +233,8 @@ public class ObjectPopupMenu extends JPopupMenu {
             page = (ORPageInf) selected;
         } else if (selected instanceof ORObjectInf) {
             page = ((ORObjectInf) selected).getPage();
-        } else if (selected instanceof ObjectGroup) {
-            page = ((ObjectGroup) selected).getParent();
         }
+        
         if (page != null && page.getRoot() instanceof com.ing.datalib.or.web.WebOR) {
             com.ing.datalib.or.web.WebOR root = (com.ing.datalib.or.web.WebOR) page.getRoot();
             return root.isShared();
@@ -242,5 +244,28 @@ public class ObjectPopupMenu extends JPopupMenu {
             return root.isShared();
         }
         return false;
+    }
+    
+    private boolean isSameOR(Object selected) {
+        if (selected instanceof ORPageInf) {
+            return ((ORPageInf) selected).getParent() == getCurrentRoot();
+        }
+        if (selected instanceof ORObjectInf) {
+            return ((ORObjectInf) selected).getPage().getParent() == getCurrentRoot();
+        }
+        return false;
+    }
+
+    private ORRootInf getCurrentRoot() {
+        if (currentSelection instanceof ORRootInf) {
+            return (ORRootInf) currentSelection;
+        }
+        if (currentSelection instanceof ORPageInf) {
+            return (ORRootInf) ((ORPageInf) currentSelection).getParent();
+        }
+        if (currentSelection instanceof ORObjectInf) {
+            return (ORRootInf) ((ORObjectInf) currentSelection).getPage().getParent();
+        }
+        return null;
     }
 }

--- a/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/or/ObjectRepDnD.java
+++ b/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/or/ObjectRepDnD.java
@@ -4,6 +4,8 @@ package com.ing.ide.main.mainui.components.testdesign.or;
 import com.ing.datalib.or.common.ORObjectInf;
 import com.ing.datalib.or.common.ORPageInf;
 import com.ing.datalib.or.common.ObjectGroup;
+import com.ing.datalib.or.mobile.MobileOR;
+import com.ing.datalib.or.web.WebOR;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -102,11 +104,18 @@ public class ObjectRepDnD {
     }
     
     private String scopeOf(ORPageInf page) {
-        try {
-            var m = page.getClass().getMethod("getSource");
-            Object src = m.invoke(page);
-            if (src != null && src.toString().equalsIgnoreCase("SHARED")) return "SHARED";
-        } catch (Exception ignore) { }
+        if (page == null) {
+            return "PROJECT";
+        }
+        Object parent = page.getParent();
+        if (parent instanceof WebOR) {
+            WebOR root = (WebOR) parent;
+            return root.getScope().name();
+        }
+        if (parent instanceof MobileOR) {
+            MobileOR root = (MobileOR) parent;
+            return root.getScope().name();
+        }
         return "PROJECT";
     }
 

--- a/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/or/ObjectTree.java
+++ b/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/or/ObjectTree.java
@@ -2,14 +2,22 @@
 package com.ing.ide.main.mainui.components.testdesign.or;
 
 import com.ing.datalib.component.Project;
+import com.ing.datalib.component.Scenario;
 import com.ing.datalib.component.TestCase;
+import com.ing.datalib.component.TestStep;
 import com.ing.datalib.or.ObjectRepository;
 import com.ing.datalib.or.common.ORObjectInf;
 import com.ing.datalib.or.common.ORPageInf;
 import com.ing.datalib.or.common.ORRootInf;
 import com.ing.datalib.or.common.ObjectGroup;
+import com.ing.datalib.or.mobile.MobileOR;
+import com.ing.datalib.or.mobile.MobileORObject;
+import com.ing.datalib.or.mobile.MobileORPage;
+import com.ing.datalib.or.mobile.ResolvedMobileObject;
 import com.ing.datalib.or.web.ResolvedWebObject;
 import com.ing.datalib.or.web.WebOR;
+import com.ing.datalib.or.web.WebORObject;
+import com.ing.datalib.or.web.WebORPage;
 import com.ing.ide.main.help.Help;
 
 import com.ing.ide.main.utils.keys.Keystroke;
@@ -31,6 +39,11 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import com.ing.ide.main.mainui.AppMainFrame;
+import com.ing.ide.main.mainui.components.testdesign.or.clipboard.ORClipboardManager;
+import com.ing.ide.main.mainui.components.testdesign.or.clipboard.ORObjectClipboard;
+import com.ing.ide.main.mainui.components.testdesign.or.mobile.MobileORPanel;
+import com.ing.ide.main.mainui.components.testdesign.or.mobile.MobileObjectTree;
+import com.ing.ide.main.mainui.components.testdesign.or.web.WebORPanel;
 import com.ing.ide.main.mainui.components.testdesign.or.web.WebObjectTree;
 import java.awt.Toolkit;
 import java.awt.event.KeyEvent;
@@ -52,7 +65,6 @@ import javax.swing.tree.DefaultTreeModel;
 import javax.swing.tree.TreeNode;
 import javax.swing.tree.TreePath;
 import java.io.File;
-import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerFactory;
@@ -62,12 +74,13 @@ import javax.xml.xpath.XPathConstants;
 import javax.xml.xpath.XPathExpression;
 import javax.xml.xpath.XPathFactory;
 import org.w3c.dom.Document;
-import org.w3c.dom.Element;
 import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Enumeration;
+import java.util.HashSet;
+import java.util.Iterator;
 
 /**
  * Base abstract class representing a fully interactive Object Repository (OR) tree.
@@ -300,8 +313,17 @@ public abstract class ObjectTree implements ActionListener {
             case "Open Page Dump":
                 openPageDump();
                 break;
-            case "Copy to Shared":
-                copyToShared();
+            case "Move to Shared":
+                moveToShared();
+                break;
+            case "Copy":
+                copySelection();
+                break;
+            case "Cut":
+                cutSelection();
+                break;
+            case "Paste":
+                pasteSelection();
                 break;
             default:
                 throw new UnsupportedOperationException();
@@ -471,116 +493,155 @@ public abstract class ObjectTree implements ActionListener {
             }
         }
     }
-    
+
     private void removeUnusedObject() {
+        boolean webDeletionPerformed = false;
+        boolean mobileDeletionPerformed = false;
         try {
-            Map<String, List> allORObject = new HashMap<String, List>();
-            Map<String, List> unUsedbject = new HashMap<String, List>();
-            List<String> objects = new ArrayList<>();
-            List<ORPageInf> pages = getSelectedPages();
-            if (!pages.isEmpty()) {
-                for (ORPageInf selectedPage : pages) {
-                    String page = selectedPage.toString();
-                    String orFilePath = getProject().getLocation() + "/OR.object";
-                    DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
-                    DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();
-                    Document doc = documentBuilder.parse(orFilePath);
-                    NodeList pageList = doc.getElementsByTagName("Page");
-                    for (int i = 0; i < pageList.getLength(); i++) {
-
-                        Node pageNode = pageList.item(i);
-                        if (pageNode.getNodeType() == Node.ELEMENT_NODE) {
-                            Element pageElement = (Element) pageNode;
-                            String pageName = pageElement.getAttribute("ref");
-                            if (pageName.equals(page)) {
-                                NodeList objectGroupNodeList = pageElement.getChildNodes();
-                                for (int j = 0; j < objectGroupNodeList.getLength(); j++) {
-
-                                    Node objectGroupNode = objectGroupNodeList.item(j);
-                                    if (objectGroupNode.getNodeType() == Node.ELEMENT_NODE) {
-                                        if (pageNode.getNodeType() == Node.ELEMENT_NODE) {
-                                            Element objectGroupElement = (Element) objectGroupNode;
-                                            NodeList objectList = objectGroupElement.getChildNodes();
-
-                                            for (int k = 0; k < objectList.getLength(); k++) {
-                                                Node objectNode = objectList.item(k);
-                                                if (objectNode.getNodeType() == Node.ELEMENT_NODE) {
-
-                                                    Element objectElement = (Element) objectNode;
-                                                    String objectName = objectElement.getAttribute("ref");
-                                                    if (!allORObject.containsKey(page)) {
-                                                        allORObject.put(page, new ArrayList<String>());
-                                                        allORObject.get(page).add(objectName);
-                                                    } else {
-                                                        allORObject.get(page).add(objectName);
-                                                    }
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
+            List<ORPageInf> selectedPages = getSelectedPages();
+            if (selectedPages == null || selectedPages.isEmpty()) {
+                return;
+            }
+            ObjectRepository repo = getProject().getObjectRepository();
+            WebOR projectWebOR = repo.getWebOR();
+            MobileOR projectMobileOR = repo.getMobileOR();
+            Set<String> usedProjectObjects = new HashSet<>();
+            for (Scenario scenario : getProject().getAllScenarios()) {
+                for (TestCase testCase : scenario.getTestCases()) {
+                    testCase.loadTableModel();
+                    for (TestStep step : testCase.getTestSteps()) {
+                        if (!step.isPageObjectStep()) {
+                            continue;
+                        }
+                        String ref = step.getReference();
+                        if (ref == null || ref.isBlank()) {
+                            continue;
+                        }
+                        String pageName = normalizePageRef(ref);
+                        String objectName = step.getObject();
+                        if (!pageName.isBlank() && !objectName.isBlank()) {
+                            usedProjectObjects.add(pageName + "@" + objectName);
+                        }
+                    }
+                }
+            }
+            for (ORPageInf selectedPage : selectedPages) {
+                String pageName = selectedPage.getName();
+                WebORPage webPage = projectWebOR.getPageByName(pageName);
+                if (webPage == null) {
+                    continue;
+                }
+                List<String> unusedWebObjects = new ArrayList<>();
+                for (ObjectGroup group : webPage.getObjectGroups()) {
+                    if (!usedProjectObjects.contains(pageName + "@" + group.getName())) {
+                        unusedWebObjects.add(group.getName());
+                    }
+                }
+                if (!unusedWebObjects.isEmpty()) {
+                    int option = JOptionPane.showConfirmDialog(
+                        null,
+                        "<html><body><p style='width: 260px;'>"
+                        + "Delete the following Web objects from page [ "
+                        + pageName + " ]?<br>"
+                        + unusedWebObjects
+                        + "</p></body></html>",
+                        "Delete Web Objects",
+                        JOptionPane.YES_NO_OPTION
+                    );
+                    if (option == JOptionPane.YES_OPTION) {
+                        Iterator<ObjectGroup<WebORObject>> it = webPage.getObjectGroups().iterator();
+                        while (it.hasNext()) {
+                            ObjectGroup group = it.next();
+                            if (unusedWebObjects.contains(group.getName())) {
+                                it.remove();
+                                projectWebOR.setSaved(false);
+                                webDeletionPerformed = true;
                             }
                         }
-                    }
-                }
-            }
-            unUsedbject = UnusedObject(allORObject, usedObject());
-            int unusedObjectCount = 0;
-            for (String page : unUsedbject.keySet()) {
-
-                List<String> unUsedobjects = unUsedbject.get(page);
-                if (!unUsedobjects.isEmpty()) {
-                    unusedObjectCount = unusedObjectCount + 1;
-                    int option = JOptionPane.showConfirmDialog(null,
-                            "<html><body><p style='width: 200px;'>"
-                            + "Are you sure want to delete the following Objects from page [ "
-                            + page
-                            + " ]"
-                            + " ?<br>"
-                            + unUsedobjects
-                            + "</p></body></html>",
-                            "Delete Objects",
-                            JOptionPane.YES_NO_OPTION);
-                    if (option == JOptionPane.YES_OPTION) {
-                        for (String objectName : unUsedobjects) {
-                            deleteUnusedObject(page, objectName);
-
+                        if (webDeletionPerformed) {
+                            repo.saveWebPageNow(webPage);
                         }
-
                     }
                 }
-
             }
-            if (unusedObjectCount != 0) {
-                int option = JOptionPane.showConfirmDialog(null,
-                        "<html><body><p style='width: 200px;'>"
-                        + "Do you want to restart INGenious to load updated Object Repository ?"
-                        + " <br>"
+            for (ORPageInf selectedPage : selectedPages) {
+                String pageName = selectedPage.getName();
+                MobileORPage mobilePage = projectMobileOR.getPageByName(pageName);
+                if (mobilePage == null) {
+                    continue;
+                }
+                List<String> unusedMobileObjects = new ArrayList<>();
+                for (ObjectGroup group : mobilePage.getObjectGroups()) {
+                    if (!usedProjectObjects.contains(pageName + "@" + group.getName())) {
+                        unusedMobileObjects.add(group.getName());
+                    }
+                }
+                if (!unusedMobileObjects.isEmpty()) {
+                    int option = JOptionPane.showConfirmDialog(
+                        null,
+                        "<html><body><p style='width: 260px;'>"
+                        + "Delete the following Mobile objects from page [ "
+                        + pageName + " ]?<br>"
+                        + unusedMobileObjects
                         + "</p></body></html>",
-                        "Restart INGenious",
-                        JOptionPane.YES_NO_OPTION);
+                        "Delete Mobile Objects",
+                        JOptionPane.YES_NO_OPTION
+                    );
+                    if (option == JOptionPane.YES_OPTION) {
+                        Iterator<ObjectGroup<MobileORObject>> it = mobilePage.getObjectGroups().iterator();
+                        while (it.hasNext()) {
+                            ObjectGroup group = it.next();
+                            if (unusedMobileObjects.contains(group.getName())) {
+                                it.remove();
+                                projectMobileOR.setSaved(false);
+                                mobileDeletionPerformed = true;
+                            }
+                        }
+                        if (mobileDeletionPerformed) {
+                            repo.saveMobilePageNow(mobilePage);
+                        }
+                    }
+                }
+            }
+            if (webDeletionPerformed || mobileDeletionPerformed) {
+                repo.save();
+                int option = JOptionPane.showConfirmDialog(
+                    null,
+                    "<html><body><p style='width: 260px;'>"
+                    + "Do you want to restart INGenious to load the updated Object Repository?"
+                    + "</p></body></html>",
+                    "Restart INGenious",
+                    JOptionPane.YES_NO_OPTION
+                );
                 if (option == JOptionPane.YES_OPTION) {
-                    AppMainFrame s = new AppMainFrame();
-                    s.restart();
+                    new AppMainFrame().restart();
                 }
             } else {
-                 
-                 JOptionPane.showMessageDialog(null,
-                        "<html><body><p style='width: 200px;'>"
-                        + "No unused object found"
-                        + " <br>"
-                        + "</p></body></html>",
-                        "Unused Object",
-                        JOptionPane.OK_OPTION);
+                JOptionPane.showMessageDialog(
+                    null,
+                    "<html><body><p style='width: 240px;'>"
+                    + "No unused object found or removal was cancelled."
+                    + "</p></body></html>",
+                    "Unused Object",
+                    JOptionPane.INFORMATION_MESSAGE
+                );
             }
-
+            ((DefaultTreeModel) tree.getModel()).reload();
+            tree.updateUI();
         } catch (Exception e) {
             e.printStackTrace();
         }
+    }
 
+    private String normalizePageRef(String ref) {
+        if (ref == null) return "";
+        ref = ref.trim();
+        if (ref.startsWith("[Project] ")) return ref.substring(10).trim();
+        if (ref.startsWith("[Shared] "))  return ref.substring(9).trim();
+        return ref;
     }
     
-        public Map usedObject() {   
+    public Map usedObject() {   
         Map<String, ArrayList<String>> attributeMap = new HashMap<>();
         ArrayList<String> records = new ArrayList<>();
         try {
@@ -821,121 +882,108 @@ public abstract class ObjectTree implements ActionListener {
         }
     }
 
-    private void copyToShared() {
-        ORObjectInf obj = getSelectedObject();
-        ObjectGroup group = getSelectedObjectGroup();
-        ORPageInf selectedPage = getSelectedPage();
-
-        if (obj == null && group == null && selectedPage == null) {
-            com.ing.ide.util.Notification.show("Select an Object, Object Group, or Page.");
+    private void moveToShared() {
+        if (isSharedScope()) {
+            Notification.show("Objects already in Shared Repository");
             return;
         }
-
-        ORPageInf page = (obj != null) ? obj.getPage()
-                : (group != null) ? group.getParent()
-                : selectedPage;
-
-        ObjectRepository repo = getProject().getObjectRepository();
-
-        ORRootInf root = getOR();
-        boolean isWeb = (root instanceof com.ing.datalib.or.web.WebOR);
-        boolean isMobile = (root instanceof com.ing.datalib.or.mobile.MobileOR);
-
-        if (obj == null && group == null && selectedPage != null) {
-            if (isWeb) {
-                String newName = repo.copyWebPage(page.getName(), page.getName());
-                if (newName != null) {
-                    com.ing.ide.util.Notification.show("Copied Page '" + page.getName() + "' to Shared Web Object successfully as '" + newName + "'.");
-                } else {
-                    com.ing.ide.util.Notification.show("Copy failed. Could not copy Page '" + page.getName() + "' to Shared Web Objects.");
-                }
-                if (newName != null) {
-                    if (this instanceof com.ing.ide.main.mainui.components.testdesign.or.web.WebObjectTree) {
-                        com.ing.ide.main.mainui.components.testdesign.or.web.WebORPanel panel =
-                            ((com.ing.ide.main.mainui.components.testdesign.or.web.WebObjectTree) this).getORPanel();
-                        panel.getSharedTree().load();
-                    } else {
-                        reload();
-                    }
-                }
-                return;
-            } else if (isMobile) {
-                String newName = repo.copyMobilePage(page.getName(), page.getName());
-                if (newName != null) {
-                    com.ing.ide.util.Notification.show("Copied Page '" + page.getName() + "' to Shared Mobile Object successfully as '" + newName + "'.");
-                } else {
-                    com.ing.ide.util.Notification.show("Copy failed. Could not copy Page '" + page.getName() + "' to Shared Mobile Objects.");
-                }
-                if (newName != null) {
-                    if (this instanceof com.ing.ide.main.mainui.components.testdesign.or.mobile.MobileObjectTree) {
-                        com.ing.ide.main.mainui.components.testdesign.or.mobile.MobileORPanel panel =
-                            ((com.ing.ide.main.mainui.components.testdesign.or.mobile.MobileObjectTree) this).getORPanel();
-                        panel.getSharedTree().load();
-                    } else {
-                        reload();
-                    }
-                }
-                return;
-            }
+        if (getSelectedObject() != null) {
+            moveObjectToShared(getSelectedObject());
+            return;
         }
+        if (getSelectedPage() != null) {
+            movePageToShared(getSelectedPage());
+        }
+    }
 
-        String objectName = (obj != null) ? obj.getName() : group.getName();
-
+    private void moveObjectToShared(ORObjectInf obj) {
+        ObjectRepository repo = getProject().getObjectRepository();
+        ORPageInf page = obj.getPage();
+        ORRootInf root = getOR();
+        boolean isWeb = root instanceof WebOR;
+        boolean isMobile = root instanceof MobileOR;
+        String objectName = obj.getName().toString();
         if (isWeb) {
             ResolvedWebObject resolved =
                 repo.resolveWebObject(
-                    new ResolvedWebObject.PageRef(page.getName(), com.ing.datalib.or.web.WebOR.ORScope.PROJECT),
-                    objectName
-                );
-            if (resolved == null) {
-                com.ing.ide.util.Notification.show("Object '" + objectName + "' not found in Project OR (Page '" + page.getName() + "').");
-                return;
-            }
-
-            String copiedName = repo.copyWebObject(resolved, page.getName());
-            if (copiedName != null) {
-                com.ing.ide.util.Notification.show("Copied Object '" + copiedName + "' from Page '" + page.getName() + "' to Shared Web Object successfully.");
-            } else {
-                com.ing.ide.util.Notification.show("Copy failed. Could not copy Object '" + objectName + "' to Shared Web Object (Page '" + page.getName() + "').");
-            }
-            if (copiedName != null) {
-                if (this instanceof com.ing.ide.main.mainui.components.testdesign.or.web.WebObjectTree) {
-                    com.ing.ide.main.mainui.components.testdesign.or.web.WebORPanel panel =
-                        ((com.ing.ide.main.mainui.components.testdesign.or.web.WebObjectTree) this).getORPanel();
-                    panel.getSharedTree().load();
-                } else {
-                    reload();
-                }
-            }
-        } else if (isMobile) {
-            com.ing.datalib.or.mobile.ResolvedMobileObject mresolved =
-                repo.resolveMobileObject(
-                    new com.ing.datalib.or.mobile.ResolvedMobileObject.PageRef(
+                    new ResolvedWebObject.PageRef(
                         page.getName(),
-                        com.ing.datalib.or.web.WebOR.ORScope.PROJECT
+                        WebOR.ORScope.PROJECT
                     ),
                     objectName
                 );
-            if (mresolved == null) {
-                com.ing.ide.util.Notification.show("Object '" + objectName + "' not found in Project Mobile OR (Page '" + page.getName() + "').");
+            if (resolved == null) {
+                Notification.show("Object not found in Project OR");
                 return;
             }
+            String newName = repo.moveWebObject(resolved, page.getName());
+            if (newName != null) {
+                objectRemoved(obj);
+                obj.removeFromParent();
+                repo.save();
+                refreshSharedTree();
+                Notification.show("Moved Object '" + newName + "' to Shared OR");
+            }
+        }
+        if (isMobile) {
+            ResolvedMobileObject resolved =
+                repo.resolveMobileObject(
+                    new ResolvedMobileObject.PageRef(
+                        page.getName(),
+                        WebOR.ORScope.PROJECT
+                    ),
+                    objectName
+                );
+            if (resolved == null || !resolved.isPresent()) {
+                Notification.show("Mobile Object not found in Project OR");
+                return;
+            }
+            String newName = repo.moveMobileObject(resolved, page.getName());
+            if (newName != null) {
+                objectRemoved(obj);
+                obj.removeFromParent();
+                repo.save();
+                refreshSharedTree();
+                Notification.show("Moved Mobile Object '" + newName + "' to Shared OR");
+            }
+        }
+    }
 
-            String copiedName = repo.copyMobileObject(mresolved, page.getName());
-            if (copiedName != null) {
-                com.ing.ide.util.Notification.show("Copied Object '" + copiedName + "' from Page '" + page.getName() + "' to Shared Mobile Object successfully.");
-            } else {
-                com.ing.ide.util.Notification.show("Copy failed. Could not copy Object '" + objectName + "' to Shared Mobile Object (Page '" + page.getName() + "').");
+    private void movePageToShared(ORPageInf page) {
+        ObjectRepository repo = getProject().getObjectRepository();
+        ORRootInf root = getOR();
+        boolean isWeb = root instanceof WebOR;
+        boolean isMobile = root instanceof MobileOR;
+        if (isWeb) {
+            String newPageName = repo.copyWebPage(page.getName(), page.getName());
+            if (newPageName != null) {
+                pageRemoved(page);
+                page.removeFromParent();
+                repo.save();
+                refreshSharedTree();
+                Notification.show( "Moved Page '" + page.getName() + "' to Shared OR");
             }
-            if (copiedName != null) {
-                if (this instanceof com.ing.ide.main.mainui.components.testdesign.or.mobile.MobileObjectTree) {
-                    com.ing.ide.main.mainui.components.testdesign.or.mobile.MobileORPanel panel =
-                        ((com.ing.ide.main.mainui.components.testdesign.or.mobile.MobileObjectTree) this).getORPanel();
-                    panel.getSharedTree().load();
-                } else {
-                    reload();
-                }
+        }
+        if (isMobile) {
+            String newPageName = repo.copyMobilePage(page.getName(), page.getName());
+            if (newPageName != null) {
+                pageRemoved(page);
+                page.removeFromParent();
+                repo.save();
+                refreshSharedTree();
+                Notification.show("Moved Mobile Page '" + page.getName() + "' to Shared OR");
             }
+        }
+    }
+
+    private void refreshSharedTree() {
+        if (this instanceof WebObjectTree) {
+            WebORPanel panel = ((WebObjectTree) this).getORPanel();
+            panel.getSharedTree().load();
+
+        } else if (this instanceof MobileObjectTree) {
+            MobileORPanel panel = ((MobileObjectTree) this).getORPanel();
+            panel.getSharedTree().load();
         }
     }
 
@@ -1116,5 +1164,417 @@ public abstract class ObjectTree implements ActionListener {
                     + String.join(", ", projects);
         }
         return "";
+    }
+
+    private void pasteObject() {
+        if (!ORClipboardManager.hasData()) {
+            return;
+        }
+        ORObjectClipboard cb = ORClipboardManager.get();
+        ORObjectInf source = cb.getObject();
+        boolean cut = cb.isCut();
+        ORPageInf targetPage = getSelectedPage();
+        if (targetPage == null && getSelectedObjectGroup() != null) {
+            targetPage = getSelectedObjectGroup().getParent();
+        }
+        if (targetPage == null || source == null) {
+            return;
+        }
+        ORRootInf currentOR = getOR();
+        ORRootInf sourceOR  = (ORRootInf) source.getPage().getParent();
+        ObjectGroup sourceGroup = source.getParent();
+        ObjectRepository repo = getProject().getObjectRepository();
+        if (cut && sourceOR instanceof WebOR && ((WebOR) sourceOR).isShared() && currentOR instanceof WebOR && !((WebOR) currentOR).isShared()) {
+            Notification.show("Cut is not allowed from Shared to Project Object Repository");
+            return;
+        }
+        if (cut && sourceOR instanceof MobileOR && ((MobileOR) sourceOR).isShared() && currentOR instanceof MobileOR && !((MobileOR) currentOR).isShared()) {
+            Notification.show("Cut is not allowed from Shared to Project Object Repository");
+            return;
+        }
+        if (cut && sourceOR instanceof WebOR && !((WebOR) sourceOR).isShared() && currentOR instanceof WebOR && ((WebOR) currentOR).isShared()) {
+            Notification.show("Cut is not allowed in Shared Object Repository. Use `Move to Shared` instead.");
+            return;
+        }
+        if (cut && sourceOR instanceof MobileOR && !((MobileOR) sourceOR).isShared() && currentOR instanceof MobileOR && ((MobileOR) currentOR).isShared()) {
+            Notification.show("Cut is not allowed in Shared Object Repository. Use `Move to Shared` instead.");
+            return;
+        }
+        if (sourceOR == currentOR) {
+            String newGroupName;
+            if (!cut) {
+                newGroupName = computeCopyName(
+                    targetPage,
+                    (ORObjectInf) sourceGroup.getObjects().get(0)
+                );
+            } else {
+                if (targetPage.getObjectGroupByName(sourceGroup.getName()) != null) {
+                    newGroupName = computeCopyName(
+                        targetPage,
+                        (ORObjectInf) sourceGroup.getObjects().get(0)
+                    );
+                } else {
+                    newGroupName = sourceGroup.getName();
+                }
+            }
+            ObjectGroup newGroup = new ObjectGroup(newGroupName, targetPage);
+            if (currentOR instanceof WebOR) {
+                for (Object o : sourceGroup.getObjects()) {
+                    WebORObject srcObj = (WebORObject) o;
+                    String newObjectName;
+                    if (!cut) {
+                        newObjectName = computeCopyName(targetPage, srcObj);
+                    } else {
+                        if (objectNameExists(targetPage, srcObj.getName())) {
+                            newObjectName = computeCopyName(targetPage, srcObj);
+                        } else {
+                            newObjectName = srcObj.getName();
+                        }
+                    }
+                    WebORObject cloned = new WebORObject();
+                    cloned.setName(newObjectName);
+                    cloned.setParent(newGroup);
+                    srcObj.clone(cloned);
+                    newGroup.getObjects().add(cloned);
+                }
+                targetPage.getObjectGroups().add(newGroup);
+                ((WebOR) currentOR).setSaved(false);
+                repo.saveWebPageNow((WebORPage) targetPage);
+            }
+            else if (currentOR instanceof MobileOR) {
+                for (Object o : sourceGroup.getObjects()) {
+                    MobileORObject srcObj = (MobileORObject) o;
+                    String newObjectName;
+                    if (!cut) {
+                        newObjectName = computeCopyName(targetPage, srcObj);
+                    } else {
+                        if (objectNameExists(targetPage, srcObj.getName())) {
+                            newObjectName = computeCopyName(targetPage, srcObj);
+                        } else {
+                            newObjectName = srcObj.getName();
+                        }
+                    }
+                    MobileORObject cloned = new MobileORObject();
+                    cloned.setName(newObjectName);
+                    cloned.setParent(newGroup);
+                    srcObj.clone(cloned);
+                    newGroup.getObjects().add(cloned);
+                }
+                targetPage.getObjectGroups().add(newGroup);
+                ((MobileOR) currentOR).setSaved(false);
+                repo.saveMobilePageNow((MobileORPage) targetPage);
+            }
+            if (cut) {
+                ORPageInf sourcePage = source.getPage();
+                objectRemoved(source);
+                sourceGroup.removeFromParent();
+                ORClipboardManager.clear();
+                if (sourceOR instanceof WebOR) {
+                    ((WebOR) sourceOR).setSaved(false);
+                    repo.saveWebPageNow((WebORPage) sourcePage);
+                } else if (sourceOR instanceof MobileOR) {
+                    ((MobileOR) sourceOR).setSaved(false);
+                    repo.saveMobilePageNow((MobileORPage) sourcePage);
+                }
+            }
+            reload();
+            return;
+        }
+        if (currentOR instanceof WebOR && !((WebOR) currentOR).isShared() && sourceOR instanceof WebOR && ((WebOR) sourceOR).isShared()) {
+            String baseName = sourceGroup.getName().replaceAll("_Copy_\\d+$", "");
+            String newGroupName;
+            int i = 1;
+            do {
+                newGroupName = baseName + "_Copy_" + i++;
+            } while (targetPage.getObjectGroupByName(newGroupName) != null);
+            ObjectGroup<WebORObject> newGroup = new ObjectGroup<>(newGroupName, (WebORPage) targetPage);
+            for (Object o : sourceGroup.getObjects()) {
+                WebORObject srcObj = (WebORObject) o;
+                WebORObject cloned = new WebORObject();
+                cloned.setName(newGroupName);
+                cloned.setParent(newGroup);
+                srcObj.clone(cloned);
+                newGroup.getObjects().add(cloned);
+            }
+            targetPage.getObjectGroups().add(newGroup);
+            reload();
+            return;
+        }
+        if (currentOR instanceof WebOR) {
+            ResolvedWebObject resolved =
+                repo.resolveWebObjectWithScope(
+                    source.getPage().getName(),
+                    sourceGroup.getName()
+                );
+            if (resolved == null) {
+                Notification.show("Failed to resolve Web object");
+                return;
+            }
+            repo.copyWebObject(resolved, targetPage.getName());
+            if (cut) {
+                objectRemoved(source);
+                source.removeFromParent();
+                ORClipboardManager.clear();
+            }
+            reload();
+            return;
+        }
+        if (currentOR instanceof MobileOR) {
+            ResolvedMobileObject resolved =
+                repo.resolveMobileObjectWithScope(
+                    source.getPage().getName(),
+                    sourceGroup.getName()
+                );
+            if (resolved == null || !resolved.isPresent()) {
+                Notification.show("Failed to resolve Mobile object");
+                return;
+            }
+            repo.copyMobileObject(resolved, targetPage.getName());
+            if (cut) {
+                objectRemoved(source);
+                source.removeFromParent();
+                ORClipboardManager.clear();
+            }
+            reload();
+        }
+    }
+
+    private String computeCopyName(ORPageInf page, ORObjectInf source) {
+        String original = source.getName();
+        String base = original.replaceAll("_Copy_\\d+$", "");
+        int index = 1;
+        String candidate;
+        do {
+            candidate = base + "_Copy_" + index++;
+        } while (objectNameExists(page, candidate));
+        return candidate;
+    }
+
+    private boolean objectNameExists(ORPageInf page, String name) {
+        for (Object groupObj : page.getObjectGroups()) {
+            ObjectGroup group = (ObjectGroup) groupObj;
+            Enumeration<?> children = group.children();
+            while (children.hasMoreElements()) {
+                Object child = children.nextElement();
+                if (child instanceof ORObjectInf) {
+                    ORObjectInf obj = (ORObjectInf) child;
+                    if (name.equals(obj.getName())) {
+                        return true;
+                    }
+                }
+            }
+        }
+        return false;
+    }
+    
+    private void copySelection() {
+        if (getSelectedObject() != null) {
+            ORClipboardManager.copy(getSelectedObject());
+            return;
+        }
+        if (getSelectedPage() != null) {
+            ORClipboardManager.copy(getSelectedPage());
+        }
+    }
+    private void cutSelection() {
+        if (getSelectedObject() != null) {
+            ORObjectInf obj = getSelectedObject();
+            ORRootInf sourceOR = (ORRootInf) obj.getPage().getParent();
+            ORRootInf currentOR = getOR();
+            if (sourceOR != currentOR) {
+                Notification.show("Cut is allowed only within the same Object Repository.");
+                return;
+            }
+            ORClipboardManager.cut(obj);
+            return;
+        }
+        if (getSelectedPage() != null) {
+            ORPageInf page = getSelectedPage();
+            ORRootInf sourceOR = (ORRootInf) page.getParent();
+            ORRootInf currentOR = getOR();
+            if (sourceOR != currentOR) {
+                Notification.show("Cut is allowed only within the same Object Repository.");
+                return;
+            }
+            ORClipboardManager.cut(page);
+        }
+    }
+
+    private void pasteSelection() {
+        if (!ORClipboardManager.hasData()) {
+            return;
+        }
+        ORObjectClipboard cb = ORClipboardManager.get();
+        if (cb.getType() == ORObjectClipboard.Type.OBJECT) {
+            pasteObject();
+            return;
+        }
+        if (cb.getType() == ORObjectClipboard.Type.PAGE) {
+            pastePage();
+        }
+    }
+
+    private void pastePage() {
+        if (!ORClipboardManager.hasData()) {
+            return;
+        }
+        ORObjectClipboard cb = ORClipboardManager.get();
+        ORPageInf sourcePage = cb.getPage();
+        boolean cut = cb.isCut();
+        if (sourcePage == null) {
+            return;
+        }
+        ORRootInf currentOR = getOR();
+        ORRootInf sourceOR = (ORRootInf) sourcePage.getParent();
+        ObjectRepository repo = getProject().getObjectRepository();
+        if (cut && sourceOR instanceof WebOR && ((WebOR) sourceOR).isShared() && currentOR instanceof WebOR && !((WebOR) currentOR).isShared()) {
+            Notification.show("Cut is not allowed from Shared to Project Object Repository"
+            );
+            return;
+        }
+        if (cut && sourceOR instanceof MobileOR && ((MobileOR) sourceOR).isShared() && currentOR instanceof MobileOR && !((MobileOR) currentOR).isShared()) {
+            Notification.show("Cut is not allowed from Shared to Project Object Repository"
+            );
+            return;
+        }
+        if (cut && sourceOR instanceof WebOR && !((WebOR) sourceOR).isShared() && currentOR instanceof WebOR && ((WebOR) currentOR).isShared()) {
+            Notification.show( "Cut is not allowed in Shared Object Repository. Use `Move to Shared` instead.");
+            return;
+        }
+        if (cut && sourceOR instanceof MobileOR && !((MobileOR) sourceOR).isShared() && currentOR instanceof MobileOR && ((MobileOR) currentOR).isShared()) {
+            Notification.show( "Cut is not allowed in Shared Object Repository. Use `Move to Shared` instead.");
+            return;
+        }
+        if (sourceOR == currentOR) {
+            String newPageName = cut
+                ? sourcePage.getName()
+                : computeCopyPageName(sourcePage);
+            ORPageInf newPage = getOR().addPage(newPageName);
+            if (currentOR instanceof WebOR) {
+                WebORPage srcPage = (WebORPage) sourcePage;
+                WebORPage tgtPage = (WebORPage) newPage;
+                for (Object g : srcPage.getObjectGroups()) {
+                    ObjectGroup srcGroup = (ObjectGroup) g;
+                    ObjectGroup newGroup = new ObjectGroup(srcGroup.getName(), tgtPage);
+                    for (Object o : srcGroup.getObjects()) {
+                        WebORObject srcObj = (WebORObject) o;
+                        WebORObject cloned = new WebORObject();
+                        cloned.setName(srcObj.getName());
+                        cloned.setParent(newGroup);
+                        srcObj.clone(cloned);
+                        newGroup.getObjects().add(cloned);
+                    }
+                    tgtPage.getObjectGroups().add(newGroup);
+                }
+            }
+            else if (currentOR instanceof MobileOR) {
+                MobileORPage srcPage = (MobileORPage) sourcePage;
+                MobileORPage tgtPage = (MobileORPage) newPage;
+                for (Object g : srcPage.getObjectGroups()) {
+                    ObjectGroup srcGroup = (ObjectGroup) g;
+                    ObjectGroup newGroup = new ObjectGroup(srcGroup.getName(), tgtPage);
+                    for (Object o : srcGroup.getObjects()) {
+                        MobileORObject srcObj = (MobileORObject) o;
+                        MobileORObject cloned = new MobileORObject();
+                        cloned.setName(srcObj.getName());
+                        cloned.setParent(newGroup);
+                        srcObj.clone(cloned);
+                        newGroup.getObjects().add(cloned);
+                    }
+                    tgtPage.getObjectGroups().add(newGroup);
+                }
+            }
+            pageAdded(newPage);
+            if (cut) {
+                pageRemoved(sourcePage);
+                sourcePage.removeFromParent();
+                ORClipboardManager.clear();
+            }
+            reload();
+            return;
+        }
+        if (currentOR instanceof WebOR && !((WebOR) currentOR).isShared() && sourceOR instanceof WebOR && ((WebOR) sourceOR).isShared()) {
+            String newPageName = cut
+                ? sourcePage.getName()
+                : computeCopyPageName(sourcePage);
+            ORPageInf newPage = getOR().addPage(newPageName);
+            WebORPage srcPage = (WebORPage) sourcePage;
+            WebORPage tgtPage = (WebORPage) newPage;
+            for (Object g : srcPage.getObjectGroups()) {
+                ObjectGroup srcGroup = (ObjectGroup) g;
+                ObjectGroup newGroup = new ObjectGroup(srcGroup.getName(), tgtPage);
+                for (Object o : srcGroup.getObjects()) {
+                    WebORObject srcObj = (WebORObject) o;
+                    WebORObject cloned = new WebORObject();
+                    cloned.setName(srcObj.getName());
+                    cloned.setParent(newGroup);
+                    srcObj.clone(cloned);
+                    newGroup.getObjects().add(cloned);
+                }
+                tgtPage.getObjectGroups().add(newGroup);
+            }
+            pageAdded(newPage);
+            reload();
+            return;
+        }
+        if (currentOR instanceof MobileOR && !((MobileOR) currentOR).isShared() && sourceOR instanceof MobileOR && ((MobileOR) sourceOR).isShared()) {
+            String newPageName = cut
+                ? sourcePage.getName()
+                : computeCopyPageName(sourcePage);
+            ORPageInf newPage = getOR().addPage(newPageName);
+            MobileORPage srcPage = (MobileORPage) sourcePage;
+            MobileORPage tgtPage = (MobileORPage) newPage;
+            for (Object g : srcPage.getObjectGroups()) {
+                ObjectGroup srcGroup = (ObjectGroup) g;
+                ObjectGroup newGroup = new ObjectGroup(srcGroup.getName(), tgtPage);
+                for (Object o : srcGroup.getObjects()) {
+                    MobileORObject srcObj = (MobileORObject) o;
+                    MobileORObject cloned = new MobileORObject();
+                    cloned.setName(srcObj.getName());
+                    cloned.setParent(newGroup);
+                    srcObj.clone(cloned);
+                    newGroup.getObjects().add(cloned);
+                }
+                tgtPage.getObjectGroups().add(newGroup);
+            }
+            pageAdded(newPage);
+            reload();
+            return;
+        }
+        if (currentOR instanceof WebOR) {
+            String targetName = cut
+                ? sourcePage.getName()
+                : computeCopyPageName(sourcePage);
+            repo.copyWebPage(sourcePage.getName(), targetName);
+            if (cut) {
+                pageRemoved(sourcePage);
+                sourcePage.removeFromParent();
+                ORClipboardManager.clear();
+            }
+            reload();
+            return;
+        }
+        if (currentOR instanceof MobileOR) {
+            String targetName = cut
+                ? sourcePage.getName()
+                : computeCopyPageName(sourcePage);
+            repo.copyMobilePage(sourcePage.getName(), targetName);
+            if (cut) {
+                pageRemoved(sourcePage);
+                sourcePage.removeFromParent();
+                ORClipboardManager.clear();
+            }
+            reload();
+        }
+    }
+
+    private String computeCopyPageName(ORPageInf source) {
+        String base = source.getName().replaceAll("_Copy_\\d+$", "");
+        int i = 1;
+        String candidate;
+        do {
+            candidate = base + "_Copy_" + i++;
+        } while (getOR().getPageByName(candidate) != null);
+        return candidate;
     }
 }

--- a/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/or/ObjectTree.java
+++ b/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/or/ObjectTree.java
@@ -499,6 +499,12 @@ public abstract class ObjectTree implements ActionListener {
         boolean webDeletionPerformed = false;
         boolean mobileDeletionPerformed = false;
         try {
+            if (isSharedScope()) {
+                Notification.show(
+                    "Remove Unused Objects is only supported for Project Object Repository"
+                );
+                return;
+            }
             List<ORPageInf> selectedPages = getSelectedPages();
             if (selectedPages == null || selectedPages.isEmpty()) {
                 return;
@@ -518,105 +524,109 @@ public abstract class ObjectTree implements ActionListener {
                         if (ref == null || ref.isBlank()) {
                             continue;
                         }
+                        if (ref.startsWith("[Shared]")) {
+                            continue;
+                        }
                         String pageName = normalizePageRef(ref);
-                        String objectName = step.getObject();
-                        if (!pageName.isBlank() && !objectName.isBlank()) {
-                            usedProjectObjects.add(pageName + "@" + objectName);
+                        String objectGroupName = step.getObject();
+                        if (!pageName.isBlank() && !objectGroupName.isBlank()) {
+                            usedProjectObjects.add(
+                                pageName + "@" + objectGroupName
+                            );
                         }
                     }
                 }
             }
-            for (ORPageInf selectedPage : selectedPages) {
-                String pageName = selectedPage.getName();
-                WebORPage webPage = projectWebOR.getPageByName(pageName);
-                if (webPage == null) {
-                    continue;
-                }
-                List<String> unusedWebObjects = new ArrayList<>();
-                for (ObjectGroup group : webPage.getObjectGroups()) {
-                    if (!usedProjectObjects.contains(pageName + "@" + group.getName())) {
-                        unusedWebObjects.add(group.getName());
+            if (projectWebOR != null) {
+                for (ORPageInf selectedPage : selectedPages) {
+                    String pageName = selectedPage.getName();
+                    WebORPage webPage = projectWebOR.getPageByName(pageName);
+                    if (webPage == null) {
+                        continue;
                     }
-                }
-                if (!unusedWebObjects.isEmpty()) {
-                    int option = JOptionPane.showConfirmDialog(
-                        null,
-                        "<html><body><p style='width: 260px;'>"
-                        + "Delete the following Web objects from page [ "
-                        + pageName + " ]?<br>"
-                        + unusedWebObjects
-                        + "</p></body></html>",
-                        "Delete Web Objects",
-                        JOptionPane.YES_NO_OPTION
-                    );
-                    if (option == JOptionPane.YES_OPTION) {
-                        Iterator<ObjectGroup<WebORObject>> it = webPage.getObjectGroups().iterator();
-                        while (it.hasNext()) {
-                            ObjectGroup group = it.next();
-                            if (unusedWebObjects.contains(group.getName())) {
-                                it.remove();
-                                projectWebOR.setSaved(false);
-                                webDeletionPerformed = true;
-                            }
+                    List<String> unusedWebObjects = new ArrayList<>();
+                    for (ObjectGroup<WebORObject> group : webPage.getObjectGroups()) {
+                        if (!usedProjectObjects.contains(
+                                pageName + "@" + group.getName())) {
+                            unusedWebObjects.add(group.getName());
                         }
-                        if (webDeletionPerformed) {
-                            repo.saveWebPageNow(webPage);
+                    }
+                    if (!unusedWebObjects.isEmpty()) {
+                        int option = JOptionPane.showConfirmDialog(
+                            null,
+                            "<html><body><p style='width: 260px;'>"
+                            + "Delete the following Web objects from page [ "
+                            + pageName + " ]?<br>"
+                            + unusedWebObjects
+                            + "</p></body></html>",
+                            "Delete Web Objects",
+                            JOptionPane.YES_NO_OPTION
+                        );
+
+                        if (option == JOptionPane.YES_OPTION) {
+                            Iterator<ObjectGroup<WebORObject>> it =
+                                webPage.getObjectGroups().iterator();
+
+                            while (it.hasNext()) {
+                                ObjectGroup<WebORObject> group = it.next();
+                                if (unusedWebObjects.contains(group.getName())) {
+                                    it.remove();
+                                    projectWebOR.setSaved(false);
+                                    webDeletionPerformed = true;
+                                }
+                            }
+                            if (webDeletionPerformed) {
+                                repo.saveWebPageNow(webPage);
+                            }
                         }
                     }
                 }
             }
-            for (ORPageInf selectedPage : selectedPages) {
-                String pageName = selectedPage.getName();
-                MobileORPage mobilePage = projectMobileOR.getPageByName(pageName);
-                if (mobilePage == null) {
-                    continue;
-                }
-                List<String> unusedMobileObjects = new ArrayList<>();
-                for (ObjectGroup group : mobilePage.getObjectGroups()) {
-                    if (!usedProjectObjects.contains(pageName + "@" + group.getName())) {
-                        unusedMobileObjects.add(group.getName());
+            if (projectMobileOR != null) {
+                for (ORPageInf selectedPage : selectedPages) {
+                    String pageName = selectedPage.getName();
+                    MobileORPage mobilePage = projectMobileOR.getPageByName(pageName);
+                    if (mobilePage == null) {
+                        continue;
                     }
-                }
-                if (!unusedMobileObjects.isEmpty()) {
-                    int option = JOptionPane.showConfirmDialog(
-                        null,
-                        "<html><body><p style='width: 260px;'>"
-                        + "Delete the following Mobile objects from page [ "
-                        + pageName + " ]?<br>"
-                        + unusedMobileObjects
-                        + "</p></body></html>",
-                        "Delete Mobile Objects",
-                        JOptionPane.YES_NO_OPTION
-                    );
-                    if (option == JOptionPane.YES_OPTION) {
-                        Iterator<ObjectGroup<MobileORObject>> it = mobilePage.getObjectGroups().iterator();
-                        while (it.hasNext()) {
-                            ObjectGroup group = it.next();
-                            if (unusedMobileObjects.contains(group.getName())) {
-                                it.remove();
-                                projectMobileOR.setSaved(false);
-                                mobileDeletionPerformed = true;
-                            }
+                    List<String> unusedMobileObjects = new ArrayList<>();
+                    for (ObjectGroup<MobileORObject> group : mobilePage.getObjectGroups()) {
+                        if (!usedProjectObjects.contains(
+                                pageName + "@" + group.getName())) {
+                            unusedMobileObjects.add(group.getName());
                         }
-                        if (mobileDeletionPerformed) {
-                            repo.saveMobilePageNow(mobilePage);
+                    }
+                    if (!unusedMobileObjects.isEmpty()) {
+                        int option = JOptionPane.showConfirmDialog(
+                            null,
+                            "<html><body><p style='width: 260px;'>"
+                            + "Delete the following Mobile objects from page [ "
+                            + pageName + " ]?<br>"
+                            + unusedMobileObjects
+                            + "</p></body></html>",
+                            "Delete Mobile Objects",
+                            JOptionPane.YES_NO_OPTION
+                        );
+                        if (option == JOptionPane.YES_OPTION) {
+                            Iterator<ObjectGroup<MobileORObject>> it =
+                                mobilePage.getObjectGroups().iterator();
+                            while (it.hasNext()) {
+                                ObjectGroup<MobileORObject> group = it.next();
+                                if (unusedMobileObjects.contains(group.getName())) {
+                                    it.remove();
+                                    projectMobileOR.setSaved(false);
+                                    mobileDeletionPerformed = true;
+                                }
+                            }
+                            if (mobileDeletionPerformed) {
+                                repo.saveMobilePageNow(mobilePage);
+                            }
                         }
                     }
                 }
             }
             if (webDeletionPerformed || mobileDeletionPerformed) {
                 repo.save();
-                int option = JOptionPane.showConfirmDialog(
-                    null,
-                    "<html><body><p style='width: 260px;'>"
-                    + "Do you want to restart INGenious to load the updated Object Repository?"
-                    + "</p></body></html>",
-                    "Restart INGenious",
-                    JOptionPane.YES_NO_OPTION
-                );
-                if (option == JOptionPane.YES_OPTION) {
-                    new AppMainFrame().restart();
-                }
             } else {
                 JOptionPane.showMessageDialog(
                     null,
@@ -627,8 +637,9 @@ public abstract class ObjectTree implements ActionListener {
                     JOptionPane.INFORMATION_MESSAGE
                 );
             }
-            ((DefaultTreeModel) tree.getModel()).reload();
-            tree.updateUI();
+            load();
+            reload();
+            tree.repaint();
         } catch (Exception e) {
             e.printStackTrace();
         }

--- a/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/or/ObjectTree.java
+++ b/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/or/ObjectTree.java
@@ -1192,6 +1192,7 @@ public abstract class ObjectTree implements ActionListener {
         if (!ORClipboardManager.hasData()) {
             return;
         }
+        ORObjectInf pastedObject = null;
         ORObjectClipboard cb = ORClipboardManager.get();
         ORObjectInf source = cb.getObject();
         boolean cut = cb.isCut();
@@ -1258,6 +1259,7 @@ public abstract class ObjectTree implements ActionListener {
                     cloned.setParent(newGroup);
                     srcObj.clone(cloned);
                     newGroup.getObjects().add(cloned);
+                    pastedObject = cloned;
                 }
                 targetPage.getObjectGroups().add(newGroup);
                 ((WebOR) currentOR).setSaved(false);
@@ -1281,6 +1283,7 @@ public abstract class ObjectTree implements ActionListener {
                     cloned.setParent(newGroup);
                     srcObj.clone(cloned);
                     newGroup.getObjects().add(cloned);
+                    pastedObject = cloned;
                 }
                 targetPage.getObjectGroups().add(newGroup);
                 ((MobileOR) currentOR).setSaved(false);
@@ -1300,6 +1303,12 @@ public abstract class ObjectTree implements ActionListener {
                 }
             }
             reload();
+            final ORObjectInf highlight = pastedObject;
+            if (highlight != null) {
+                SwingUtilities.invokeLater(() -> {
+                    selectAndSrollTo(highlight.getTreePath());
+                });
+            }
             return;
         }
         if (currentOR instanceof WebOR && !((WebOR) currentOR).isShared() && sourceOR instanceof WebOR && ((WebOR) sourceOR).isShared()) {
@@ -1320,8 +1329,16 @@ public abstract class ObjectTree implements ActionListener {
             }
             targetPage.getObjectGroups().add(newGroup);
             reload();
+            final ORObjectInf highlight = pastedObject;
+            if (highlight != null) {
+                SwingUtilities.invokeLater(() -> {
+                    selectAndSrollTo(highlight.getTreePath());
+                });
+            }
             return;
         }
+        String expectedObjectName = source.getName();
+        String targetPageName = targetPage.getName();
         if (currentOR instanceof WebOR) {
             ResolvedWebObject resolved =
                 repo.resolveWebObjectWithScope(
@@ -1339,6 +1356,15 @@ public abstract class ObjectTree implements ActionListener {
                 ORClipboardManager.clear();
             }
             reload();
+            SwingUtilities.invokeLater(() -> {
+                ORPageInf page = getOR().getPageByName(targetPageName);
+                if (page != null) {
+                    ORObjectInf pasted = findObjectInPage(page, expectedObjectName);
+                    if (pasted != null) {
+                        selectAndSrollTo(pasted.getTreePath());
+                    }
+                }
+            });
             return;
         }
         if (currentOR instanceof MobileOR) {
@@ -1358,6 +1384,15 @@ public abstract class ObjectTree implements ActionListener {
                 ORClipboardManager.clear();
             }
             reload();
+            SwingUtilities.invokeLater(() -> {
+                ORPageInf page = getOR().getPageByName(targetPageName);
+                if (page != null) {
+                    ORObjectInf pasted = findObjectInPage(page, expectedObjectName);
+                    if (pasted != null) {
+                        selectAndSrollTo(pasted.getTreePath());
+                    }
+                }
+            });
         }
     }
 
@@ -1370,6 +1405,19 @@ public abstract class ObjectTree implements ActionListener {
             candidate = base + "_Copy_" + index++;
         } while (objectNameExists(page, candidate));
         return candidate;
+    }
+
+    private ORObjectInf findObjectInPage(ORPageInf page, String objectName) {
+        for (Object groupObj : page.getObjectGroups()) {
+            ObjectGroup<?> group = (ObjectGroup<?>) groupObj;
+            for (Object obj : group.getObjects()) {
+                ORObjectInf orObj = (ORObjectInf) obj;
+                if (objectName.equals(orObj.getName())) {
+                    return orObj;
+                }
+            }
+        }
+        return null;
     }
 
     private boolean objectNameExists(ORPageInf page, String name) {
@@ -1513,6 +1561,7 @@ public abstract class ObjectTree implements ActionListener {
                 ORClipboardManager.clear();
             }
             reload();
+            SwingUtilities.invokeLater(() -> {selectAndSrollTo(newPage.getTreePath());});
             return;
         }
         if (currentOR instanceof WebOR && !((WebOR) currentOR).isShared() && sourceOR instanceof WebOR && ((WebOR) sourceOR).isShared()) {
@@ -1537,6 +1586,7 @@ public abstract class ObjectTree implements ActionListener {
             }
             pageAdded(newPage);
             reload();
+            SwingUtilities.invokeLater(() -> {selectAndSrollTo(newPage.getTreePath());});
             return;
         }
         if (currentOR instanceof MobileOR && !((MobileOR) currentOR).isShared() && sourceOR instanceof MobileOR && ((MobileOR) sourceOR).isShared()) {
@@ -1561,32 +1611,45 @@ public abstract class ObjectTree implements ActionListener {
             }
             pageAdded(newPage);
             reload();
+            SwingUtilities.invokeLater(() -> {selectAndSrollTo(newPage.getTreePath());});
             return;
         }
         if (currentOR instanceof WebOR) {
-            String targetName = cut
+            String targetPageName = cut
                 ? sourcePage.getName()
                 : computeCopyPageName(sourcePage);
-            repo.copyWebPage(sourcePage.getName(), targetName);
+            repo.copyWebPage(sourcePage.getName(), targetPageName);
             if (cut) {
                 pageRemoved(sourcePage);
                 sourcePage.removeFromParent();
                 ORClipboardManager.clear();
             }
             reload();
+            SwingUtilities.invokeLater(() -> {
+                ORPageInf pastedPage = getOR().getPageByName(targetPageName);
+                if (pastedPage != null) {
+                    selectAndSrollTo(pastedPage.getTreePath());
+                }
+            });
             return;
         }
         if (currentOR instanceof MobileOR) {
-            String targetName = cut
+            String targetPageName = cut
                 ? sourcePage.getName()
                 : computeCopyPageName(sourcePage);
-            repo.copyMobilePage(sourcePage.getName(), targetName);
+            repo.copyMobilePage(sourcePage.getName(), targetPageName);
             if (cut) {
                 pageRemoved(sourcePage);
                 sourcePage.removeFromParent();
                 ORClipboardManager.clear();
             }
             reload();
+            SwingUtilities.invokeLater(() -> {
+                ORPageInf pastedPage = getOR().getPageByName(targetPageName);
+                if (pastedPage != null) {
+                    selectAndSrollTo(pastedPage.getTreePath());
+                }
+            });
         }
     }
 
@@ -1599,4 +1662,5 @@ public abstract class ObjectTree implements ActionListener {
         } while (getOR().getPageByName(candidate) != null);
         return candidate;
     }
+    
 }

--- a/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/or/ObjectTree.java
+++ b/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/or/ObjectTree.java
@@ -39,6 +39,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import com.ing.ide.main.mainui.AppMainFrame;
+import com.ing.ide.main.mainui.components.testdesign.TestDesign;
 import com.ing.ide.main.mainui.components.testdesign.or.clipboard.ORClipboardManager;
 import com.ing.ide.main.mainui.components.testdesign.or.clipboard.ORObjectClipboard;
 import com.ing.ide.main.mainui.components.testdesign.or.mobile.MobileORPanel;
@@ -491,6 +492,9 @@ public abstract class ObjectTree implements ActionListener {
                     objectRemoved(object);
                     object.removeFromParent();
                 }
+                // Save immediately to update YAML files
+                ObjectRepository repo = getProject().getObjectRepository();
+                repo.save();
             }
         }
     }
@@ -793,6 +797,9 @@ public abstract class ObjectTree implements ActionListener {
                     objectGroupRemoved(object);
                     object.removeFromParent();
                 }
+                // Save immediately to update YAML files
+                ObjectRepository repo = getProject().getObjectRepository();
+                repo.save();
             }
         }
     }
@@ -816,6 +823,9 @@ public abstract class ObjectTree implements ActionListener {
                     pageRemoved(page);
                     page.removeFromParent();
                 }
+                // Save immediately to update YAML files
+                ObjectRepository repo = getProject().getObjectRepository();
+                repo.save();
             }
         }
     }
@@ -870,6 +880,8 @@ public abstract class ObjectTree implements ActionListener {
 
     public abstract Project getProject();
 
+    public abstract TestDesign getTestDesign();
+
     public void load() {
         tree.setModel(new DefaultTreeModel(getOR()) {
             @Override
@@ -915,11 +927,13 @@ public abstract class ObjectTree implements ActionListener {
         boolean isWeb = root instanceof WebOR;
         boolean isMobile = root instanceof MobileOR;
         String objectName = obj.getName().toString();
+        String pageName = page.getName();
+        
         if (isWeb) {
             ResolvedWebObject resolved =
                 repo.resolveWebObject(
                     new ResolvedWebObject.PageRef(
-                        page.getName(),
+                        pageName,
                         WebOR.ORScope.PROJECT
                     ),
                     objectName
@@ -928,20 +942,27 @@ public abstract class ObjectTree implements ActionListener {
                 Notification.show("Object not found in Project OR");
                 return;
             }
-            String newName = repo.moveWebObject(resolved, page.getName());
+            String newName = repo.moveWebObject(resolved, pageName);
             if (newName != null) {
-                objectRemoved(obj);
-                obj.removeFromParent();
+                // Check if source page is now empty and remove it
+                WebOR projectOR = repo.getWebOR();
+                WebORPage sourcePage = projectOR.getPageByName(pageName);
+                if (sourcePage != null && sourcePage.getObjectGroups().isEmpty()) {
+                    sourcePage.removeFromParent();
+                }
+                
                 repo.save();
+                reload();
                 refreshSharedTree();
                 Notification.show("Moved Object '" + newName + "' to Shared OR");
+                promptTestCaseReload();
             }
         }
         if (isMobile) {
             ResolvedMobileObject resolved =
                 repo.resolveMobileObject(
                     new ResolvedMobileObject.PageRef(
-                        page.getName(),
+                        pageName,
                         WebOR.ORScope.PROJECT
                     ),
                     objectName
@@ -950,14 +971,30 @@ public abstract class ObjectTree implements ActionListener {
                 Notification.show("Mobile Object not found in Project OR");
                 return;
             }
-            String newName = repo.moveMobileObject(resolved, page.getName());
+            String newName = repo.moveMobileObject(resolved, pageName);
             if (newName != null) {
-                objectRemoved(obj);
-                obj.removeFromParent();
+                // Check if source page is now empty and remove it
+                MobileOR projectOR = repo.getMobileOR();
+                MobileORPage sourcePage = projectOR.getPageByName(pageName);
+                if (sourcePage != null && sourcePage.getObjectGroups().isEmpty()) {
+                    sourcePage.removeFromParent();
+                }
+                
                 repo.save();
+                reload();
                 refreshSharedTree();
                 Notification.show("Moved Mobile Object '" + newName + "' to Shared OR");
+                promptTestCaseReload();
             }
+        }
+    }
+
+    private void promptTestCaseReload() {
+        try {
+            getTestDesign().getTestCaseComp().reload();
+            Notification.show("Test cases reloaded successfully");
+        } catch (Exception e) {
+            // Silently ignore if no test case is currently open
         }
     }
 
@@ -966,24 +1003,30 @@ public abstract class ObjectTree implements ActionListener {
         ORRootInf root = getOR();
         boolean isWeb = root instanceof WebOR;
         boolean isMobile = root instanceof MobileOR;
+        String pageName = page.getName();
+        
         if (isWeb) {
-            String newPageName = repo.copyWebPage(page.getName(), page.getName());
-            if (newPageName != null) {
-                pageRemoved(page);
-                page.removeFromParent();
+            String movedPageName = repo.moveWebPage(pageName, pageName);
+            if (movedPageName != null) {
                 repo.save();
+                reload();
                 refreshSharedTree();
-                Notification.show( "Moved Page '" + page.getName() + "' to Shared OR");
+                Notification.show("Moved Page '" + pageName + "' to Shared OR");
+                promptTestCaseReload();
+            } else {
+                Notification.show("Failed to move page '" + pageName + "' to Shared OR");
             }
         }
         if (isMobile) {
-            String newPageName = repo.copyMobilePage(page.getName(), page.getName());
-            if (newPageName != null) {
-                pageRemoved(page);
-                page.removeFromParent();
+            String movedPageName = repo.moveMobilePage(pageName, pageName);
+            if (movedPageName != null) {
                 repo.save();
+                reload();
                 refreshSharedTree();
-                Notification.show("Moved Mobile Page '" + page.getName() + "' to Shared OR");
+                Notification.show("Moved Mobile Page '" + pageName + "' to Shared OR");
+                promptTestCaseReload();
+            } else {
+                Notification.show("Failed to move mobile page '" + pageName + "' to Shared OR");
             }
         }
     }
@@ -999,8 +1042,12 @@ public abstract class ObjectTree implements ActionListener {
         }
     }
 
+
     public Boolean navigateToObject(String objectName, String pageName) {
-        ORPageInf page = getOR().getPageByName(pageName);
+        // Parse the pageName to extract actual page name (handles scoped references like "[Project] PageName")
+        String actualPageName = extractPageName(pageName);
+
+        ORPageInf page = getOR().getPageByName(actualPageName);
         if (page != null) {
             ObjectGroup group = page.getObjectGroupByName(objectName);
             if (group != null) {
@@ -1009,6 +1056,32 @@ public abstract class ObjectTree implements ActionListener {
             }
         }
         return false;
+    }
+
+    /**
+     * Extracts the actual page name from a scoped reference.
+     * Handles references like "[Project] PageName" or "[Shared] PageName"
+     * by removing the scope prefix and returning just the page name.
+     *
+     * @param pageReference the page reference token (may contain scope prefix)
+     * @return the actual page name without scope prefix
+     */
+    private String extractPageName(String pageReference) {
+        if (pageReference == null || pageReference.trim().isEmpty()) {
+            return pageReference;
+        }
+
+        String trimmed = pageReference.trim();
+
+        // Check if reference starts with "[" and contains "]"
+        if (trimmed.startsWith("[") && trimmed.contains("]")) {
+            int endBracket = trimmed.indexOf(']');
+            // Return the part after "]", trimming any leading whitespace
+            return trimmed.substring(endBracket + 1).trim();
+        }
+
+        // No scope prefix, return as-is
+        return trimmed;
     }
 
     private void objectAddedPage(final ORObjectInf object) {

--- a/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/or/ObjectTree.java
+++ b/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/or/ObjectTree.java
@@ -130,6 +130,7 @@ public abstract class ObjectTree implements ActionListener {
         tree.setInvokesStopCellEditing(true);
         
         alterDefaultKeyBindings();
+        installClipboardActions();
         
         tree.setTransferHandler(new ObjectDnD(tree));
 
@@ -1100,6 +1101,27 @@ public abstract class ObjectTree implements ActionListener {
          tree.getInputMap().put(KeyStroke.getKeyStroke(KeyEvent.VK_X, menuShortcutKeyMask), "cut");
          tree.getInputMap().put(KeyStroke.getKeyStroke(KeyEvent.VK_C, menuShortcutKeyMask), "copy");
          tree.getInputMap().put(KeyStroke.getKeyStroke(KeyEvent.VK_V, menuShortcutKeyMask), "paste");   
+    }
+
+    private void installClipboardActions() {
+        tree.getActionMap().put("cut", new AbstractAction() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                cutSelection();
+            }
+        });
+        tree.getActionMap().put("copy", new AbstractAction() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                copySelection();
+            }
+        });
+        tree.getActionMap().put("paste", new AbstractAction() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                pasteSelection();
+            }
+        });
     }
 
     private boolean isSharedScope() {

--- a/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/or/clipboard/ORClipboardManager.java
+++ b/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/or/clipboard/ORClipboardManager.java
@@ -1,0 +1,42 @@
+
+package com.ing.ide.main.mainui.components.testdesign.or.clipboard;
+
+import com.ing.datalib.or.common.ORObjectInf;
+import com.ing.datalib.or.common.ORPageInf;
+
+/**
+ * Simple application-level clipboard manager
+ * for OR objects.
+ */
+public final class ORClipboardManager {
+
+    private static ORObjectClipboard clipboard;
+
+    public static void copy(ORObjectInf object) {
+        clipboard = new ORObjectClipboard(object, false);
+    }
+
+    public static void cut(ORObjectInf object) {
+        clipboard = new ORObjectClipboard(object, true);
+    }
+
+    public static void copy(ORPageInf page) {
+        clipboard = new ORObjectClipboard(page, false);
+    }
+
+    public static void cut(ORPageInf page) {
+        clipboard = new ORObjectClipboard(page, true);
+    }
+
+    public static boolean hasData() {
+        return clipboard != null;
+    }
+
+    public static ORObjectClipboard get() {
+        return clipboard;
+    }
+
+    public static void clear() {
+        clipboard = null;
+    }
+}

--- a/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/or/clipboard/ORObjectClipboard.java
+++ b/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/or/clipboard/ORObjectClipboard.java
@@ -1,0 +1,48 @@
+
+package com.ing.ide.main.mainui.components.testdesign.or.clipboard;
+
+import com.ing.datalib.or.common.ORObjectInf;
+import com.ing.datalib.or.common.ORPageInf;
+
+/**
+ * Holds a single OR object in clipboard along with
+ * the action type (copy or cut).
+ *
+ * This is a UI-level helper class.
+ */
+public class ORObjectClipboard {
+
+    public enum Type { OBJECT, PAGE }
+
+    private final Object data;     // ORObjectInf or ORPageInf
+    private final boolean cut;
+    private final Type type;
+
+    public ORObjectClipboard(ORObjectInf object, boolean cut) {
+        this.data = object;
+        this.cut = cut;
+        this.type = Type.OBJECT;
+    }
+
+    public ORObjectClipboard(ORPageInf page, boolean cut) {
+        this.data = page;
+        this.cut = cut;
+        this.type = Type.PAGE;
+    }
+
+    public boolean isCut() {
+        return cut;
+    }
+
+    public Type getType() {
+        return type;
+    }
+
+    public ORObjectInf getObject() {
+        return (ORObjectInf) data;
+    }
+
+    public ORPageInf getPage() {
+        return (ORPageInf) data;
+    }
+}

--- a/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/or/mobile/MobileObjectTree.java
+++ b/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/or/mobile/MobileObjectTree.java
@@ -6,6 +6,7 @@ import com.ing.datalib.or.ObjectRepository;
 import com.ing.datalib.or.common.ORObjectInf;
 import com.ing.datalib.or.common.ORRootInf;
 import com.ing.datalib.or.mobile.MobileORObject;
+import com.ing.ide.main.mainui.components.testdesign.TestDesign;
 import com.ing.ide.main.mainui.components.testdesign.or.ObjectTree;
 import java.util.List;
 import javax.swing.tree.TreePath;
@@ -79,5 +80,10 @@ public class MobileObjectTree extends ObjectTree {
     
     public MobileORPanel getORPanel() {
         return oRPanel;
+    }
+
+    @Override
+    public TestDesign getTestDesign() {
+        return oRPanel.getTestDesign();
     }
 }

--- a/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/or/structureddata/StructuredDataObjectTree.java
+++ b/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/or/structureddata/StructuredDataObjectTree.java
@@ -5,6 +5,7 @@ import com.ing.datalib.component.TestCase;
 import com.ing.datalib.or.structureddata.StructuredDataORObject;
 import com.ing.datalib.or.common.ORObjectInf;
 import com.ing.datalib.or.common.ORRootInf;
+import com.ing.ide.main.mainui.components.testdesign.TestDesign;
 import com.ing.ide.main.mainui.components.testdesign.or.ObjectTree;
 import java.util.List;
 import javax.swing.tree.TreePath;
@@ -54,6 +55,11 @@ public class StructuredDataObjectTree extends ObjectTree {
 
     public StructuredDataORObject getLoadedObject() {
         return oRPanel.getObjectTable().getObject();
+    }
+
+    @Override
+    public TestDesign getTestDesign() {
+        return oRPanel.getTestDesign();
     }
 
 }

--- a/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/or/web/WebObjectTree.java
+++ b/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/or/web/WebObjectTree.java
@@ -7,6 +7,7 @@ import com.ing.datalib.or.ObjectRepository;
 import com.ing.datalib.or.common.ORObjectInf;
 import com.ing.datalib.or.common.ORRootInf;
 import com.ing.datalib.or.web.WebORObject;
+import com.ing.ide.main.mainui.components.testdesign.TestDesign;
 import com.ing.ide.main.mainui.components.testdesign.or.ObjectTree;
 import java.util.List;
 import javax.swing.tree.TreePath;
@@ -94,5 +95,10 @@ public class WebObjectTree extends ObjectTree {
     
     public WebORPanel getORPanel() {
         return oRPanel;
+    }
+
+    @Override
+    public TestDesign getTestDesign() {
+        return oRPanel.getTestDesign();
     }
 }

--- a/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/testcase/TestCaseComponent.java
+++ b/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/testcase/TestCaseComponent.java
@@ -22,6 +22,7 @@ import com.ing.ide.main.utils.Utils;
 import com.ing.ide.main.utils.keys.Keystroke;
 import com.ing.ide.main.utils.table.TableColumnManager;
 import com.ing.ide.main.utils.table.XTable;
+import com.ing.ide.util.Notification;
 import com.ing.ide.util.Canvas;
 import com.ing.ide.util.Notification;
 import com.ing.ide.util.WindowMover;
@@ -160,6 +161,17 @@ public class TestCaseComponent extends JPanel implements ActionListener {
             validator.initValidations();
             changeSave(tc.isSaved());
             refreshTitle();
+            
+            // Check if migration occurred and show notification
+            int migratedCount = tc.getMigratedReferencesCount();
+            if (migratedCount > 0) {
+                Notification.show(
+                    String.format("Migrated %d object reference%s to explicit scope prefix in '%s'",
+                        migratedCount,
+                        migratedCount > 1 ? "es" : "",
+                        tc.getName())
+                );
+            }
         }
     }
 

--- a/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/testcase/TestCaseTableDnD.java
+++ b/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/testcase/TestCaseTableDnD.java
@@ -2,8 +2,11 @@
 package com.ing.ide.main.mainui.components.testdesign.testcase;
 
 import com.ing.datalib.component.TestCase;
+import com.ing.datalib.component.TestStep;
 import com.ing.datalib.component.TestStep.HEADERS;
+import com.ing.datalib.or.ObjectRepository;
 import com.ing.datalib.or.common.ORPageInf;
+import com.ing.datalib.or.web.ResolvedWebObject;
 import com.ing.ide.main.mainui.components.testdesign.or.ObjectDnD;
 import com.ing.ide.main.mainui.components.testdesign.or.ObjectRepDnD;
 import com.ing.ide.main.mainui.components.testdesign.testdata.TestDataDetail;
@@ -123,7 +126,17 @@ public class TestCaseTableDnD extends TransferHandler {
                     testCase.setValueAt(objs.getPageName(val), row, HEADERS.Reference.getIndex());
                     testCase.fireTableRowsUpdated(row, row);
                 } else {
-                    testCase.addObjectStep(row, objs.getObjectName(val), objs.getPageName(val));
+                    ObjectRepository or = testCase.getProject().getObjectRepository();
+                    TestStep tempStep = new TestStep(testCase);
+                    ResolvedWebObject rwo =
+                        or.resolveWebObjectWithScope(
+                            objs.getPageName(val),
+                            objs.getObjectName(val),
+                            tempStep
+                        );
+                    if (rwo != null) {
+                        testCase.addObjectStep(row, rwo);
+                    }
                 }
                 row++;
             }

--- a/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/testcase/validation/ObjectRenderer.java
+++ b/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/testcase/validation/ObjectRenderer.java
@@ -1,6 +1,7 @@
 package com.ing.ide.main.mainui.components.testdesign.testcase.validation;
 
 import com.ing.datalib.component.TestStep;
+import com.ing.datalib.or.ObjectRepository;
 import com.ing.datalib.or.web.ResolvedWebObject;
 import com.ing.datalib.or.structureddata.ResolvedStructuredDataObject;
 import com.ing.datalib.or.mobile.ResolvedMobileObject;
@@ -25,35 +26,38 @@ public class ObjectRenderer extends AbstractRenderer {
 
     @Override
     public void render(JComponent comp, TestStep step, Object value) {
-        if (!step.isCommented()) {
-            if (isEmpty(value)) {
-                setEmpty(comp);
-            } else if ("Execute".equals(Objects.toString(value, "").trim())) {
-                setExecute(comp);
-            } else if (step.isPageObjectStep()) {
-                if (isObjectPresent(step)) {
-                    setDefault(comp);
-                } else {
-                    setNotPresent(comp, objNotPresent);
-                }
-            } else if (isValidObject(value)) {
-                setDefault(comp);
-            } else {
-                setNotPresent(comp, objNotPresent);
-            }
-        } else {
-            setDefault(comp);
-            Color c = UIManager.getColor("ing.commentedForeground");
-            comp.setForeground(c != null ? c : Color.lightGray);
-            comp.setFont(new Font("Default", Font.ITALIC, 11));
+        setDefault(comp);
+        comp.setFont(comp.getFont().deriveFont(java.awt.Font.PLAIN));
+        comp.setEnabled(true);
+        comp.setToolTipText(null);
+
+        String objectName = Objects.toString(step.getObject(), "").trim();
+        String reference  = Objects.toString(step.getReference(), "").trim();
+
+        if (objectName.isEmpty() && reference.isEmpty()) {
+            return;
         }
+        if (isValidObject(objectName)) {
+            comp.setFont(comp.getFont().deriveFont(java.awt.Font.BOLD));
+            return;
+        }
+        if (!objectName.isEmpty() && reference.isEmpty()) {
+            setNotPresent(comp, "Reference is missing");
+            comp.setFont(comp.getFont().deriveFont(java.awt.Font.BOLD));
+            return;
+        }
+        if (!isObjectPresent(step)) {
+            setNotPresent(comp, objNotPresent);
+            comp.setFont(comp.getFont().deriveFont(java.awt.Font.BOLD));
+            return;
+        }
+        comp.setFont(comp.getFont().deriveFont(java.awt.Font.BOLD));
     }
 
     private Boolean isObjectPresent(TestStep step) {
         var repo = step.getProject().getObjectRepository();
         String pageToken = step.getReference();
         String objectName = step.getObject();
-        
         
         ResolvedWebObject.PageRef wref = ResolvedWebObject.PageRef.parse(pageToken);
         if ((wref != null && wref.name != null && wref.scope != null) && (repo.resolveWebObject(wref, objectName) != null)

--- a/IDE/src/main/java/com/ing/ide/main/playwrightrecording/PlaywrightRecordingParser.java
+++ b/IDE/src/main/java/com/ing/ide/main/playwrightrecording/PlaywrightRecordingParser.java
@@ -48,6 +48,7 @@ public class PlaywrightRecordingParser {
             filePath.put("projectPath", sMainFrame.getProject().getLocation());
             filePath.put("importPlaywrightRecordingFilePath", file.getAbsolutePath());
             String baseName = FilenameUtils.getBaseName(file.getAbsolutePath());
+            // Use the basename as-is since sanitization is handled in the UI dialog
             testCase.put("fileName", StringUtils.capitalize(baseName));
             testCase.put("pageName", testCase.get("fileName"));
             String testScenarioName = filePath.get("projectPath") + "/TestPlan/" + testCase.get("fileName");
@@ -125,6 +126,11 @@ public class PlaywrightRecordingParser {
                         group.getObjects().add(obj);
                     }
                     testCase.put("step", String.valueOf(stepNumber));
+                    // Only add [Project] reference for object-based actions, not for Browser actions
+                    String objectName = testCase.get("ObjectName");
+                    String reference = (objectName != null && objectName.trim().equals("Browser")) 
+                        ? "" 
+                        : "[Project] " + testCase.get("pageName");
                     String stepAppender =
                             testCase.get("step") + "," +
                             testCase.get("ObjectName") + "," +
@@ -132,7 +138,7 @@ public class PlaywrightRecordingParser {
                             testCase.get("action") + "," +
                             testCase.get("input") + "," +
                             testCase.get("Condition") + "," +
-                            testCase.get("pageName");
+                            reference;
                     stepBuilder.append(stepAppender).append("\n");
                     stepNumber++;
                     testCase.put("input", "");

--- a/IDE/src/main/java/com/ing/ide/main/playwrightrecording/PlaywrightRecordingParser.java
+++ b/IDE/src/main/java/com/ing/ide/main/playwrightrecording/PlaywrightRecordingParser.java
@@ -1,9 +1,12 @@
 package com.ing.ide.main.playwrightrecording;
 
+import com.ing.datalib.or.common.ObjectGroup;
+import com.ing.datalib.or.web.WebOR;
+import com.ing.datalib.or.web.WebORObject;
+import com.ing.datalib.or.web.WebORPage;
 import com.ing.ide.main.mainui.AppMainFrame;
-import com.ing.ide.util.logging.UILogger;
+
 import java.io.File;
-import java.io.IOException;
 import java.io.PrintWriter;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -15,26 +18,11 @@ import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.parsers.ParserConfigurationException;
-import javax.xml.transform.Transformer;
-import javax.xml.transform.TransformerException;
-import javax.xml.transform.TransformerFactory;
-import javax.xml.transform.dom.DOMSource;
-import javax.xml.transform.stream.StreamResult;
 
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.w3c.dom.DOMException;
-import org.w3c.dom.Document;
-import org.w3c.dom.Element;
-import org.xml.sax.SAXException;
 
 public class PlaywrightRecordingParser {
 
@@ -52,226 +40,127 @@ public class PlaywrightRecordingParser {
         this.sMainFrame = sMainFrame;
     }
 
-    public void playwrightParser(File file) throws ParserConfigurationException, TransformerException, SAXException, IOException {
-        if (file != null && file.exists()) {
-            try {
-                filePath.put("projectPath", sMainFrame.getProject().getLocation());
-                filePath.put("importPlaywrightRecordingFilePath", file.getAbsolutePath());
-                File PlaywrightRecordingfile = new File(filePath.get("importPlaywrightRecordingFilePath"));
-                filePath.put("orFilePath", (filePath.get("projectPath") + "/OR.object"));
-                String baseName = FilenameUtils.getBaseName(filePath.get("importPlaywrightRecordingFilePath"));
-                testCase.put("fileName", StringUtils.capitalize(baseName));
-                File OrFile = new File(filePath.get("orFilePath"));
-                Element objectFrame = null;
-                testCase.put("pageName", testCase.get("fileName"));
-                testCase.put("testScenarioName", (filePath.get("projectPath") + "/TestPlan/" + testCase.get("fileName")).replace("\\", "/"));
-                File testScenario = new File(testCase.get("testScenarioName"));
-                if (!testScenario.exists()) {
-                    testScenario.mkdirs();
-                }
-                testCase.put("pageName", getPageName(testScenario, testCase.get("pageName")));
-
-                if (!OrFile.exists()) {
-                    boolean orExistFlag = false;
-                    DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
-                    DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
-                    Document doc = dBuilder.newDocument();
-                    Element rootElement = doc.createElement("Root");
-                    doc.appendChild(rootElement);
-                    rootElement.setAttribute("ref", testCase.get("fileName"));
-                    rootElement.setAttribute("type", "OR");
-                    Element page = doc.createElement("Page");
-                    rootElement.appendChild(page);
-
-                    List l = readFileInList(
-                            filePath.get("importPlaywrightRecordingFilePath"));
-
-                    Iterator<String> iterator = l.iterator();
-                    executeParse(iterator, objectFrame, testCase.get("testScenarioName"), filePath.get("orFilePath"), page, doc, orExistFlag, rootElement);
-                    allObjectMaping.clear();
-                } else {
-                    boolean orExistFlag = true;
-                    DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
-                    DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();
-                    Document doc = documentBuilder.parse(new File(filePath.get("orFilePath")));
-                    doc.getDocumentElement().normalize();
-                    Element root = doc.getDocumentElement();
-                    Element page = doc.createElement("Page");
-                    List l = readFileInList(
-                            filePath.get("importPlaywrightRecordingFilePath"));
-
-                    Iterator<String> iterator = l.iterator();
-                    executeParse(iterator, objectFrame, testCase.get("testScenarioName"), filePath.get("orFilePath"), page, doc, orExistFlag, root);
-                    allObjectMaping.clear();
-                }
-                testCase.clear();
-                attribute.clear();
-                filePath.clear();
-                ObjectNameList.clear();
-            } catch (Exception ex) {
-                Logger.getLogger(PlaywrightRecordingParser.class.getName()).log(Level.SEVERE, null, ex);
+    public void playwrightParser(File file) {
+        if (file == null || !file.exists()) {
+            return;
+        }
+        try {
+            filePath.put("projectPath", sMainFrame.getProject().getLocation());
+            filePath.put("importPlaywrightRecordingFilePath", file.getAbsolutePath());
+            String baseName = FilenameUtils.getBaseName(file.getAbsolutePath());
+            testCase.put("fileName", StringUtils.capitalize(baseName));
+            testCase.put("pageName", testCase.get("fileName"));
+            String testScenarioName = filePath.get("projectPath") + "/TestPlan/" + testCase.get("fileName");
+            testScenarioName = testScenarioName.replace("\\", "/");
+            testCase.put("testScenarioName", testScenarioName);
+            File testScenario = new File(testScenarioName);
+            if (!testScenario.exists()) {
+                testScenario.mkdirs();
             }
+            WebOR webOR = sMainFrame.getProject().getObjectRepository().getWebOR();
+            String basePageName = testCase.get("pageName");
+            String pageName = basePageName;
+            if (webOR.getPageByName(pageName) != null) {
+                int counter = 1;
+                while (webOR.getPageByName(basePageName + "_" + counter) != null) {
+                    counter++;
+                }
+                pageName = basePageName + "_" + counter;
+            }
+            testCase.put("pageName", pageName);
+            WebORPage page = webOR.addPage(pageName);
+            List<String> lines = readFileInList(filePath.get("importPlaywrightRecordingFilePath"));
+            Iterator<String> iterator = lines.iterator();
+            executeParse(iterator, page, testScenarioName);
+            page.getRoot() .getObjectRepository() .saveWebPageNow(page);
+        } catch (Exception ex) {
+            Logger.getLogger(PlaywrightRecordingParser.class.getName()).log(Level.SEVERE, null, ex);
         }
     }
 
-    private void executeParse(Iterator iterator, Element objectFrame, String testScenarioName, String orFilePath, Element page, Document doc, boolean orExistFlag, Element root) throws TransformerException {
-
+    private void executeParse(Iterator<String> iterator, WebORPage page, String testScenarioName) {
         StringBuilder stepBuilder = new StringBuilder();
         testCaseParameter();
         attributeDeclaration();
         int stepNumber = 1;
-        stepBuilder.append("Step" + "," + "ObjectName" + "," + "Description" + "," + "Action" + "," + "Input" + ","
-                + "Condition" + "," + "Reference");
-        stepBuilder.append("\n");
-        page.setAttribute("ref", testCase.get("pageName"));
-        page.setAttribute("title", "");
         int playwrightSteps = 0;
+        stepBuilder.append("Step,ObjectName,Description,Action,Input,Condition,Reference\n");
         while (iterator.hasNext()) {
             attributeDeclaration();
             testCaseParameter();
-            String line = (String) iterator.next();
+            String line = iterator.next();
             checkPageSwitch(line);
             storePageIndex(line);
             if (line.trim().startsWith("page")) {
                 pageMapping.put("currentPage", line.trim().split("\\.")[0]);
             }
-            if (!line.contains("System.out.println(") && !line.contains(pageMapping.get("currentPage") + ".onceDialog(dialog") && !line.contains(".waitForPopup(() ->")) {
-
+            if (!line.contains("System.out.println(")
+                    && !line.contains(pageMapping.get("currentPage") + ".onceDialog(dialog")
+                    && !line.contains(".waitForPopup(() ->")) {
                 if (line.trim().startsWith("page")) {
-                    playwrightSteps = playwrightSteps + 1;
+                    playwrightSteps++;
                 }
-
-                if (playwrightSteps >= 1) {
-                    if (!line.contains("}")) {
-                        int matchingAttribute = 0;
-                        testCaseMap(getAction(line), getInput(line));
-                        attributeInitialization(line);
-                        if (!testCase.get("ObjectName").equals("Browser")) {
-                            if (!allObjectMaping.isEmpty() && allObjectMaping.containsKey(testCase.get("ObjectName"))) {
-                                if (objectFrameMap.get(testCase.get("ObjectName")).equals(testCase.get("frame"))) {
-                                    HashMap<String, String> objectAttributeMap = allObjectMaping.get(testCase.get("ObjectName"));
-
-                                    Set<String> attributesKey = objectAttributeMap.keySet();
-                                    for (String allObjectAttributeKey : attributesKey) {
-                                        if (objectAttributeMap.get(allObjectAttributeKey).equals(attribute.get(allObjectAttributeKey))) {
-                                            matchingAttribute = matchingAttribute + 1;
-                                        }
-                                    }
-                                }
-                            }
-
-                            if (!testCase.get("ObjectName").equals("Browser")) {
-                                ObjectNameList.add(testCase.get("ObjectName"));
-                                int j = 0;
-                                int k = 0;
-                                for (String Locator : ObjectNameList) {
-                                    if ((Locator.trim()).equals(testCase.get("ObjectName").trim())) {
-                                        j++;
-                                    }
-                                    if (j > 1) {
-                                        k = (j - 1);
-                                    }
-                                }
-                                String locatorNumber = Integer.toString(k);
-                                if (attribute.size() != matchingAttribute || testCase.get("ObjectName").contains("Refactor_Object")) {
-                                    if (!locatorNumber.equals("0")) {
-                                        testCase.put("ObjectName", testCase.get("ObjectName") + "_" + locatorNumber);
-                                    }
-                                }
-
-                            }
-                            Map<String, String> objectAttribute = new HashMap<>();
-                            Set a = attribute.keySet();
-                            for (Object key : a) {
-                                String newKey = key.toString();
-                                objectAttribute.put(newKey, attribute.get(newKey));
-                            }
-                            objectFrameMap.put(testCase.get("ObjectName"), testCase.get("frame"));
-
-                            allObjectMaping.put(testCase.get("ObjectName"), (HashMap) objectAttribute);
-                            if (attribute.size() != matchingAttribute || testCase.get("ObjectName").contains("Refactor_Object")) {
-                                if (!testCase.get("ObjectName").equals("Browser")) {
-                                    Element objectGroup = doc.createElement("ObjectGroup");
-                                    page.appendChild(objectGroup);
-                                    objectGroup.setAttribute("ref", testCase.get("ObjectName"));
-                                    objectFrame = doc.createElement("Object");
-                                    objectGroup.appendChild(objectFrame);
-                                    objectFrame.setAttribute("frame", testCase.get("frame"));
-                                    objectFrame.setAttribute("ref", testCase.get("ObjectName"));
-
-                                    for (int p = 0; p < attribute.size(); p++) {
-                                        Element Property = doc.createElement("Property");
-                                        objectFrame.appendChild(Property);
-                                        String key = (String) attribute.keySet().toArray()[p];
-                                        Property.setAttribute("ref", key);
-                                        Property.setAttribute("value", attribute.get(key));
-                                        String prefNumber = Integer.toString(p + 1);
-                                        Property.setAttribute("pref", prefNumber);
-                                    }
-                                }
-
+                if (playwrightSteps >= 1 && !line.contains("}")) {
+                    testCaseMap(getAction(line), getInput(line));
+                    attributeInitialization(line);
+                    if (!"Browser".equals(testCase.get("ObjectName"))) {
+                        String objectName = testCase.get("ObjectName");
+                        ObjectGroup group = page.getObjectGroupByName(objectName);
+                        if (group == null) {
+                            group = new ObjectGroup(objectName, page);
+                            page.getObjectGroups().add(group);
+                        }
+                        WebORObject obj = new WebORObject(objectName, group);
+                        for (Map.Entry<String, String> entry : attribute.entrySet()) {
+                            String key = entry.getKey();
+                            String value = entry.getValue();
+                            if (value != null && !value.isEmpty()) {
+                                obj.setAttributeByName(key, value);
                             }
                         }
-                        if (stepNumber > 1) {
-                            if (!pageMapping.get("currentPage").equals(pageMapping.get("previousPage")) && !pageMapping.get("switchedPageName").equals(pageMapping.get("currentPage"))) {
-                                testCase.put("step", String.valueOf(stepNumber));
-                                String pageIndex = "@" + pageMapping.get(pageMapping.get("currentPage"));
-                                String stepAppenderString = testCase.get("step") + "," + "Browser" + "," + "" + "," + "switchToPageByIndex" + "," + pageIndex + ","
-                                        + "" + "," + "";
-                                testCase.put("stepAppender", stepAppenderString);
-                                stepBuilder.append(testCase.get("stepAppender"));
-                                stepBuilder.append("\n");
-                                testCase.put("input", "");
-                                stepNumber++;
-                            }
+                        if (!testCase.get("frame").isEmpty()) {
+                            obj.setFrame(testCase.get("frame"));
                         }
-                        if (line.trim().startsWith("page")) {
-                            pageMapping.put("previousPage", line.trim().split("\\.")[0]);
-                        }
-                        attributeDeclaration();
-                        if (!testCase.get("action").equals("Open")) {
-                            testCase.put("step", String.valueOf(stepNumber));
-
-                            String stepAppenderString = testCase.get("step") + "," + testCase.get("ObjectName") + "," + "" + "," + testCase.get("action") + "," + testCase.get("input") + ","
-                                    + testCase.get("Condition") + "," + testCase.get("pageName");
-                            testCase.put("stepAppender", stepAppenderString);
-                            stepBuilder.append(testCase.get("stepAppender"));
-                            stepBuilder.append("\n");
-                            testCase.put("input", "");
-                            stepNumber++;
-                        }
-
-                        if (testCase.get("action").equals("Open")) {
-                            testCase.put("step", String.valueOf(stepNumber));
-                            String stepAppenderValue = testCase.get("step") + "," + testCase.get("ObjectName") + "," + "" + "," + testCase.get("action") + "," + testCase.get("input") + ","
-                                    + testCase.get("Condition") + "," + "";
-                            testCase.put("stepAppender", stepAppenderValue);
-                            stepBuilder.append(testCase.get("stepAppender"));
-                            stepBuilder.append("\n");
-                            testCase.put("input", "");
-                            stepNumber++;
-                        }
-                        testCase.put("csvFileName", testCase.get("pageName"));
-                        filePath.put("csvFilePath", (testScenarioName + "/" + testCase.get("csvFileName") + ".csv"));
-                        File file = new File(filePath.get("csvFilePath"));
-                        try (PrintWriter printWriter = new PrintWriter(file)) {
-                            printWriter.write(stepBuilder.toString());
-                            printWriter.flush();
-                        } catch (Exception ex) {
-
-                        }
+                        group.getObjects().clear();
+                        group.getObjects().add(obj);
                     }
+                    testCase.put("step", String.valueOf(stepNumber));
+                    String stepAppender =
+                            testCase.get("step") + "," +
+                            testCase.get("ObjectName") + "," +
+                            "" + "," +
+                            testCase.get("action") + "," +
+                            testCase.get("input") + "," +
+                            testCase.get("Condition") + "," +
+                            testCase.get("pageName");
+                    stepBuilder.append(stepAppender).append("\n");
+                    stepNumber++;
+                    testCase.put("input", "");
                 }
             }
+            if (line.trim().startsWith("page")) {
+                pageMapping.put(
+                        "previousPage",
+                        line.trim().split("\\.")[0]
+                );
+            }
         }
-        if (orExistFlag) {
-            root.appendChild(page);
+        try {
+            testCase.put("csvFileName", testCase.get("pageName"));
+            filePath.put(
+                    "csvFilePath",
+                    testScenarioName + "/"
+                            + testCase.get("csvFileName")
+                            + ".csv"
+            );
+            File csvFile = new File(filePath.get("csvFilePath"));
+            try (PrintWriter printWriter = new PrintWriter(csvFile)) {
+                printWriter.write(stepBuilder.toString());
+                printWriter.flush();
+            }
+        } catch (Exception e) {
+            Logger.getLogger(PlaywrightRecordingParser.class.getName()).log(Level.WARNING, "Failed to write CSV", e);
         }
-        TransformerFactory transformerFactory = TransformerFactory.newInstance();
-        Transformer transformer = transformerFactory.newTransformer();
-        DOMSource source = new DOMSource(doc);
-        StreamResult result = new StreamResult(new File(orFilePath));
-        transformer.transform(source, result);
     }
 
     public void attributeDeclaration() {

--- a/IDE/src/main/java/com/ing/ide/main/playwrightrecording/RecordedStepsNameDialogue.java
+++ b/IDE/src/main/java/com/ing/ide/main/playwrightrecording/RecordedStepsNameDialogue.java
@@ -13,10 +13,41 @@ public class RecordedStepsNameDialogue extends javax.swing.JFrame {
     public static String ScenarioName;
     
     private final AppMainFrame sMainFrame;
+    private javax.swing.JLabel errorLabel;
     
     public RecordedStepsNameDialogue(AppMainFrame sMainFrame) {
         this.sMainFrame = sMainFrame;
         initComponents();
+        
+        // Add error label programmatically
+        errorLabel = new javax.swing.JLabel();
+        errorLabel.setFont(new java.awt.Font("SansSerif", 0, 11));
+        errorLabel.setForeground(new java.awt.Color(204, 0, 0)); // Red color
+        errorLabel.setText("");
+        errorLabel.setVisible(false);
+        errorLabel.setHorizontalAlignment(javax.swing.SwingConstants.CENTER);
+        
+        // Use null layout for absolute positioning
+        jPanel1.setLayout(null);
+        
+        // Reposition existing components
+        jLabel1.setBounds(35, 89, 360, 16);
+        errorLabel.setBounds(35, 118, 360, 20); // Wider to fit full error message
+        jTextField1.setBounds(62, 140, 309, 22);
+        jButton1.setBounds(175, 194, 80, 26);
+        
+        // Add error label
+        jPanel1.add(errorLabel);
+        
+        // Add listener to clear error when user types
+        jTextField1.addKeyListener(new java.awt.event.KeyAdapter() {
+            @Override
+            public void keyTyped(java.awt.event.KeyEvent evt) {
+                if (errorLabel.isVisible()) {
+                    errorLabel.setVisible(false);
+                }
+            }
+        });
         
         setDefaultCloseOperation(JFrame.DO_NOTHING_ON_CLOSE);
         addWindowListener(new WindowAdapter() {
@@ -110,7 +141,24 @@ public class RecordedStepsNameDialogue extends javax.swing.JFrame {
     }// </editor-fold>//GEN-END:initComponents
 
     private void jButton1ActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_jButton1ActionPerformed
-        RecordedStepsNameDialogue.setScenarioName(jTextField1.getText());
+        // Sanitize the scenario name by removing leading whitespace
+        String scenarioName = jTextField1.getText();
+        if (scenarioName != null) {
+            scenarioName = scenarioName.replaceAll("^\\s+", ""); // Remove leading whitespace
+        }
+        
+        // Validate that the name is not empty after sanitization
+        if (scenarioName == null || scenarioName.trim().isEmpty()) {
+            // Show error inline instead of popup
+            errorLabel.setText("⚠ Scenario name cannot be empty or contain only whitespace.");
+            errorLabel.setVisible(true);
+            return; // Don't proceed with the import
+        }
+        
+        // Clear any previous error
+        errorLabel.setVisible(false);
+        
+        RecordedStepsNameDialogue.setScenarioName(scenarioName);
         ActionEvent newEvent = new ActionEvent(this, ActionEvent.ACTION_PERFORMED, "Import via Playwright Recorder");
         sMainFrame.getsActionListener().actionPerformed(newEvent);
         setVisible(false);

--- a/IDE/src/main/java/com/ing/ide/main/shr/mobile/MobileObjectSpy.java
+++ b/IDE/src/main/java/com/ing/ide/main/shr/mobile/MobileObjectSpy.java
@@ -11,6 +11,7 @@ import com.ing.datalib.or.mobile.MobileORPage;
 import com.ing.datalib.settings.emulators.Emulator;
 import com.ing.datalib.util.data.LinkedProperties;
 import com.ing.ide.main.mainui.AppMainFrame;
+import com.ing.ide.main.mainui.components.testdesign.TestDesign;
 import com.ing.ide.main.mainui.components.testdesign.or.ObjectTree;
 import com.ing.ide.main.settings.PropUtils;
 import com.ing.ide.main.shr.mobile.android.AndroidAdbCLI;
@@ -119,6 +120,11 @@ public class MobileObjectSpy extends javax.swing.JFrame {
             @Override
             public ORRootInf getOR() {
                 return mobileOR;
+            }
+
+            @Override
+            public TestDesign getTestDesign() {
+                return sMainFrame.getTestDesign();
             }
         };
         treePanel.add(new JScrollPane(objectTree.getTree()), BorderLayout.CENTER);

--- a/IDE/src/main/java/com/ing/ide/main/ui/ImpactUI.java
+++ b/IDE/src/main/java/com/ing/ide/main/ui/ImpactUI.java
@@ -26,12 +26,40 @@ public class ImpactUI extends javax.swing.JDialog {
 
     TestDesign testDesign;
 
+    /**
+     * Custom cell renderer to display test cases with source indicator
+     */
+    private static class TestCaseListCellRenderer extends javax.swing.DefaultListCellRenderer {
+        @Override
+        public java.awt.Component getListCellRendererComponent(
+                javax.swing.JList<?> list,
+                Object value,
+                int index,
+                boolean isSelected,
+                boolean cellHasFocus) {
+            
+            super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
+            
+            if (value instanceof TestCase) {
+                TestCase testCase = (TestCase) value;
+                String sourceIndicator = testCase.getScenario().getSource() == com.ing.datalib.component.Scenario.Source.REUSABLE_COMPONENTS
+                        ? "[Reusable Component] "
+                        : "[Test Plan] ";
+                String displayText = sourceIndicator + testCase.getScenario().getName() + "/" + testCase.getName();
+                setText(displayText);
+            }
+            
+            return this;
+        }
+    }
+
     public ImpactUI(TestDesign testDesign) {
         super(new JFrame());
         this.testDesign = testDesign;
         initComponents();
         listModel = new DefaultListModel();
         testCaseList.setModel(listModel);
+        testCaseList.setCellRenderer(new TestCaseListCellRenderer());
         setSize(400, 300);
         setIconImage(Utils.getFavIcon());
     }


### PR DESCRIPTION
- Existing XML files should be converted to YAML (Project and Shared)
- New Projects created should be using YAML moving forward
- Import playwright recording should be converted to YAML as well (WebOR)
- Menu options for OR should be working as expected (Add, Rename, Delete, Get Impacted Cases, Removed Unused Objects)
- Disabled Add Object for Object lvl selection (to prevent creation of objectgroup)
- Fixed faulty CCP (Cut, Copy, Paste)
- Copy to Shared replaced with Moved to Shared