### PR TITLE
Resolve LambdaTest Configuration and Save State UI Issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,9 @@ Release Date: <insert date of release>
 - Fixed OR Tables' add row (+) button 
 - Updated suffix handling for copied objects/pages so it is only applied when another object or page with the same name already exists
 - Resolved issues with multi-object and multi-page copy-paste and cut-paste operations in the Object Repository
+- Fixed issue where enabling or disabling the LambdaTest option in the Manange Devices caused the Properties table to display empty entries.
+- Corrected Save button behavior that becomes disabled after switching applications using Alt+Tab, despite having unsaved changes.
+- Fixed behaqvior in the LambdaTest Remote URL field where the cursor unexpectedly jumped to the beginning of the text after typing characters beyond the @ symbol.
 
 
 ### Browser/Playwright Testing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,7 +77,7 @@ Release Date: <insert date of release>
 - Resolved issues with multi-object and multi-page copy-paste and cut-paste operations in the Object Repository
 - Fixed issue where enabling or disabling the LambdaTest option in the Manange Devices caused the Properties table to display empty entries.
 - Corrected Save button behavior that becomes disabled after switching applications using Alt+Tab, despite having unsaved changes.
-- Fixed behaqvior in the LambdaTest Remote URL field where the cursor unexpectedly jumped to the beginning of the text after typing characters beyond the @ symbol.
+- Fixed behavior in the LambdaTest Remote URL field where the cursor unexpectedly jumped to the beginning of the text after typing characters beyond the @ symbol.
 
 
 ### Browser/Playwright Testing

--- a/IDE/src/main/java/com/ing/ide/main/settings/DriverSettings.java
+++ b/IDE/src/main/java/com/ing/ide/main/settings/DriverSettings.java
@@ -114,6 +114,9 @@ public class DriverSettings extends javax.swing.JFrame {
         initAddNewContextListener();
         initAddNewDBAPIListener();
 
+        // Initial state: nothing is edited yet.
+        clearDirty();
+
         final JTextField resolutionText = new JTextField();
         //final JTextField resolutionText = (JTextField) resolution.getEditor().getEditorComponent();
         resolutionText.addKeyListener(
@@ -462,9 +465,7 @@ public class DriverSettings extends javax.swing.JFrame {
 
         model.insertRow(safeRow, emptyRow);
 
-        if (saveSettings != null) {
-            saveSettings.setEnabled(true);
-        }
+        markDirty();
     }
 
     private void initAddEmulatorListener() {
@@ -500,7 +501,7 @@ public class DriverSettings extends javax.swing.JFrame {
                     @Override
                     public void actionPerformed(ActionEvent ae) {
                         addNewDB();
-                        saveSettings.setEnabled(true);
+                        markDirty();
                     }
                 }
             );
@@ -515,7 +516,7 @@ public class DriverSettings extends javax.swing.JFrame {
                     @Override
                     public void actionPerformed(ActionEvent ae) {
                         addNewContext();
-                        saveSettings.setEnabled(true);
+                        markDirty();
                     }
                 }
             );
@@ -530,7 +531,7 @@ public class DriverSettings extends javax.swing.JFrame {
                     @Override
                     public void actionPerformed(ActionEvent ae) {
                         addNewAPI();
-                        saveSettings.setEnabled(true);
+                        markDirty();
                     }
                 }
             );
