### PR TITLE
[Contribution] Webservice payload handling update

### DIFF
--- a/Engine/src/main/java/com/ing/engine/commands/webservice/Webservice.java
+++ b/Engine/src/main/java/com/ing/engine/commands/webservice/Webservice.java
@@ -133,6 +133,13 @@ public class Webservice extends General {
      *
      * @see #setEndPoint()
      */
+
+    /**
+     * Previously, the postRestRequest method mandated a payload for executing POST requests.
+     * Since POST requests do not always require a payload, I have modified the implementation to make the payload optional.
+     * This change improves flexibility and ensures the framework aligns more closely with standard API practices.
+     */
+
     @Action(object = ObjectType.WEBSERVICE, desc = "POST Rest Request ", input = InputType.OPTIONAL, condition = InputType.OPTIONAL)
     public void postRestRequest() {
         try {
@@ -553,36 +560,6 @@ public class Webservice extends General {
         }
     }
 
-    /**
-     * This method will store response headers in datasheet
-     */
-
-    @Action(object = ObjectType.WEBSERVICE, desc = "Store Response Headers In DataSheet ", input = InputType.YES)
-    public void storeResponseHeadersInDataSheet() {
-        try {
-            String strObj = Input;
-            if (strObj.matches(".*:.*")) {
-                try {
-                    System.out.println("Updating value in SubIteration " + userData.getSubIteration());
-                    String sheetName = strObj.split(":", 2)[0];
-                    String columnName = strObj.split(":", 2)[1];
-                    userData.putData(sheetName, columnName, response.get(key).headers().toString());
-                    Report.updateTestLog(Action, "Response headers stored in " + strObj, Status.DONE);
-                } catch (Exception ex) {
-                    Logger.getLogger(this.getClass().getName()).log(Level.OFF, ex.getMessage(), ex);
-                    Report.updateTestLog(Action, "Error Storing text in datasheet :" + ex.getMessage(), Status.DEBUG);
-                }
-            } else {
-                Report.updateTestLog(Action,
-                        "Given input [" + Input + "] format is invalid. It should be [sheetName:ColumnName]",
-                        Status.DEBUG);
-            }
-        } catch (Exception ex) {
-            Logger.getLogger(this.getClass().getName()).log(Level.OFF, null, ex);
-            Report.updateTestLog(Action, "Error Storing response body in datasheet :" + "\n" + ex.getMessage(),
-                    Status.DEBUG);
-        }
-    }
 
     /**
      * Asserts that an XML element value equals the expected value.
@@ -1648,6 +1625,14 @@ public class Webservice extends General {
      * @param reqOrRes "request" or "response" to indicate which type of payload to save
      * @param data the payload data to save
      */
+
+    /**
+     * The existing HTML reporting displayed only the response payload once a request was marked as Complete.
+     * This limitation made debugging challenging, particularly in cases where critical information-such as trace IDs was present exclusively in the response headers.
+     * I have enhanced the reporting to include response headers along with the response payload
+     * Provides greater visibility and significantly aiding effective debugging
+     */
+
     private void savePayload(String reqOrRes, String data) {
         String payloadFileName = "";
         String path = "";

--- a/Engine/src/main/java/com/ing/engine/commands/webservice/Webservice.java
+++ b/Engine/src/main/java/com/ing/engine/commands/webservice/Webservice.java
@@ -134,12 +134,6 @@ public class Webservice extends General {
      * @see #setEndPoint()
      */
 
-    /**
-     * Previously, the postRestRequest method mandated a payload for executing POST requests.
-     * Since POST requests do not always require a payload, I have modified the implementation to make the payload optional.
-     * This change improves flexibility and ensures the framework aligns more closely with standard API practices.
-     */
-
     @Action(object = ObjectType.WEBSERVICE, desc = "POST Rest Request ", input = InputType.OPTIONAL, condition = InputType.OPTIONAL)
     public void postRestRequest() {
         try {
@@ -1624,13 +1618,6 @@ public class Webservice extends General {
      *
      * @param reqOrRes "request" or "response" to indicate which type of payload to save
      * @param data the payload data to save
-     */
-
-    /**
-     * The existing HTML reporting displayed only the response payload once a request was marked as Complete.
-     * This limitation made debugging challenging, particularly in cases where critical information-such as trace IDs was present exclusively in the response headers.
-     * I have enhanced the reporting to include response headers along with the response payload
-     * Provides greater visibility and significantly aiding effective debugging
      */
 
     private void savePayload(String reqOrRes, String data) {

--- a/Engine/src/main/java/com/ing/engine/commands/webservice/Webservice.java
+++ b/Engine/src/main/java/com/ing/engine/commands/webservice/Webservice.java
@@ -121,18 +121,19 @@ public class Webservice extends General {
     }
 
     /**
-     * Sends a POST HTTP request to the configured endpoint with the specified payload.
+     * Sends a POST HTTP request to the configured endpoint with an optional payload.
      * <p>
-     * Executes a POST REST request using the data from the Input field and the endpoint
+     * Executes a POST REST request using the data from the Input field (if provided) and the endpoint
      * previously set with {@code setEndPoint}.
+     * <p>
      * <ul>
-     *   <li>Input: Request payload</li>
+     *   <li>Input: Request payload (optional)</li>
      *   <li>Condition: Optional API configuration alias (e.g., #alias)</li>
      * </ul>
      *
      * @see #setEndPoint()
      */
-    @Action(object = ObjectType.WEBSERVICE, desc = "POST Rest Request ", input = InputType.YES, condition = InputType.OPTIONAL)
+    @Action(object = ObjectType.WEBSERVICE, desc = "POST Rest Request ", input = InputType.OPTIONAL, condition = InputType.OPTIONAL)
     public void postRestRequest() {
         try {
             createhttpRequest(RequestMethod.POST);
@@ -536,6 +537,37 @@ public class Webservice extends General {
                     String columnName = strObj.split(":", 2)[1];
                     userData.putData(sheetName, columnName, responsebodies.get(key));
                     Report.updateTestLog(Action, "Response body is stored in " + strObj, Status.DONE);
+                } catch (Exception ex) {
+                    Logger.getLogger(this.getClass().getName()).log(Level.OFF, ex.getMessage(), ex);
+                    Report.updateTestLog(Action, "Error Storing text in datasheet :" + ex.getMessage(), Status.DEBUG);
+                }
+            } else {
+                Report.updateTestLog(Action,
+                        "Given input [" + Input + "] format is invalid. It should be [sheetName:ColumnName]",
+                        Status.DEBUG);
+            }
+        } catch (Exception ex) {
+            Logger.getLogger(this.getClass().getName()).log(Level.OFF, null, ex);
+            Report.updateTestLog(Action, "Error Storing response body in datasheet :" + "\n" + ex.getMessage(),
+                    Status.DEBUG);
+        }
+    }
+
+    /**
+     * This method will store response headers in datasheet
+     */
+
+    @Action(object = ObjectType.WEBSERVICE, desc = "Store Response Headers In DataSheet ", input = InputType.YES)
+    public void storeResponseHeadersInDataSheet() {
+        try {
+            String strObj = Input;
+            if (strObj.matches(".*:.*")) {
+                try {
+                    System.out.println("Updating value in SubIteration " + userData.getSubIteration());
+                    String sheetName = strObj.split(":", 2)[0];
+                    String columnName = strObj.split(":", 2)[1];
+                    userData.putData(sheetName, columnName, response.get(key).headers().toString());
+                    Report.updateTestLog(Action, "Response headers stored in " + strObj, Status.DONE);
                 } catch (Exception ex) {
                     Logger.getLogger(this.getClass().getName()).log(Level.OFF, ex.getMessage(), ex);
                     Report.updateTestLog(Action, "Error Storing text in datasheet :" + ex.getMessage(), Status.DEBUG);
@@ -1635,6 +1667,11 @@ public class Webservice extends General {
                 if (location.createNewFile()) {
                     FileWriter writer = new FileWriter(location);
                     writer.write(data);
+                    // Appending headers when saving response
+                    if (reqOrRes.equals("response")) {
+                        writer.write("\n\n--- Response Headers ---\n");
+                        writer.write(response.get(key).headers().toString());
+                    }
                     writer.close();
                 }
             }


### PR DESCRIPTION
Enhancements:

Payload Handling for POST Requests
Previously, the postRestRequest method mandated a payload for executing POST requests. Since POST requests do not always require a payload, I have modified the implementation to make the payload optional. This change improves flexibility and ensures the framework aligns more closely with standard API practices.
Enhanced HTML Reporting with Response Headers
The existing HTML reporting displayed only the response payload once a request was marked as Complete. This limitation made debugging challenging, particularly in cases where critical information-such as trace IDs was present exclusively in the response headers. I have enhanced the reporting to include response headers along with the response payload, providing greater visibility and significantly aiding effective debugging