### PR TITLE
Fix TestCaseTest.testGetLocation on Windows

### DIFF
--- a/Datalib/src/test/java/com/ing/datalib/component/TestCaseTest.java
+++ b/Datalib/src/test/java/com/ing/datalib/component/TestCaseTest.java
@@ -52,10 +52,9 @@ public class TestCaseTest {
 
     @Test
     public void testGetLocation() {
+        String scenarioDir = new File("/tmp/test-project/TestPlan/LoginScenario").getPath();
         assertThat(testCase.getLocation())
-            .isEqualTo(
-                "/tmp/test-project/TestPlan/LoginScenario" + File.separator + "TC_Login.yaml"
-            );
+            .isEqualTo(scenarioDir + File.separator + "TC_Login.yaml");
     }
 
     // ---- toString ----


### PR DESCRIPTION
### Problem

`TestCaseTest.testGetLocation` cannot pass on Windows. The expected value hardcodes a POSIX path prefix and only applies `File.separator` to the final separator:

```java
assertThat(testCase.getLocation())
    .isEqualTo(
        "/tmp/test-project/TestPlan/LoginScenario" + File.separator + "TC_Login.yaml"
    );
```

Running the suite on Windows 11 / JDK 17:

```
[ERROR] com.ing.datalib.component.TestCaseTest.testGetLocation
expected: "/tmp/test-project/TestPlan/LoginScenario\TC_Login.yaml"
but was:  "\tmp\test-project\TestPlan\LoginScenario\TC_Login.yaml"

Tests run: 28, Failures: 1, Errors: 0, Skipped: 0
```

CI runs on `ubuntu-latest`, so the failure isn't visible there — but it makes `mvn clean install` red for anyone building on Windows.

### Cause

`TestCase.getLocation()` normalises the directory through `java.io.File`:

```java
File dir = new File(scenario.getLocation());
...
return dir.getPath() + File.separator + name + fmt.extension();
```

On Windows `new File("/tmp/...").getPath()` converts **every** separator to `\`, so the whole path is backslashed — not just the last segment the test accounted for.

### Fix

Mirror what the production code does instead of assuming the platform separator:

```java
String scenarioDir = new File("/tmp/test-project/TestPlan/LoginScenario").getPath();
assertThat(testCase.getLocation())
    .isEqualTo(scenarioDir + File.separator + "TC_Login.yaml");
```

Test-only change, no production code touched. On Linux `getPath()` is identity for that string, so the assertion is unchanged there.

### Verification

Windows 11, JDK 17.0.19, Maven 3.9.16, on `release/3.1.0` at `15274331`:

| | Result |
|---|---|
| Before | `Tests run: 28, Failures: 1` — `testGetLocation` |
| After | `Tests run: 28, Failures: 0, Errors: 0, Skipped: 0` → `BUILD SUCCESS` |

Command used:

```
mvn -B test -pl Datalib -Dtest=TestCaseTest
```