@@ -540,6 +541,8 @@ public class DriverSettings extends javax.swing.JFrame {
         this.sProject = sMainFrame.getProject();
         settings = sProject.getProjectSettings();
         loadSettings();
+        // Loading persisted data is not a user edit.
+        clearDirty();
     }
 
     private void loadSettings() {
@@ -759,6 +762,8 @@ public class DriverSettings extends javax.swing.JFrame {
 
     public void open() {
         loadBrowsers();
+        // Ensure Save starts disabled when opening the window.
+        clearDirty();
         setLocationRelativeTo(null);
         setVisible(true);
     }
@@ -767,7 +772,7 @@ public class DriverSettings extends javax.swing.JFrame {
         String newEmName = browserCombo.getEditor().getItem().toString();
         if (!getTotalBrowserList().contains(newEmName)) {
             isAddingEmulator = true;
-            saveSettings.setEnabled(true);
+            markDirty();
             settings.getEmulators().addEmulator(newEmName);
             browserCombo.addItem(newEmName);
             //dupDriverCombo.addItem(newEmName);
@@ -1913,12 +1918,12 @@ public class DriverSettings extends javax.swing.JFrame {
 
     private void saveSettingsActionPerformed(java.awt.event.ActionEvent evt) { //GEN-FIRST:event_saveSettingsActionPerformed
         saveSettings();
-        saveSettings.setEnabled(false);
+        clearDirty();
     } //GEN-LAST:event_saveSettingsActionPerformed
 
     private void resetSettingsActionPerformed(java.awt.event.ActionEvent evt) { //GEN-FIRST:event_resetSettingsActionPerformed
         // TODO add your handling code here:
-        saveSettings.setEnabled(false);
+        clearDirty();
     } //GEN-LAST:event_resetSettingsActionPerformed
 
     private void formWindowClosing(java.awt.event.WindowEvent evt) { //GEN-FIRST:event_formWindowClosing
@@ -1976,8 +1981,7 @@ public class DriverSettings extends javax.swing.JFrame {
     } //GEN-LAST:event_dbComboItemStateChanged
 
     private void formWindowActivated(java.awt.event.WindowEvent evt) { //GEN-FIRST:event_formWindowActivated
-        // TODO add your handling code here:
-        saveSettings.setEnabled(false);
+        // Keep Save state tied to real edits; do not clear it on window focus.
         addListeners();
     } //GEN-LAST:event_formWindowActivated
 
@@ -2167,6 +2171,9 @@ public class DriverSettings extends javax.swing.JFrame {
     }
 
     private void addListeners() {
+        if (saveListenersAttached) {
+            return;
+        }
         // Add SaveSettings listeners
         saveSettingsListeners = new SaveSettingsListeners(saveSettings);
 
@@ -2188,6 +2195,11 @@ public class DriverSettings extends javax.swing.JFrame {
         contextPropTable
             .getModel()
             .addTableModelListener(saveSettingsListeners.new SaveTableModelListener());
+        if (kafkaSSLPanel != null && kafkaSSLPanel.table != null) {
+            kafkaSSLPanel
+                .table.getModel()
+                .addTableModelListener(saveSettingsListeners.new SaveTableModelListener());
+        }
         if (deviceCombo != null) {
             deviceCombo.addItemListener(saveSettingsListeners.new SaveItemListener());
             deviceCapTable
@@ -2198,6 +2210,7 @@ public class DriverSettings extends javax.swing.JFrame {
             // ensureLambdaCapsPanel() once the panel actually exists.
         }
         // End of SaveSettings Listeners
+        saveListenersAttached = true;
     }
 
     // ====================================================================
@@ -2228,6 +2241,7 @@ public class DriverSettings extends javax.swing.JFrame {
     private boolean isAddingDevice = false;
     private boolean isTogglingLambdaTest = false;
     private boolean isLoadingDevice = false;
+    private boolean saveListenersAttached = false;
 
     // Holds the unmasked Remote URL for the currently displayed device. The
     // text field shows a masked version (credentials replaced with ****) while
@@ -2295,10 +2309,12 @@ public class DriverSettings extends javax.swing.JFrame {
         // new value as the canonical URL, then mask if needed.
         actualRemoteUrl = text;
         if (hasCredentials(text)) {
+            int caret = deviceRemoteUrlField.getCaretPosition();
+            String masked = maskRemoteUrl(text);
             isMaskingRemoteUrl = true;
             try {
-                deviceRemoteUrlField.setText(maskRemoteUrl(text));
-                deviceRemoteUrlField.setCaretPosition(0);
+                deviceRemoteUrlField.setText(masked);
+                deviceRemoteUrlField.setCaretPosition(Math.min(caret, masked.length()));
             } finally {
                 isMaskingRemoteUrl = false;
             }
@@ -2529,7 +2545,7 @@ public class DriverSettings extends javax.swing.JFrame {
                         if (isLoadingDevice || isMaskingRemoteUrl) {
                             return;
                         }
-                        saveSettings.setEnabled(true);
+                        markDirty();
                         // If credentials are visible in the field (e.g. just pasted or
                         // typed in full), mask them right away. Defer the mutation so
                         // we don't modify the document from inside its own listener.
@@ -2653,7 +2669,7 @@ public class DriverSettings extends javax.swing.JFrame {
             return;
         }
         addNewDevice(newName);
-        saveSettings.setEnabled(true);
+        markDirty();
     }
 
     private void addNewDevice(String newName) {
@@ -2730,7 +2746,7 @@ public class DriverSettings extends javax.swing.JFrame {
             m.removeElement(oldName);
             m.insertElementAt(newName, idx);
             deviceCombo.setSelectedIndex(idx);
-            saveSettings.setEnabled(true);
+            markDirty();
         }
     }
 
@@ -2800,10 +2816,11 @@ public class DriverSettings extends javax.swing.JFrame {
         if (d == null) {
             return;
         }
+        // Read from the currently visible card before switching views.
+        LinkedProperties current = readActiveCaps();
         boolean enabled = lambdaTestCheckBox.isSelected();
         d.setLambdaTest(enabled);
-        // Preserve whatever the user has already typed in the visible view
-        LinkedProperties current = readActiveCaps();
+        // Preserve whatever the user has already typed in the active view.
         if (enabled) {
             showLambdaCapsView(current.isEmpty() ? null : current);
         } else {
@@ -2819,7 +2836,30 @@ public class DriverSettings extends javax.swing.JFrame {
             }
             showFlatCapsView(merged);
         }
-        saveSettings.setEnabled(true);
+        markDirty();
+    }
+
+    /**
+     * Marks settings state as dirty (unsaved changes present).
+     */
+    private void markDirty() {
+        setDirtyState(true);
+    }
+
+    /**
+     * Marks settings state as clean (no unsaved changes).
+     */
+    private void clearDirty() {
+        setDirtyState(false);
+    }
+
+    /**
+     * Centralized save-button state control for all tabs.
+     */
+    private void setDirtyState(boolean dirty) {
+        if (saveSettings != null) {
+            saveSettings.setEnabled(dirty);
+        }
     }
 
     private LinkedProperties readDeviceCapTable() {
@@ -2843,9 +2883,7 @@ public class DriverSettings extends javax.swing.JFrame {
      * (flat table or grouped LambdaTest panel).
      */
     private LinkedProperties readActiveCaps() {
-        if (
-            lambdaTestCheckBox != null && lambdaTestCheckBox.isSelected() && lambdaCapsPanel != null
-        ) {
+        if (lambdaCapsPanel != null && lambdaCapsPanel.isVisible()) {
             return lambdaCapsPanel.getProperties();
         }
         return readDeviceCapTable();

--- a/IDE/src/main/java/com/ing/ide/main/settings/DriverSettings.java
+++ b/IDE/src/main/java/com/ing/ide/main/settings/DriverSettings.java
@@ -23,7 +23,9 @@ import java.awt.event.KeyEvent;
 import java.awt.event.WindowEvent;
 import java.util.ArrayList;
 import java.util.Enumeration;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
 import java.util.regex.Matcher;
@@ -2242,12 +2244,17 @@ public class DriverSettings extends javax.swing.JFrame {
     private boolean isTogglingLambdaTest = false;
     private boolean isLoadingDevice = false;
     private boolean saveListenersAttached = false;
+    // Keep per-device in-memory snapshots while user toggles LambdaTest on/off,
+    // so mode switches do not discard the previously configured capability set.
+    private final Map<String, LinkedProperties> nonLambdaCapsSnapshots = new HashMap<>();
+    private final Map<String, LinkedProperties> lambdaCapsSnapshots = new HashMap<>();
 
     // Holds the unmasked Remote URL for the currently displayed device. The
     // text field shows a masked version (credentials replaced with ****) while
     // this variable preserves the real value for persistence.
     private String actualRemoteUrl = com.ing.datalib.settings.emulators.Device.DEFAULT_REMOTE_URL;
     private boolean isMaskingRemoteUrl = false;
+    private boolean remoteUrlMaskUpdateQueued = false;
 
     private static final Pattern REMOTE_URL_CRED_PATTERN = Pattern.compile(
         "^([a-zA-Z][a-zA-Z0-9+.-]*://)([^:/@\\s]+):([^@/\\s]+)@(.*)$"
@@ -2263,9 +2270,147 @@ public class DriverSettings extends javax.swing.JFrame {
         }
         Matcher m = REMOTE_URL_CRED_PATTERN.matcher(url);
         if (m.matches()) {
-            return m.group(1) + "****:****@" + m.group(4);
+            String maskedUser = maskSameLength(m.group(2));
+            String maskedPassword = maskSameLength(m.group(3));
+            return m.group(1) + maskedUser + ":" + maskedPassword + "@" + m.group(4);
         }
         return url;
+    }
+
+    private static String maskSameLength(String value) {
+        int len = value == null ? 0 : value.length();
+        if (len <= 0) {
+            return "";
+        }
+        StringBuilder masked = new StringBuilder(len);
+        for (int i = 0; i < len; i++) {
+            masked.append('*');
+        }
+        return masked.toString();
+    }
+
+    private static boolean isAllAsterisks(String value, int expectedLength) {
+        if (value == null || value.length() != expectedLength || expectedLength < 0) {
+            return false;
+        }
+        for (int i = 0; i < value.length(); i++) {
+            if (value.charAt(i) != '*') {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static boolean isCaretInOrAdjacentCredentialArea(String url, int caretPosition) {
+        if (url == null) {
+            return false;
+        }
+        Matcher m = REMOTE_URL_CRED_PATTERN.matcher(url);
+        if (!m.matches()) {
+            return false;
+        }
+        int start = Math.max(0, m.group(1).length() - 1);
+        int endExclusive = Math.min(
+            url.length(),
+            m.group(1).length() + m.group(2).length() + 1 + m.group(3).length() + 1
+        );
+        return caretPosition >= start && caretPosition <= endExclusive;
+    }
+
+    private void updateActualRemoteUrlFromVisibleText(String visibleText) {
+        if (visibleText == null) {
+            actualRemoteUrl = "";
+            return;
+        }
+
+        Matcher visibleMatcher = REMOTE_URL_CRED_PATTERN.matcher(visibleText);
+        Matcher actualMatcher = REMOTE_URL_CRED_PATTERN.matcher(actualRemoteUrl);
+
+        if (visibleMatcher.matches() && actualMatcher.matches()) {
+            String visibleUser = visibleMatcher.group(2);
+            String visiblePass = visibleMatcher.group(3);
+            String actualUser = actualMatcher.group(2);
+            String actualPass = actualMatcher.group(3);
+
+            boolean maskedCredentials =
+                isAllAsterisks(visibleUser, actualUser.length()) &&
+                isAllAsterisks(visiblePass, actualPass.length());
+
+            if (maskedCredentials) {
+                actualRemoteUrl =
+                    visibleMatcher.group(1) +
+                    actualUser +
+                    ":" +
+                    actualPass +
+                    "@" +
+                    visibleMatcher.group(4);
+                return;
+            }
+        }
+
+        actualRemoteUrl = visibleText;
+    }
+
+    private void updateRemoteUrlMaskByCaret() {
+        if (deviceRemoteUrlField == null || !deviceRemoteUrlField.isEnabled()) {
+            return;
+        }
+        String visibleText = deviceRemoteUrlField.getText();
+        String maskedActual = maskRemoteUrl(actualRemoteUrl);
+        if (maskedActual == null || maskedActual.equals(actualRemoteUrl)) {
+            return;
+        }
+
+        int caret = deviceRemoteUrlField.getCaretPosition();
+        boolean caretNearCredentials = isCaretInOrAdjacentCredentialArea(visibleText, caret);
+
+        if (maskedActual.equals(visibleText)) {
+            if (!caretNearCredentials) {
+                return;
+            }
+            isMaskingRemoteUrl = true;
+            try {
+                deviceRemoteUrlField.setText(actualRemoteUrl);
+                deviceRemoteUrlField.setCaretPosition(Math.min(caret, actualRemoteUrl.length()));
+            } finally {
+                isMaskingRemoteUrl = false;
+            }
+            return;
+        }
+
+        if (
+            visibleText.equals(actualRemoteUrl) &&
+            !caretNearCredentials &&
+            hasCredentials(visibleText)
+        ) {
+            isMaskingRemoteUrl = true;
+            try {
+                deviceRemoteUrlField.setText(maskedActual);
+                deviceRemoteUrlField.setCaretPosition(Math.min(caret, maskedActual.length()));
+            } finally {
+                isMaskingRemoteUrl = false;
+            }
+        }
+    }
+
+    private void requestRemoteUrlMaskUpdate() {
+        if (remoteUrlMaskUpdateQueued) {
+            return;
+        }
+        remoteUrlMaskUpdateQueued = true;
+        SwingUtilities.invokeLater(
+            () -> {
+                remoteUrlMaskUpdateQueued = false;
+                if (isLoadingDevice || isMaskingRemoteUrl || deviceRemoteUrlField == null) {
+                    return;
+                }
+                if (!deviceRemoteUrlField.hasFocus()) {
+                    syncAndMaskRemoteUrlField();
+                    return;
+                }
+                updateRemoteUrlMaskByCaret();
+            }
+        );
     }
 
     private void setRemoteUrlValue(String url) {
@@ -2546,20 +2691,12 @@ public class DriverSettings extends javax.swing.JFrame {
                             return;
                         }
                         markDirty();
-                        // If credentials are visible in the field (e.g. just pasted or
-                        // typed in full), mask them right away. Defer the mutation so
-                        // we don't modify the document from inside its own listener.
-                        final String text = deviceRemoteUrlField.getText();
-                        if (hasCredentials(text)) {
-                            SwingUtilities.invokeLater(
-                                () -> {
-                                    // Re-check inside the EDT runnable in case the value
-                                    // changed again before we got here.
-                                    if (hasCredentials(deviceRemoteUrlField.getText())) {
-                                        syncAndMaskRemoteUrlField();
-                                    }
-                                }
-                            );
+                        // Keep canonical URL updated while preserving credentials if
+                        // masked placeholders are still present in the visible value.
+                        if (deviceRemoteUrlField.hasFocus()) {
+                            updateActualRemoteUrlFromVisibleText(deviceRemoteUrlField.getText());
+                            // Defer text mutations outside document notification.
+                            requestRemoteUrlMaskUpdate();
                         }
                     }
 
@@ -2579,36 +2716,22 @@ public class DriverSettings extends javax.swing.JFrame {
                     }
                 }
             );
+        // Mask / unmask is driven by caret position.
+        deviceRemoteUrlField.addCaretListener(
+            e -> {
+                if (isLoadingDevice || isMaskingRemoteUrl) {
+                    return;
+                }
+                requestRemoteUrlMaskUpdate();
+            }
+        );
 
-        // When the user focuses the field, reveal the real URL for editing;
-        // when focus is lost, re-mask any credentials.
         deviceRemoteUrlField.addFocusListener(
             new java.awt.event.FocusAdapter() {
 
                 @Override
-                public void focusGained(java.awt.event.FocusEvent e) {
-                    if (!deviceRemoteUrlField.isEnabled()) {
-                        return;
-                    }
-                    String masked = maskRemoteUrl(actualRemoteUrl);
-                    if (
-                        masked != null &&
-                        !masked.equals(actualRemoteUrl) &&
-                        deviceRemoteUrlField.getText().equals(masked)
-                    ) {
-                        isMaskingRemoteUrl = true;
-                        try {
-                            deviceRemoteUrlField.setText(actualRemoteUrl);
-                            deviceRemoteUrlField.selectAll();
-                        } finally {
-                            isMaskingRemoteUrl = false;
-                        }
-                    }
-                }
-
-                @Override
                 public void focusLost(java.awt.event.FocusEvent e) {
-                    syncAndMaskRemoteUrlField();
+                    requestRemoteUrlMaskUpdate();
                 }
             }
         );
@@ -2618,6 +2741,8 @@ public class DriverSettings extends javax.swing.JFrame {
         if (deviceCombo == null) {
             return;
         }
+        nonLambdaCapsSnapshots.clear();
+        lambdaCapsSnapshots.clear();
         List<String> names = new ArrayList<>(settings.getDevices().getDeviceNames());
         deviceCombo.setModel(new DefaultComboBoxModel<>(names.toArray(new String[0])));
         if (!names.isEmpty()) {
@@ -2746,6 +2871,16 @@ public class DriverSettings extends javax.swing.JFrame {
             m.removeElement(oldName);
             m.insertElementAt(newName, idx);
             deviceCombo.setSelectedIndex(idx);
+
+            LinkedProperties nonLambdaSnapshot = nonLambdaCapsSnapshots.remove(oldName);
+            if (nonLambdaSnapshot != null) {
+                nonLambdaCapsSnapshots.put(newName, nonLambdaSnapshot);
+            }
+            LinkedProperties lambdaSnapshot = lambdaCapsSnapshots.remove(oldName);
+            if (lambdaSnapshot != null) {
+                lambdaCapsSnapshots.put(newName, lambdaSnapshot);
+            }
+
             markDirty();
         }
     }
@@ -2757,6 +2892,8 @@ public class DriverSettings extends javax.swing.JFrame {
         String name = deviceCombo.getSelectedItem().toString();
         settings.getDevices().deleteDevice(name);
         settings.getCapabilities().getBrowserCapabilties().remove(name);
+        nonLambdaCapsSnapshots.remove(name);
+        lambdaCapsSnapshots.remove(name);
         deviceCombo.removeItem(name);
         if (deviceCombo.getItemCount() == 0) {
             ((DefaultTableModel) deviceCapTable.getModel()).setRowCount(0);
@@ -2792,8 +2929,10 @@ public class DriverSettings extends javax.swing.JFrame {
         if (saved != null && !saved.isEmpty()) {
             // If LambdaTest, re-display with category headers around recognised keys
             if (d.isLambdaTest()) {
+                lambdaCapsSnapshots.put(name, copyProperties(saved));
                 showLambdaCapsView(saved);
             } else {
+                nonLambdaCapsSnapshots.put(name, copyProperties(saved));
                 showFlatCapsView(saved);
             }
         } else {
@@ -2801,7 +2940,9 @@ public class DriverSettings extends javax.swing.JFrame {
             if (d.isLambdaTest()) {
                 showLambdaCapsView(null);
             } else {
-                showFlatCapsView(settings.getDevices().defaultDeviceCap());
+                LinkedProperties defaults = settings.getDevices().defaultDeviceCap();
+                nonLambdaCapsSnapshots.put(name, copyProperties(defaults));
+                showFlatCapsView(defaults);
             }
         }
     }
@@ -2820,23 +2961,42 @@ public class DriverSettings extends javax.swing.JFrame {
         LinkedProperties current = readActiveCaps();
         boolean enabled = lambdaTestCheckBox.isSelected();
         d.setLambdaTest(enabled);
-        // Preserve whatever the user has already typed in the active view.
         if (enabled) {
-            showLambdaCapsView(current.isEmpty() ? null : current);
-        } else {
-            // Show the simple default set but keep existing values for matching keys
-            LinkedProperties defaults = settings.getDevices().defaultDeviceCap();
-            LinkedProperties merged = new LinkedProperties();
-            for (Object key : defaults.orderedKeys()) {
-                String k = key.toString();
-                merged.setProperty(
-                    k,
-                    Objects.toString(current.containsKey(k) ? current.get(k) : defaults.get(k), "")
-                );
+            // Capture the current non-Lambda set so untoggle restores it exactly.
+            nonLambdaCapsSnapshots.put(name, copyProperties(current));
+
+            LinkedProperties lambdaProps = lambdaCapsSnapshots.get(name);
+            if (lambdaProps != null && !lambdaProps.isEmpty()) {
+                showLambdaCapsView(copyProperties(lambdaProps));
+            } else {
+                // First-time switch: seed Lambda groups from existing values where keys overlap.
+                showLambdaCapsView(current.isEmpty() ? null : current);
             }
-            showFlatCapsView(merged);
+        } else {
+            // Preserve Lambda edits for when user re-enables LambdaTest.
+            lambdaCapsSnapshots.put(name, copyProperties(current));
+
+            LinkedProperties nonLambdaProps = nonLambdaCapsSnapshots.get(name);
+            if (nonLambdaProps != null && !nonLambdaProps.isEmpty()) {
+                showFlatCapsView(copyProperties(nonLambdaProps));
+            } else {
+                LinkedProperties defaults = settings.getDevices().defaultDeviceCap();
+                showFlatCapsView(defaults);
+            }
         }
         markDirty();
+    }
+
+    private LinkedProperties copyProperties(LinkedProperties source) {
+        LinkedProperties copy = new LinkedProperties();
+        if (source == null) {
+            return copy;
+        }
+        for (Object key : source.orderedKeys()) {
+            String k = key.toString();
+            copy.setProperty(k, Objects.toString(source.get(k), ""));
+        }
+        return copy;
     }
 
     /**


### PR DESCRIPTION
- Fixed issue where enabling or disabling the LambdaTest option in the Manange Devices caused the Properties table to display empty entries.
- Corrected Save button behavior that becomes disabled after switching applications using Alt+Tab, despite having unsaved changes.
- Fixed behavior in the LambdaTest Remote URL field where the cursor unexpectedly jumped to the beginning of the text after typing characters beyond the @ symbol.