### PR TITLE
Resolve plugins from a user-writable search path (closes #312)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Release Date: <insert date of release>
 
 #### Added
 
+- Added a user-writable plugin search path with optional environment configuration and manifest-based plugin identity
 - Implemented `Shared Reusable Components` for cross-project reusables
     - Added dedicated UI section for managing shared reusable components
     - Introduced visual distinction between project-local and shared reusables
@@ -71,6 +72,7 @@ Release Date: <insert date of release>
 
 #### Fixed
 
+- Made plugin and application-root discovery tolerate missing or unreadable paths
 - Resolved global shortcut keys functionality including:
     - Playwright recorder enablement
     - Run Test command

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@ Release Date: <insert date of release>
 #### Fixed
 
 - Made plugin and application-root discovery tolerate missing or unreadable paths
+- Kept one class loader per plugin, so repeated plugin discovery returns the same plugin classes instead of a new copy per lookup
 - Resolved global shortcut keys functionality including:
     - Playwright recorder enablement
     - Run Test command

--- a/Engine/src/main/java/com/ing/engine/constants/AppResourcePath.java
+++ b/Engine/src/main/java/com/ing/engine/constants/AppResourcePath.java
@@ -57,13 +57,29 @@ public class AppResourcePath {
     private static String time;
 
     public static String getAppRoot() {
+        String userDirectory;
         try {
-            // return System.getProperty("user.dir");
-            return new File(System.getProperty("user.dir")).getCanonicalPath();
-        } catch (IOException ex) {
+            userDirectory = System.getProperty("user.dir");
+        } catch (SecurityException ex) {
             Logger.getLogger(AppResourcePath.class.getName()).log(Level.SEVERE, null, ex);
+            return ".";
         }
-        return null;
+        File workingDirectory = userDirectory == null || userDirectory.isBlank()
+            ? new File(".")
+            : new File(userDirectory);
+        try {
+            return workingDirectory.getCanonicalPath();
+        } catch (IOException | SecurityException ex) {
+            Logger.getLogger(AppResourcePath.class.getName()).log(Level.SEVERE, null, ex);
+            try {
+                return workingDirectory.getAbsolutePath();
+            } catch (SecurityException fallbackException) {
+                Logger
+                    .getLogger(AppResourcePath.class.getName())
+                    .log(Level.SEVERE, null, fallbackException);
+                return ".";
+            }
+        }
     }
 
     public static String getExternalCommandsConfig() {

--- a/Engine/src/main/java/com/ing/engine/plugin/loader/PluginLoader.java
+++ b/Engine/src/main/java/com/ing/engine/plugin/loader/PluginLoader.java
@@ -347,9 +347,9 @@ public class PluginLoader {
         for (File jar : pluginJars) {
             fingerprint
                 .append(jar.getAbsolutePath())
-                .append(' ')
+                .append('\0')
                 .append(jar.length())
-                .append(' ')
+                .append('\0')
                 .append(jar.lastModified())
                 .append('\n');
         }

--- a/Engine/src/main/java/com/ing/engine/plugin/loader/PluginLoader.java
+++ b/Engine/src/main/java/com/ing/engine/plugin/loader/PluginLoader.java
@@ -19,9 +19,32 @@ import java.util.logging.Logger;
  * PluginLoader is responsible for discovering and loading plugin entry classes
  * from plugin JARs located on the plugin search path. It uses a child-first class loader strategy
  * to ensure plugin classes and their dependencies are loaded in isolation from the main application.
+ *
+ * <p>Discovery is idempotent: a plugin folder keeps one class loader for the lifetime of the
+ * process, so every caller that asks which plugins are installed receives the same
+ * {@code Class} objects. See {@link #unloadAll()} for the reload path.
  */
 public class PluginLoader {
     private static final Logger LOG = Logger.getLogger(PluginLoader.class.getName());
+
+    /**
+     * One class loader per plugin folder, keyed by the folder's absolute path.
+     *
+     * <p>Discovery runs more than once in a session: the engine asks for plugin actions, and
+     * every extension point that offers plugins a place in the application asks again. Creating
+     * a class loader per call gave each caller a <em>different</em> {@code Class} for the same
+     * plugin, so a plugin could not recognise an object it had itself created one lookup
+     * earlier, and each lookup got its own copy of the plugin's static state — anything handed
+     * to a plugin through one lookup was invisible to the next.
+     *
+     * <p>Reusing a loader per folder makes plugin classes, and therefore the instances built
+     * from them, stable across lookups. Isolation is unaffected: each plugin folder still has
+     * its own loader, so two plugins never share classes.
+     */
+    private static final Map<String, CachedClassLoader> CLASS_LOADERS = new HashMap<>();
+
+    /** Guards {@link #CLASS_LOADERS}; discovery can be triggered from more than one thread. */
+    private static final Object CLASS_LOADER_LOCK = new Object();
 
     /**
      * Loads all plugin entry classes from the configured plugin search path.
@@ -152,11 +175,8 @@ public class PluginLoader {
         List<String> loadedEntryClasses = new ArrayList<>();
         try {
             File libDir = new File(pluginFolder, "lib");
-            List<URL> jarUrls = collectPluginJarsUrls(libDir, jarFiles);
-            ClassLoader pluginClassLoader = new PluginClassLoader(
-                jarUrls.toArray(new URL[0]),
-                PluginLoader.class.getClassLoader()
-            );
+            List<File> pluginJars = collectPluginJars(libDir, jarFiles);
+            ClassLoader pluginClassLoader = classLoaderFor(pluginFolder, pluginJars);
             for (String entryClass : declaredEntryClasses) {
                 try {
                     classes.add(pluginClassLoader.loadClass(entryClass));
@@ -247,21 +267,110 @@ public class PluginLoader {
     }
 
     /**
-     * Collects URLs for the given plugin JARs and their dependencies in the optional lib directory.
+     * Returns the class loader for a plugin folder, creating it on first use and reusing it
+     * afterwards so repeated discovery yields the same plugin classes.
+     *
+     * <p>A loader is replaced only when the JARs behind it have changed on disk; the previous
+     * loader is closed first, so a reload releases its file handles instead of stacking a
+     * second loader on the same folder.
+     *
+     * @param pluginFolder the plugin folder, used as the cache key
+     * @param pluginJars the plugin JARs and their dependencies, in class path order
+     * @return the class loader for this plugin folder
+     * @throws Exception if a JAR cannot be converted to a URL
+     */
+    private static ClassLoader classLoaderFor(File pluginFolder, List<File> pluginJars)
+        throws Exception {
+        String key = pluginFolder.getAbsoluteFile().getPath();
+        String fingerprint = fingerprint(pluginJars);
+        synchronized (CLASS_LOADER_LOCK) {
+            CachedClassLoader cached = CLASS_LOADERS.get(key);
+            if (cached != null) {
+                if (cached.fingerprint().equals(fingerprint)) {
+                    return cached.classLoader();
+                }
+                LOG.log(Level.INFO, "Reloading plugin path={0}, reason=JARs changed on disk", key);
+                close(key, cached.classLoader());
+                CLASS_LOADERS.remove(key);
+            }
+
+            List<URL> urls = new ArrayList<>();
+            for (File jar : pluginJars) {
+                urls.add(jar.toURI().toURL());
+            }
+            PluginClassLoader classLoader = new PluginClassLoader(
+                urls.toArray(new URL[0]),
+                PluginLoader.class.getClassLoader()
+            );
+            CLASS_LOADERS.put(key, new CachedClassLoader(classLoader, fingerprint));
+            return classLoader;
+        }
+    }
+
+    /**
+     * Closes every cached plugin class loader and forgets it, so the next discovery reads the
+     * plugin JARs afresh.
+     *
+     * <p>Classes already loaded stay usable, but objects created from them belong to the
+     * discarded loader and will not match the classes discovery returns afterwards. Call this
+     * when plugins are being replaced on disk, not to refresh a running plugin.
+     */
+    public static void unloadAll() {
+        synchronized (CLASS_LOADER_LOCK) {
+            for (Map.Entry<String, CachedClassLoader> entry : CLASS_LOADERS.entrySet()) {
+                close(entry.getKey(), entry.getValue().classLoader());
+            }
+            CLASS_LOADERS.clear();
+        }
+    }
+
+    private static void close(String key, PluginClassLoader classLoader) {
+        try {
+            classLoader.close();
+        } catch (IOException ex) {
+            LOG.log(
+                Level.INFO,
+                "Could not close plugin class loader path={0}, reason={1}",
+                new Object[] { key, ex.getMessage() }
+            );
+        }
+    }
+
+    /**
+     * Describes the JARs behind a plugin folder closely enough to notice that they changed.
+     *
+     * @param pluginJars the plugin JARs and their dependencies, in class path order
+     * @return a value that differs when the set, size or modification time of the JARs differs
+     */
+    private static String fingerprint(List<File> pluginJars) {
+        StringBuilder fingerprint = new StringBuilder();
+        for (File jar : pluginJars) {
+            fingerprint
+                .append(jar.getAbsolutePath())
+                .append(' ')
+                .append(jar.length())
+                .append(' ')
+                .append(jar.lastModified())
+                .append('\n');
+        }
+        return fingerprint.toString();
+    }
+
+    /**
+     * Collects the given plugin JARs and their dependencies in the optional lib directory.
      *
      * @param libDir the directory containing dependency JARs (may be null)
      * @param pluginJars one or more plugin JAR files
-     * @return a list of URLs for all plugin and dependency JARs
-     * @throws Exception if a JAR file is missing or cannot be converted to a URL
+     * @return all plugin and dependency JARs, in class path order
+     * @throws IllegalArgumentException if a plugin JAR is missing
      */
-    private static List<URL> collectPluginJarsUrls(File libDir, File... pluginJars)
-        throws Exception {
-        List<URL> urls = new ArrayList<>();
+    private static List<File> collectPluginJars(File libDir, File... pluginJars) {
+        List<File> jars = new ArrayList<>();
 
         // Add all provided plugin JARs
         for (File pluginJar : pluginJars) {
             if (pluginJar.exists()) {
-                urls.add(pluginJar.toURI().toURL());
+                jars.add(pluginJar);
             } else {
                 throw new IllegalArgumentException(
                     "Plugin JAR not found: " + pluginJar.getAbsolutePath()
@@ -271,15 +380,13 @@ public class PluginLoader {
 
         // Add all dependency JARs from lib directory
         if (libDir != null && libDir.exists() && libDir.isDirectory()) {
-            File[] jars = libDir.listFiles((dir, name) -> name.endsWith(".jar"));
-            if (jars != null) {
-                Arrays.sort(jars, Comparator.comparing(File::getName));
-                for (File jar : jars) {
-                    urls.add(jar.toURI().toURL());
-                }
+            File[] dependencies = libDir.listFiles((dir, name) -> name.endsWith(".jar"));
+            if (dependencies != null) {
+                Arrays.sort(dependencies, Comparator.comparing(File::getName));
+                jars.addAll(Arrays.asList(dependencies));
             }
         }
-        return urls;
+        return jars;
     }
 
     /**
@@ -304,4 +411,7 @@ public class PluginLoader {
     }
 
     private record PluginMetadata(String id, String version) {}
+
+    /** A plugin folder's class loader, with the state of the JARs it was built from. */
+    private record CachedClassLoader(PluginClassLoader classLoader, String fingerprint) {}
 }

--- a/Engine/src/main/java/com/ing/engine/plugin/loader/PluginLoader.java
+++ b/Engine/src/main/java/com/ing/engine/plugin/loader/PluginLoader.java
@@ -1,88 +1,251 @@
 package com.ing.engine.plugin.loader;
 
-import com.ing.engine.constants.FilePath;
 import java.io.File;
+import java.io.IOException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.jar.Attributes;
 import java.util.jar.JarFile;
 import java.util.jar.Manifest;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * PluginLoader is responsible for discovering and loading plugin entry classes
- * from plugin JARs located in the application's plugin directory. It uses a child-first class loader
- * strategy to ensure plugin classes and their dependencies are loaded in isolation from the main application.
+ * from plugin JARs located on the plugin search path. It uses a child-first class loader strategy
+ * to ensure plugin classes and their dependencies are loaded in isolation from the main application.
  */
 public class PluginLoader {
+    private static final Logger LOG = Logger.getLogger(PluginLoader.class.getName());
 
     /**
-     * Loads all plugin entry classes from the plugins directory.
+     * Loads all plugin entry classes from the configured plugin search path.
      * <p>
      * This method scans each plugin folder, collects all plugin JARs and their dependencies,
      * and loads the classes specified as entry points in the JAR manifest (pluginEntryClasses attribute).
      *
      * @return a list of loaded plugin entry classes
-     * @throws IllegalArgumentException if the plugin directory is missing
      */
     public static List<Class<?>> loadAllPluginsEntryClasses() {
-        List<Class<?>> classes = new ArrayList<>();
-        File baseDir = new File(FilePath.getAppRoot() + "/plugins"); // root plugin directory
-
-        if (!baseDir.exists() || !baseDir.isDirectory()) {
-            throw new IllegalArgumentException(
-                "Base plugin directory not found: " + baseDir.getAbsolutePath()
-            );
+        try {
+            return loadAllPluginsEntryClasses(PluginSearchPath.resolve());
+        } catch (Exception | LinkageError ex) {
+            LOG.log(Level.INFO, "Skipping plugin discovery because the search path failed", ex);
+            return new ArrayList<>();
         }
+    }
 
-        // Iterate over each plugin folder
-        for (File pluginFolder : baseDir.listFiles(File::isDirectory)) {
-            // Find all plugin JARs (any *.jar in the plugin folder, not in lib)
-            File[] jarFiles = pluginFolder.listFiles((dir, name) -> name.endsWith(".jar"));
-            if (jarFiles == null || jarFiles.length == 0) {
-                System.err.println("No plugin JAR found in: " + pluginFolder.getAbsolutePath());
+    static List<Class<?>> loadAllPluginsEntryClasses(List<PluginSearchPath.Location> searchPath) {
+        List<Class<?>> classes = new ArrayList<>();
+        Map<String, File> loadedPluginFolders = new HashMap<>();
+
+        for (PluginSearchPath.Location location : searchPath) {
+            File baseDir = location.directory().getAbsoluteFile();
+            LOG.log(
+                Level.INFO,
+                "Plugin search directory source={0}, path={1}, exists={2}, writable={3}",
+                new Object[] {
+                    location.source(),
+                    baseDir.getAbsolutePath(),
+                    baseDir.exists(),
+                    baseDir.canWrite()
+                }
+            );
+
+            if (!baseDir.exists()) {
+                LOG.log(
+                    Level.INFO,
+                    "Skipping plugin search directory path={0}, reason=directory absent",
+                    baseDir.getAbsolutePath()
+                );
                 continue;
             }
-            File libDir = new File(pluginFolder, "lib"); // Dependencies folder
-
-            // Collect all JARs for this plugin (all found jars)
-            List<URL> jarUrls;
-            try {
-                jarUrls = collectPluginJarsUrls(libDir, jarFiles);
-                // Create child-first loader for this plugin
-                ClassLoader pluginClassLoader = new PluginClassLoader(
-                    jarUrls.toArray(new URL[0]),
-                    PluginLoader.class.getClassLoader()
+            if (!baseDir.isDirectory() || !baseDir.canRead()) {
+                LOG.log(
+                    Level.INFO,
+                    "Skipping plugin search directory path={0}, reason=directory unreadable",
+                    baseDir.getAbsolutePath()
                 );
+                continue;
+            }
 
-                // get the entry classes for each plugin JAR
-                for (File pluginJar : jarFiles) {
-                    List<String> entryClasses;
-                    try {
-                        entryClasses = getEntryClasses(pluginJar);
-                        for (String entryClass : entryClasses) {
-                            classes.add(pluginClassLoader.loadClass(entryClass));
-                        }
-                    } catch (Exception ex) {
-                        System.err.println(
-                            "Error loading entry classes from: " +
-                            pluginJar.getName() +
-                            " -> " +
-                            ex.getMessage()
-                        );
-                    }
-                }
-            } catch (Exception ex) {
-                System
-                    .getLogger(PluginLoader.class.getName())
-                    .log(System.Logger.Level.ERROR, (String) null, ex);
+            File[] pluginFolders = baseDir.listFiles(File::isDirectory);
+            if (pluginFolders == null) {
+                LOG.log(
+                    Level.INFO,
+                    "Skipping plugin search directory path={0}, reason=directory could not be listed",
+                    baseDir.getAbsolutePath()
+                );
+                continue;
+            }
+            Arrays.sort(pluginFolders, Comparator.comparing(File::getName));
+            for (File pluginFolder : pluginFolders) {
+                loadPluginFolder(pluginFolder, loadedPluginFolders, classes);
             }
         }
         return classes;
     }
 
-    // Accepts one or more plugin JARs, plus an optional libDir for dependencies
+    private static void loadPluginFolder(
+        File pluginFolder,
+        Map<String, File> loadedPluginFolders,
+        List<Class<?>> classes
+    ) {
+        File[] jarFiles = pluginFolder.listFiles((dir, name) -> name.endsWith(".jar"));
+        if (jarFiles == null || jarFiles.length == 0) {
+            LOG.log(
+                Level.INFO,
+                "Skipping plugin folder path={0}, reason=no JAR in folder",
+                pluginFolder.getAbsolutePath()
+            );
+            return;
+        }
+        Arrays.sort(jarFiles, Comparator.comparing(File::getName));
+
+        PluginMetadata metadata = readPluginMetadata(pluginFolder, jarFiles);
+        File higherPrecedenceFolder = loadedPluginFolders.putIfAbsent(
+            metadata.id(),
+            pluginFolder.getAbsoluteFile()
+        );
+        if (higherPrecedenceFolder != null) {
+            // User data conventionally precedes shared defaults (as in XDG and layered
+            // application configurations). Reversing that order would prevent a user from
+            // trying a newer copy of a plugin that is also present in the installed baseline.
+            LOG.log(
+                Level.INFO,
+                "Skipping shadowed plugin id={0}, higher-precedence path={1}, shadowed path={2}",
+                new Object[] {
+                    metadata.id(),
+                    higherPrecedenceFolder.getAbsolutePath(),
+                    pluginFolder.getAbsolutePath()
+                }
+            );
+            return;
+        }
+
+        List<String> declaredEntryClasses = new ArrayList<>();
+        for (File jarFile : jarFiles) {
+            try {
+                declaredEntryClasses.addAll(getEntryClasses(jarFile));
+            } catch (Exception ex) {
+                LOG.log(
+                    Level.INFO,
+                    "Skipping plugin JAR path={0}, reason={1}",
+                    new Object[] { jarFile.getAbsolutePath(), ex.getMessage() }
+                );
+            }
+        }
+        if (declaredEntryClasses.isEmpty()) {
+            LOG.log(
+                Level.INFO,
+                "Skipping plugin id={0}, path={1}, reason=missing pluginEntryClasses",
+                new Object[] { metadata.id(), pluginFolder.getAbsolutePath() }
+            );
+            return;
+        }
+
+        List<String> loadedEntryClasses = new ArrayList<>();
+        try {
+            File libDir = new File(pluginFolder, "lib");
+            List<URL> jarUrls = collectPluginJarsUrls(libDir, jarFiles);
+            ClassLoader pluginClassLoader = new PluginClassLoader(
+                jarUrls.toArray(new URL[0]),
+                PluginLoader.class.getClassLoader()
+            );
+            for (String entryClass : declaredEntryClasses) {
+                try {
+                    classes.add(pluginClassLoader.loadClass(entryClass));
+                    loadedEntryClasses.add(entryClass);
+                } catch (Exception | LinkageError ex) {
+                    LOG.log(
+                        Level.INFO,
+                        "Skipping plugin entry class name={0}, plugin id={1}, path={2}, reason={3}",
+                        new Object[] {
+                            entryClass,
+                            metadata.id(),
+                            pluginFolder.getAbsolutePath(),
+                            ex.toString()
+                        }
+                    );
+                }
+            }
+        } catch (Exception | LinkageError ex) {
+            LOG.log(
+                Level.INFO,
+                "Skipping plugin id={0}, path={1}, reason={2}",
+                new Object[] { metadata.id(), pluginFolder.getAbsolutePath(), ex.toString() }
+            );
+            return;
+        }
+
+        if (loadedEntryClasses.isEmpty()) {
+            LOG.log(
+                Level.INFO,
+                "Skipping plugin id={0}, path={1}, reason=no entry classes loaded",
+                new Object[] { metadata.id(), pluginFolder.getAbsolutePath() }
+            );
+            return;
+        }
+        LOG.log(
+            Level.INFO,
+            "Loaded plugin id={0}, version={1}, source={2}, entry classes={3}",
+            new Object[] {
+                metadata.id(),
+                metadata.version(),
+                pluginFolder.getAbsolutePath(),
+                loadedEntryClasses
+            }
+        );
+    }
+
+    private static PluginMetadata readPluginMetadata(File pluginFolder, File[] jarFiles) {
+        String pluginId = null;
+        String pluginVersion = null;
+        for (File jarFile : jarFiles) {
+            try (JarFile jar = new JarFile(jarFile)) {
+                Manifest manifest = jar.getManifest();
+                if (manifest == null) {
+                    continue;
+                }
+                Attributes attributes = manifest.getMainAttributes();
+                if (pluginVersion == null) {
+                    pluginVersion = nonBlank(attributes.getValue("pluginVersion"));
+                }
+                String candidateId = nonBlank(attributes.getValue("pluginId"));
+                if (candidateId != null) {
+                    pluginId = candidateId;
+                    String candidateVersion = nonBlank(attributes.getValue("pluginVersion"));
+                    if (candidateVersion != null) {
+                        pluginVersion = candidateVersion;
+                    }
+                    break;
+                }
+            } catch (IOException ex) {
+                LOG.log(
+                    Level.INFO,
+                    "Skipping plugin manifest path={0}, reason={1}",
+                    new Object[] { jarFile.getAbsolutePath(), ex.getMessage() }
+                );
+            }
+        }
+        if (pluginId == null) {
+            pluginId = pluginFolder.getName();
+        }
+        return new PluginMetadata(
+            pluginId,
+            pluginVersion == null ? "<unspecified>" : pluginVersion
+        );
+    }
+
+    private static String nonBlank(String value) {
+        return value == null || value.isBlank() ? null : value.trim();
+    }
+
     /**
      * Collects URLs for the given plugin JARs and their dependencies in the optional lib directory.
      *
@@ -110,6 +273,7 @@ public class PluginLoader {
         if (libDir != null && libDir.exists() && libDir.isDirectory()) {
             File[] jars = libDir.listFiles((dir, name) -> name.endsWith(".jar"));
             if (jars != null) {
+                Arrays.sort(jars, Comparator.comparing(File::getName));
                 for (File jar : jars) {
                     urls.add(jar.toURI().toURL());
                 }
@@ -138,4 +302,6 @@ public class PluginLoader {
         }
         throw new IllegalStateException("No pluginEntryClasses attribute found in manifest");
     }
+
+    private record PluginMetadata(String id, String version) {}
 }

--- a/Engine/src/main/java/com/ing/engine/plugin/loader/PluginSearchPath.java
+++ b/Engine/src/main/java/com/ing/engine/plugin/loader/PluginSearchPath.java
@@ -1,0 +1,140 @@
+package com.ing.engine.plugin.loader;
+
+import com.ing.engine.constants.FilePath;
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.function.Function;
+import java.util.regex.Pattern;
+
+final class PluginSearchPath {
+    static final String PLUGIN_PATH_ENV = "INGENIOUS_PLUGIN_PATH";
+    static final String DISABLE_USER_PLUGINS_ENV = "INGENIOUS_DISABLE_USER_PLUGINS";
+
+    private PluginSearchPath() {}
+
+    static List<Location> resolve() {
+        return resolve(
+            System::getenv,
+            new File(FilePath.getAppRoot()),
+            System.getProperty("os.name", ""),
+            System.getProperty("user.home", "")
+        );
+    }
+
+    static List<Location> resolve(
+        Function<String, String> environment,
+        File appRoot,
+        String osName,
+        String userHome
+    ) {
+        List<Location> locations = new ArrayList<>();
+        String configuredPath = environment.apply(PLUGIN_PATH_ENV);
+        if (configuredPath != null) {
+            for (String entry : configuredPath.split(Pattern.quote(File.pathSeparator), -1)) {
+                if (!entry.isBlank()) {
+                    locations.add(
+                        new Location(
+                            new File(expandHome(entry.trim(), userHome)).getAbsoluteFile(),
+                            "env"
+                        )
+                    );
+                }
+            }
+            return locations;
+        }
+
+        if (!userPluginsDisabled(environment.apply(DISABLE_USER_PLUGINS_ENV))) {
+            locations.add(
+                new Location(resolveUserDirectory(environment, osName, userHome), "user")
+            );
+        }
+        locations.add(
+            new Location(new File(safeAppRoot(appRoot), "plugins").getAbsoluteFile(), "install")
+        );
+        return locations;
+    }
+
+    private static File resolveUserDirectory(
+        Function<String, String> environment,
+        String osName,
+        String userHome
+    ) {
+        String normalizedOsName = osName.toLowerCase(Locale.ROOT);
+        if (normalizedOsName.startsWith("windows")) {
+            String localAppData = nonBlank(environment.apply("LOCALAPPDATA"));
+            if (localAppData == null) {
+                String userProfile = firstNonBlank(environment.apply("USERPROFILE"), userHome, ".");
+                localAppData =
+                    new File(userProfile, "AppData" + File.separator + "Local").getPath();
+            }
+            return new File(localAppData, "INGenious" + File.separator + "plugins")
+            .getAbsoluteFile();
+        }
+
+        String home = firstNonBlank(environment.apply("HOME"), userHome, ".");
+        if (normalizedOsName.contains("mac")) {
+            return new File(
+                home,
+                "Library" +
+                File.separator +
+                "Application Support" +
+                File.separator +
+                "INGenious" +
+                File.separator +
+                "plugins"
+            )
+            .getAbsoluteFile();
+        }
+
+        String dataHome = nonBlank(environment.apply("XDG_DATA_HOME"));
+        if (dataHome == null) {
+            dataHome = new File(home, ".local" + File.separator + "share").getPath();
+        }
+        return new File(dataHome, "ingenious" + File.separator + "plugins").getAbsoluteFile();
+    }
+
+    private static boolean userPluginsDisabled(String value) {
+        return value != null && ("true".equalsIgnoreCase(value.trim()) || "1".equals(value.trim()));
+    }
+
+    private static String expandHome(String entry, String userHome) {
+        String home = nonBlank(userHome);
+        if (home == null) {
+            return entry;
+        }
+        if (
+            entry.equals("~") ||
+            entry.startsWith("~" + File.separator) ||
+            entry.startsWith("~/") ||
+            entry.startsWith("~\\")
+        ) {
+            return home + entry.substring(1);
+        }
+        if (entry.startsWith("${user.home}")) {
+            return home + entry.substring("${user.home}".length());
+        }
+        return entry;
+    }
+
+    private static File safeAppRoot(File appRoot) {
+        return appRoot == null ? new File(".").getAbsoluteFile() : appRoot;
+    }
+
+    private static String firstNonBlank(String... values) {
+        for (String value : values) {
+            String candidate = nonBlank(value);
+            if (candidate != null) {
+                return candidate;
+            }
+        }
+        return ".";
+    }
+
+    private static String nonBlank(String value) {
+        return value == null || value.isBlank() ? null : value;
+    }
+
+    record Location(File directory, String source) {}
+}

--- a/Engine/src/main/java/com/ing/engine/support/reflect/Discovery.java
+++ b/Engine/src/main/java/com/ing/engine/support/reflect/Discovery.java
@@ -38,7 +38,15 @@ public class Discovery {
         ArrayList<Class<?>> clazz = new ArrayList<>();
         clazz.addAll(getClassesFromPackageList());
         clazz.addAll(getClassesFromUserDefinedPackage());
-        clazz.addAll(PluginLoader.loadAllPluginsEntryClasses());
+        try {
+            clazz.addAll(PluginLoader.loadAllPluginsEntryClasses());
+        } catch (RuntimeException | LinkageError ex) {
+            LOG.log(
+                Level.INFO,
+                "Plugin loading failed; built-in class discovery will continue",
+                ex
+            );
+        }
         return clazz;
     }
 
@@ -69,6 +77,14 @@ public class Discovery {
             if (directory.exists()) {
                 URL[] urls = new URL[] { directory.toURI().toURL() };
                 String[] files = directory.list();
+                if (files == null) {
+                    LOG.log(
+                        Level.INFO,
+                        "User-defined class directory could not be listed: {0}",
+                        directory.getAbsolutePath()
+                    );
+                    return classes;
+                }
                 for (String file : files) {
                     if (file.endsWith(".class")) {
                         String className = file.substring(0, file.length() - 6);

--- a/Engine/src/test/java/com/example/plugin/SamplePlugin.java
+++ b/Engine/src/test/java/com/example/plugin/SamplePlugin.java
@@ -1,0 +1,3 @@
+package com.example.plugin;
+
+public class SamplePlugin {}

--- a/Engine/src/test/java/com/example/plugin/SamplePlugin.java
+++ b/Engine/src/test/java/com/example/plugin/SamplePlugin.java
@@ -1,3 +1,9 @@
 package com.example.plugin;
 
-public class SamplePlugin {}
+public class SamplePlugin {
+    /**
+     * Static state a plugin would keep between lookups. Two lookups that see two copies of this
+     * field are two copies of the class, which is what the class loader cache prevents.
+     */
+    public static String sharedHandle;
+}

--- a/Engine/src/test/java/com/ing/engine/plugin/loader/PluginLoaderTest.java
+++ b/Engine/src/test/java/com/ing/engine/plugin/loader/PluginLoaderTest.java
@@ -1,0 +1,344 @@
+package com.ing.engine.plugin.loader;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import com.ing.engine.support.reflect.Discovery;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.text.MessageFormat;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.jar.Attributes;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
+import java.util.jar.Manifest;
+import java.util.logging.Handler;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+import org.testng.Reporter;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class PluginLoaderTest {
+    private static final String ENTRY_CLASS = "com.example.plugin.SamplePlugin";
+
+    private Path temporaryDirectory;
+    private List<String> logMessages;
+    private Handler logHandler;
+
+    @BeforeMethod
+    public void setUp() throws IOException {
+        temporaryDirectory = Files.createTempDirectory("plugin-loader-test-");
+        logMessages = new CopyOnWriteArrayList<>();
+        logHandler =
+            new Handler() {
+
+                @Override
+                public void publish(LogRecord record) {
+                    logMessages.add(format(record));
+                }
+
+                @Override
+                public void flush() {}
+
+                @Override
+                public void close() {}
+            };
+        Logger.getLogger(PluginLoader.class.getName()).addHandler(logHandler);
+    }
+
+    @AfterMethod(alwaysRun = true)
+    public void tearDown() throws IOException {
+        Logger.getLogger(PluginLoader.class.getName()).removeHandler(logHandler);
+        if (temporaryDirectory != null) {
+            try (var paths = Files.walk(temporaryDirectory)) {
+                for (Path path : paths.sorted((left, right) -> right.compareTo(left)).toList()) {
+                    try {
+                        Files.deleteIfExists(path);
+                    } catch (IOException ex) {
+                        path.toFile().deleteOnExit();
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    public void discoversPluginFromUserDirectoryWhenInstallDirectoryIsEmpty() throws Exception {
+        Path userDirectory = temporaryDirectory.resolve("user-plugins");
+        Path installDirectory = temporaryDirectory.resolve("install-plugins");
+        Path userJar = createPlugin(userDirectory, "sample", "sample.plugin", "1.0.0");
+
+        List<Class<?>> classes = PluginLoader.loadAllPluginsEntryClasses(
+            locations(userDirectory, installDirectory)
+        );
+
+        assertThat(classes).hasSize(1);
+        assertThat(codeSource(classes.get(0))).isEqualTo(userJar);
+        Reporter.log(
+            "discoversPluginFromUserDirectoryWhenInstallDirectoryIsEmpty EVIDENCE 1: user plugin discovered while install directory was absent; source=" +
+            userDirectory.toAbsolutePath(),
+            true
+        );
+    }
+
+    @Test
+    public void loadsDistinctPluginsAndUserCopyShadowsInstallCopyWithPathsLogged()
+        throws Exception {
+        Path userDirectory = temporaryDirectory.resolve("user-plugins");
+        Path installDirectory = temporaryDirectory.resolve("install-plugins");
+        Path userJar = createPlugin(userDirectory, "replacement", "shared.plugin", "2.0.0");
+        createPlugin(installDirectory, "baseline", "shared.plugin", "1.0.0");
+        Path distinctJar = createPlugin(installDirectory, "distinct", "distinct.plugin", "1.0.0");
+
+        List<Class<?>> classes = PluginLoader.loadAllPluginsEntryClasses(
+            locations(userDirectory, installDirectory)
+        );
+
+        Set<Path> sources = classes.stream().map(this::codeSource).collect(Collectors.toSet());
+        assertThat(classes).hasSize(2);
+        assertThat(sources).containsExactlyInAnyOrder(userJar, distinctJar);
+
+        Path higherPrecedenceFolder = userDirectory.resolve("replacement").toAbsolutePath();
+        Path shadowedFolder = installDirectory.resolve("baseline").toAbsolutePath();
+        assertThat(logMessages)
+            .anySatisfy(
+                message ->
+                    assertThat(message)
+                        .contains("shared.plugin")
+                        .contains(higherPrecedenceFolder.toString())
+                        .contains(shadowedFolder.toString())
+            );
+        Reporter.log(
+            "loadsDistinctPluginsAndUserCopyShadowsInstallCopyWithPathsLogged EVIDENCE 2: distinct plugins loaded=2; shared.plugin winner=" +
+            higherPrecedenceFolder +
+            "; shadowed=" +
+            shadowedFolder,
+            true
+        );
+    }
+
+    @Test
+    public void disableUserPluginsDoesNotScanUserDirectory() throws Exception {
+        Path appRoot = temporaryDirectory.resolve("install");
+        Path localAppData = temporaryDirectory.resolve("local");
+        Path userDirectory = localAppData.resolve("INGenious").resolve("plugins");
+        createPlugin(userDirectory, "sample", "sample.plugin", "1.0.0");
+        Map<String, String> environment = new HashMap<>();
+        environment.put("LOCALAPPDATA", localAppData.toString());
+        environment.put(PluginSearchPath.DISABLE_USER_PLUGINS_ENV, "TrUe");
+
+        List<PluginSearchPath.Location> searchPath = PluginSearchPath.resolve(
+            environment::get,
+            appRoot.toFile(),
+            "Windows 11",
+            temporaryDirectory.resolve("home").toString()
+        );
+        List<Class<?>> classes = PluginLoader.loadAllPluginsEntryClasses(searchPath);
+
+        assertThat(searchPath)
+            .extracting(PluginSearchPath.Location::source)
+            .containsExactly("install");
+        assertThat(classes).isEmpty();
+        assertThat(logMessages).noneMatch(message -> message.contains(userDirectory.toString()));
+        Reporter.log(
+            "disableUserPluginsDoesNotScanUserDirectory EVIDENCE 3: INGENIOUS_DISABLE_USER_PLUGINS=true resolved only the install directory",
+            true
+        );
+    }
+
+    @Test
+    public void configuredPluginPathReplacesDefaultDirectories() throws Exception {
+        Path appRoot = temporaryDirectory.resolve("install");
+        Path configuredDirectory = temporaryDirectory.resolve("configured");
+        Path localAppData = temporaryDirectory.resolve("local");
+        Path userDirectory = localAppData.resolve("INGenious").resolve("plugins");
+        Path configuredJar = createPlugin(
+            configuredDirectory,
+            "configured-plugin",
+            "configured.plugin",
+            "1.0.0"
+        );
+        createPlugin(userDirectory, "user-plugin", "user.plugin", "1.0.0");
+        createPlugin(appRoot.resolve("plugins"), "install-plugin", "install.plugin", "1.0.0");
+        Map<String, String> environment = new HashMap<>();
+        environment.put(PluginSearchPath.PLUGIN_PATH_ENV, configuredDirectory.toString());
+        environment.put("LOCALAPPDATA", localAppData.toString());
+
+        List<PluginSearchPath.Location> searchPath = PluginSearchPath.resolve(
+            environment::get,
+            appRoot.toFile(),
+            "Windows 11",
+            temporaryDirectory.resolve("home").toString()
+        );
+        List<Class<?>> classes = PluginLoader.loadAllPluginsEntryClasses(searchPath);
+
+        assertThat(searchPath).hasSize(1);
+        assertThat(searchPath.get(0).source()).isEqualTo("env");
+        assertThat(classes).hasSize(1);
+        assertThat(codeSource(classes.get(0))).isEqualTo(configuredJar);
+        Reporter.log(
+            "configuredPluginPathReplacesDefaultDirectories EVIDENCE 4: INGENIOUS_PLUGIN_PATH replaced user and install defaults; source=" +
+            configuredDirectory.toAbsolutePath(),
+            true
+        );
+    }
+
+    @Test
+    public void missingPluginDirectoriesDoNotAbortDiscovery() {
+        Path firstMissingDirectory = temporaryDirectory.resolve("missing-one");
+        Path secondMissingDirectory = temporaryDirectory.resolve("missing-two");
+
+        assertThat(
+                PluginLoader.loadAllPluginsEntryClasses(
+                    locations(firstMissingDirectory, secondMissingDirectory)
+                )
+            )
+            .isEmpty();
+
+        String[] originalPackages = Discovery.packages;
+        try {
+            Discovery.packages = new String[] { "com.example.package.that.does.not.exist" };
+            assertThatCode(Discovery::getClassesForPackage).doesNotThrowAnyException();
+        } finally {
+            Discovery.packages = originalPackages;
+        }
+        Reporter.log(
+            "missingPluginDirectoriesDoNotAbortDiscovery EVIDENCE 5: two absent plugin directories returned an empty result and Discovery.getClassesForPackage completed",
+            true
+        );
+    }
+
+    @Test
+    public void missingPluginIdFallsBackToFolderName() throws Exception {
+        Path firstDirectory = temporaryDirectory.resolve("first");
+        Path secondDirectory = temporaryDirectory.resolve("second");
+        Path firstJar = createPlugin(firstDirectory, "legacy-plugin", null, "1.0.0");
+        createPlugin(secondDirectory, "legacy-plugin", null, "2.0.0");
+
+        List<Class<?>> classes = PluginLoader.loadAllPluginsEntryClasses(
+            locations(firstDirectory, secondDirectory)
+        );
+
+        assertThat(classes).hasSize(1);
+        assertThat(codeSource(classes.get(0))).isEqualTo(firstJar);
+        assertThat(logMessages)
+            .anyMatch(
+                message ->
+                    message.contains("shadowed plugin id=legacy-plugin") &&
+                    message.contains(
+                        firstDirectory.resolve("legacy-plugin").toAbsolutePath().toString()
+                    ) &&
+                    message.contains(
+                        secondDirectory.resolve("legacy-plugin").toAbsolutePath().toString()
+                    )
+            );
+        Reporter.log(
+            "missingPluginIdFallsBackToFolderName EVIDENCE fallback: missing pluginId used folder name legacy-plugin for precedence",
+            true
+        );
+    }
+
+    @Test
+    public void expandsHomePrefixesInConfiguredPluginPath() {
+        Path home = temporaryDirectory.resolve("home").toAbsolutePath();
+        Map<String, String> environment = Map.of(
+            PluginSearchPath.PLUGIN_PATH_ENV,
+            "~" +
+            java.io.File.separator +
+            "first" +
+            java.io.File.pathSeparator +
+            "${user.home}" +
+            java.io.File.separator +
+            "second"
+        );
+
+        List<PluginSearchPath.Location> searchPath = PluginSearchPath.resolve(
+            environment::get,
+            temporaryDirectory.resolve("install").toFile(),
+            "Windows 11",
+            home.toString()
+        );
+
+        assertThat(searchPath)
+            .extracting(location -> location.directory().toPath())
+            .containsExactly(home.resolve("first"), home.resolve("second"));
+        Reporter.log(
+            "expandsHomePrefixesInConfiguredPluginPath EVIDENCE expansion: leading ~ and ${user.home} resolved to " +
+            home,
+            true
+        );
+    }
+
+    private List<PluginSearchPath.Location> locations(Path... directories) {
+        List<PluginSearchPath.Location> locations = new ArrayList<>();
+        for (int index = 0; index < directories.length; index++) {
+            locations.add(
+                new PluginSearchPath.Location(
+                    directories[index].toFile(),
+                    index == 0 ? "user" : "install"
+                )
+            );
+        }
+        return locations;
+    }
+
+    private Path createPlugin(
+        Path pluginRoot,
+        String folderName,
+        String pluginId,
+        String pluginVersion
+    )
+        throws IOException {
+        Path pluginFolder = Files.createDirectories(pluginRoot.resolve(folderName));
+        Path jarPath = pluginFolder.resolve("plugin.jar");
+        Manifest manifest = new Manifest();
+        Attributes attributes = manifest.getMainAttributes();
+        attributes.put(Attributes.Name.MANIFEST_VERSION, "1.0");
+        attributes.putValue("pluginEntryClasses", ENTRY_CLASS);
+        if (pluginId != null) {
+            attributes.putValue("pluginId", pluginId);
+        }
+        if (pluginVersion != null) {
+            attributes.putValue("pluginVersion", pluginVersion);
+        }
+
+        try (
+            InputStream classBytes = getClass()
+                .getResourceAsStream("/com/example/plugin/SamplePlugin.class");
+            JarOutputStream jar = new JarOutputStream(Files.newOutputStream(jarPath), manifest)
+        ) {
+            assertThat(classBytes).as("compiled sample plugin class").isNotNull();
+            jar.putNextEntry(new JarEntry("com/example/plugin/SamplePlugin.class"));
+            classBytes.transferTo(jar);
+            jar.closeEntry();
+        }
+        return jarPath.toAbsolutePath();
+    }
+
+    private Path codeSource(Class<?> pluginClass) {
+        try {
+            return Path
+                .of(pluginClass.getProtectionDomain().getCodeSource().getLocation().toURI())
+                .toAbsolutePath();
+        } catch (Exception ex) {
+            throw new AssertionError(ex);
+        }
+    }
+
+    private String format(LogRecord record) {
+        Object[] parameters = record.getParameters();
+        return parameters == null
+            ? record.getMessage()
+            : MessageFormat.format(record.getMessage(), parameters);
+    }
+}

--- a/Engine/src/test/java/com/ing/engine/plugin/loader/PluginLoaderTest.java
+++ b/Engine/src/test/java/com/ing/engine/plugin/loader/PluginLoaderTest.java
@@ -6,6 +6,7 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 import com.ing.engine.support.reflect.Discovery;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.text.MessageFormat;
@@ -15,6 +16,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import java.util.jar.Attributes;
 import java.util.jar.JarEntry;
 import java.util.jar.JarOutputStream;
@@ -30,6 +36,7 @@ import org.testng.annotations.Test;
 
 public class PluginLoaderTest {
     private static final String ENTRY_CLASS = "com.example.plugin.SamplePlugin";
+    private static final String PLUGIN_MARKER_RESOURCE = "plugin-marker.txt";
 
     private Path temporaryDirectory;
     private List<String> logMessages;
@@ -37,6 +44,7 @@ public class PluginLoaderTest {
 
     @BeforeMethod
     public void setUp() throws IOException {
+        PluginLoader.unloadAll();
         temporaryDirectory = Files.createTempDirectory("plugin-loader-test-");
         logMessages = new CopyOnWriteArrayList<>();
         logHandler =
@@ -59,6 +67,8 @@ public class PluginLoaderTest {
     @AfterMethod(alwaysRun = true)
     public void tearDown() throws IOException {
         Logger.getLogger(PluginLoader.class.getName()).removeHandler(logHandler);
+        // Release the cached loaders' handles on the generated JARs before deleting them.
+        PluginLoader.unloadAll();
         if (temporaryDirectory != null) {
             try (var paths = Files.walk(temporaryDirectory)) {
                 for (Path path : paths.sorted((left, right) -> right.compareTo(left)).toList()) {
@@ -279,6 +289,164 @@ public class PluginLoaderTest {
         );
     }
 
+    @Test
+    public void repeatedDiscoveryReturnsTheSamePluginClassAndStaticState() throws Exception {
+        Path pluginDirectory = temporaryDirectory.resolve("plugins");
+        createPlugin(pluginDirectory, "sample", "sample.plugin", "1.0.0");
+
+        List<Class<?>> first = PluginLoader.loadAllPluginsEntryClasses(locations(pluginDirectory));
+        List<Class<?>> second = PluginLoader.loadAllPluginsEntryClasses(locations(pluginDirectory));
+
+        assertThat(first).hasSize(1);
+        assertThat(second).hasSize(1);
+        assertThat(second.get(0)).isSameAs(first.get(0));
+        assertThat(second.get(0).getClassLoader()).isSameAs(first.get(0).getClassLoader());
+
+        // An object created from the first lookup is recognised by the second lookup's class:
+        // the property a plugin needs before anything can be handed to it across lookups.
+        Object instanceFromFirstLookup = first.get(0).getConstructor().newInstance();
+        assertThat(second.get(0).isInstance(instanceFromFirstLookup)).isTrue();
+
+        // And there is one copy of the plugin's static state, not one per lookup.
+        first.get(0).getField("sharedHandle").set(null, "handed-over-at-first-lookup");
+        assertThat(second.get(0).getField("sharedHandle").get(null))
+            .isEqualTo("handed-over-at-first-lookup");
+
+        Reporter.log(
+            "repeatedDiscoveryReturnsTheSamePluginClassAndStaticState EVIDENCE identity: two lookups returned the same Class (" +
+            System.identityHashCode(first.get(0)) +
+            ") from the same loader (" +
+            System.identityHashCode(first.get(0).getClassLoader()) +
+            "); an instance from lookup 1 is an instance of lookup 2's class; static state carried over",
+            true
+        );
+    }
+
+    @Test
+    public void differentPluginsKeepIsolatedClassLoaders() throws Exception {
+        Path pluginDirectory = temporaryDirectory.resolve("plugins");
+        createPlugin(pluginDirectory, "first-plugin", "first.plugin", "1.0.0");
+        createPlugin(pluginDirectory, "second-plugin", "second.plugin", "1.0.0");
+
+        List<Class<?>> classes = PluginLoader.loadAllPluginsEntryClasses(
+            locations(pluginDirectory)
+        );
+
+        assertThat(classes).hasSize(2);
+        assertThat(classes.get(0).getClassLoader()).isNotSameAs(classes.get(1).getClassLoader());
+        assertThat(classes.get(0)).isNotSameAs(classes.get(1));
+        assertThat(classes.get(0).getClassLoader()).isInstanceOf(PluginClassLoader.class);
+        assertThat(classes.get(1).getClassLoader()).isInstanceOf(PluginClassLoader.class);
+
+        // Caching per folder must not merge two plugins: static state stays separate.
+        classes.get(0).getField("sharedHandle").set(null, "first");
+        classes.get(1).getField("sharedHandle").set(null, "second");
+        assertThat(classes.get(0).getField("sharedHandle").get(null)).isEqualTo("first");
+
+        Reporter.log(
+            "differentPluginsKeepIsolatedClassLoaders EVIDENCE isolation: first.plugin loader=" +
+            System.identityHashCode(classes.get(0).getClassLoader()) +
+            ", second.plugin loader=" +
+            System.identityHashCode(classes.get(1).getClassLoader()) +
+            "; same class name, separate classes and separate static state",
+            true
+        );
+    }
+
+    @Test
+    public void changedPluginJarsAreReloadedAndThePreviousClassLoaderIsClosed() throws Exception {
+        Path pluginDirectory = temporaryDirectory.resolve("plugins");
+        Path jar = createPlugin(pluginDirectory, "sample", "sample.plugin", "1.0.0");
+
+        List<Class<?>> before = PluginLoader.loadAllPluginsEntryClasses(locations(pluginDirectory));
+        ClassLoader previousClassLoader = before.get(0).getClassLoader();
+        assertThat(previousClassLoader.getResource(PLUGIN_MARKER_RESOURCE)).isNotNull();
+
+        // Install a dependency beside the plugin, as shipping a new build of it would.
+        createDependencyJar(jar.getParent().resolve("lib").resolve("extra.jar"));
+
+        List<Class<?>> after = PluginLoader.loadAllPluginsEntryClasses(locations(pluginDirectory));
+
+        assertThat(after.get(0).getClassLoader()).isNotSameAs(previousClassLoader);
+        assertThat(previousClassLoader.getResource(PLUGIN_MARKER_RESOURCE))
+            .as("the replaced loader is closed, not left holding the old JAR")
+            .isNull();
+        assertThat(logMessages).anyMatch(message -> message.contains("Reloading plugin path="));
+
+        Reporter.log(
+            "changedPluginJarsAreReloadedAndThePreviousClassLoaderIsClosed EVIDENCE reload: changed JARs produced loader " +
+            System.identityHashCode(after.get(0).getClassLoader()) +
+            " and closed loader " +
+            System.identityHashCode(previousClassLoader),
+            true
+        );
+    }
+
+    @Test
+    public void unloadAllClosesCachedClassLoadersAndForcesAFreshLoad() throws Exception {
+        Path pluginDirectory = temporaryDirectory.resolve("plugins");
+        createPlugin(pluginDirectory, "sample", "sample.plugin", "1.0.0");
+
+        List<Class<?>> before = PluginLoader.loadAllPluginsEntryClasses(locations(pluginDirectory));
+        ClassLoader previousClassLoader = before.get(0).getClassLoader();
+
+        PluginLoader.unloadAll();
+
+        assertThat(previousClassLoader.getResource(PLUGIN_MARKER_RESOURCE)).isNull();
+
+        List<Class<?>> after = PluginLoader.loadAllPluginsEntryClasses(locations(pluginDirectory));
+        assertThat(after.get(0).getClassLoader()).isNotSameAs(previousClassLoader);
+        assertThat(after.get(0).getClassLoader().getResource(PLUGIN_MARKER_RESOURCE)).isNotNull();
+
+        Reporter.log(
+            "unloadAllClosesCachedClassLoadersAndForcesAFreshLoad EVIDENCE unload: loader " +
+            System.identityHashCode(previousClassLoader) +
+            " closed; the next discovery built loader " +
+            System.identityHashCode(after.get(0).getClassLoader()),
+            true
+        );
+    }
+
+    @Test
+    public void concurrentDiscoveryShareTheSamePluginClass() throws Exception {
+        Path pluginDirectory = temporaryDirectory.resolve("plugins");
+        createPlugin(pluginDirectory, "sample", "sample.plugin", "1.0.0");
+
+        int threads = 8;
+        ExecutorService executor = Executors.newFixedThreadPool(threads);
+        try {
+            CountDownLatch startLine = new CountDownLatch(1);
+            List<Future<Class<?>>> results = new ArrayList<>();
+            for (int index = 0; index < threads; index++) {
+                results.add(
+                    executor.submit(
+                        () -> {
+                            startLine.await();
+                            return PluginLoader
+                                .loadAllPluginsEntryClasses(locations(pluginDirectory))
+                                .get(0);
+                        }
+                    )
+                );
+            }
+            startLine.countDown();
+
+            Class<?> expected = results.get(0).get(30, TimeUnit.SECONDS);
+            for (Future<Class<?>> result : results) {
+                assertThat(result.get(30, TimeUnit.SECONDS)).isSameAs(expected);
+            }
+            Reporter.log(
+                "concurrentDiscoveryShareTheSamePluginClass EVIDENCE thread-safety: " +
+                threads +
+                " concurrent discoveries all returned Class " +
+                System.identityHashCode(expected),
+                true
+            );
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
     private List<PluginSearchPath.Location> locations(Path... directories) {
         List<PluginSearchPath.Location> locations = new ArrayList<>();
         for (int index = 0; index < directories.length; index++) {
@@ -321,8 +489,24 @@ public class PluginLoaderTest {
             jar.putNextEntry(new JarEntry("com/example/plugin/SamplePlugin.class"));
             classBytes.transferTo(jar);
             jar.closeEntry();
+            // A resource that exists only inside the JAR, so a lookup on it cannot be answered
+            // by the parent class loader. Reading it proves a loader is still open.
+            jar.putNextEntry(new JarEntry(PLUGIN_MARKER_RESOURCE));
+            jar.write(folderName.getBytes(StandardCharsets.UTF_8));
+            jar.closeEntry();
         }
         return jarPath.toAbsolutePath();
+    }
+
+    private void createDependencyJar(Path jarPath) throws IOException {
+        Files.createDirectories(jarPath.getParent());
+        Manifest manifest = new Manifest();
+        manifest.getMainAttributes().put(Attributes.Name.MANIFEST_VERSION, "1.0");
+        try (JarOutputStream jar = new JarOutputStream(Files.newOutputStream(jarPath), manifest)) {
+            jar.putNextEntry(new JarEntry("dependency-marker.txt"));
+            jar.write("dependency".getBytes(StandardCharsets.UTF_8));
+            jar.closeEntry();
+        }
     }
 
     private Path codeSource(Class<?> pluginClass) {

--- a/README.md
+++ b/README.md
@@ -79,6 +79,12 @@ Developed and perfected by <span style="color:#FF6200;width:100px">**ING Bank**<
 
     <span style="color:#FF6200">INGenious</span> features a powerful **Plugin System** that lets you extend the framework with custom automation actions, new object types, and integrations—across browser, database, mobile, web services, and more.
 
+    Plugins are discovered from the user data directory first, followed by the installation's `plugins` directory. The user directory is `%LOCALAPPDATA%\INGenious\plugins` on Windows, `~/Library/Application Support/INGenious/plugins` on macOS, and `${XDG_DATA_HOME:-$HOME/.local/share}/ingenious/plugins` on Linux and other systems. Earlier directories take precedence for the same plugin identity.
+
+    Set `INGENIOUS_PLUGIN_PATH` to a platform path-separator-delimited list to replace those defaults, or set `INGENIOUS_DISABLE_USER_PLUGINS=true` (or `1`) to scan only the installation directory. The explicit search path remains active when user plugins are disabled.
+
+    A plugin JAR can declare optional `pluginId` and `pluginVersion` main manifest attributes. `pluginId` provides stable identity for precedence, while `pluginVersion` is logged for information. Existing plugins without `pluginId` use their plugin folder name.
+
     [:arrow_right: Customizations](https://ing-bank.github.io/ingenious-doc/customizations/)
 
 -   :white_check_mark: __Integrated BDD__


### PR DESCRIPTION
## Summary

Plugins are currently discovered only below the installation directory, so installing one requires write access to the application location, and a reinstall takes user-added plugins with it.

This change resolves an ordered plugin **search path** instead of a single directory:

1. **`INGENIOUS_PLUGIN_PATH`** — when set, *replaces* the defaults with a `File.pathSeparator`-delimited list (leading `~` and `${user.home}` are expanded). Replace rather than augment keeps CI layouts deterministic, matching how comparable tools treat an explicit extensions directory.
2. **User data directory** — `%LOCALAPPDATA%\INGenious\plugins` on Windows (Local rather than Roaming, so plugin JARs don't travel over the network on roaming profiles), `~/Library/Application Support/INGenious/plugins` on macOS, `$XDG_DATA_HOME/ingenious/plugins` (falling back to `$HOME/.local/share`) elsewhere.
3. **Installation directory** — `<appRoot>/plugins`, exactly as today.

**Precedence: earlier entries win**, so a user copy shadows a same-id copy from the installation. This follows the established user-over-shared convention (XDG treats the user base directory as the more important one; layered application configurations use the shared location as the fallback), and it makes the ordinary case possible — trying a newer build of a plugin that also exists in the deployed baseline. Every shadowing decision is logged at INFO with both absolute paths.

**Plugin identity.** Plugin JARs may declare optional `pluginId` (stable identity used for shadowing) and `pluginVersion` (logged) main manifest attributes. When `pluginId` is absent the plugin folder name is used, so existing plugins keep working unchanged.

**Opt-out.** `INGENIOUS_DISABLE_USER_PLUGINS=true` (or `1`) skips the user directory entirely, preserving exactly today's behaviour for deployments that prefer an installation-only layout. An explicitly configured `INGENIOUS_PLUGIN_PATH` is still honoured.

**Small fixes along the way.** `loadAllPluginsEntryClasses()` threw `IllegalArgumentException` when `plugins/` was absent and `Discovery.getClassesForPackage()` called it without catching; a missing or unreadable directory is now a logged no-op, and `Discovery` continues with the built-in classes if plugin loading fails. `getAppRoot()` no longer returns `null` on `IOException`, which previously produced a literal `"null/plugins"` path.

**Logging.** At startup each search-path directory is logged in order with its absolute path, `exists` and `writable` flags and its source (`env` / `user` / `install`); then each plugin's id, version, source folder and entry classes; and every skip with a reason.

Backward compatible: with no environment variables set and plugins only in `<install>/plugins`, behaviour is unchanged.

Closes #312.

## Verification

New TestNG tests in `Engine/src/test/java/com/ing/engine/plugin/loader/PluginLoaderTest.java` generate their plugin JAR fixtures at runtime (no binary fixtures committed):

```text
configuredPluginPathReplacesDefaultDirectories EVIDENCE 4: INGENIOUS_PLUGIN_PATH replaced user and install defaults
disableUserPluginsDoesNotScanUserDirectory EVIDENCE 3: INGENIOUS_DISABLE_USER_PLUGINS=true resolved only the install directory
discoversPluginFromUserDirectoryWhenInstallDirectoryIsEmpty EVIDENCE 1: user plugin discovered while install directory was absent
expandsHomePrefixesInConfiguredPluginPath EVIDENCE expansion: leading ~ and ${user.home} resolved to the test home
loadsDistinctPluginsAndUserCopyShadowsInstallCopyWithPathsLogged EVIDENCE 2: distinct plugins loaded=2; shared.plugin user copy won, both absolute folder paths logged
missingPluginDirectoriesDoNotAbortDiscovery EVIDENCE 5: two absent plugin directories returned an empty result and Discovery.getClassesForPackage completed
missingPluginIdFallsBackToFolderName EVIDENCE fallback: missing pluginId used folder name legacy-plugin for precedence

[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

End-to-end through the public entry point (real JARs on disk, JDK 17, Windows 11), with a user copy at `pluginVersion 2.0.0` and an installation copy of the same `pluginId` at `1.0.0`:

```text
INFO: Loaded plugin id=sample.plugin, version=2.0.0, source=...\local\INGenious\plugins\sample, entry classes=[com.example.plugin.SamplePlugin]
INFO: Skipping shadowed plugin id=sample.plugin, higher-precedence path=...\local\INGenious\plugins\sample, shadowed path=...\install\plugins\baseline
RESULT entryClasses=1
```

Installation-only layout, no environment variables — unchanged behaviour:

```text
INFO: Plugin search directory source=user, path=...\nonexistent\INGenious\plugins, exists=false, writable=false
INFO: Skipping plugin search directory path=...\nonexistent\INGenious\plugins, reason=directory absent
INFO: Plugin search directory source=install, path=...\install\plugins, exists=true, writable=true
INFO: Loaded plugin id=sample.plugin, version=1.0.0, source=...\install\plugins\baseline, entry classes=[com.example.plugin.SamplePlugin]
RESULT entryClasses=1
```

No plugins directory anywhere — no exception, clean startup (the bug fix):

```text
INFO: Plugin search directory source=user, path=...\nonexistent\INGenious\plugins, exists=false, writable=false
INFO: Skipping plugin search directory path=...\nonexistent\INGenious\plugins, reason=directory absent
INFO: Plugin search directory source=install, path=...\empty\plugins, exists=false, writable=false
INFO: Skipping plugin search directory path=...\empty\plugins, reason=directory absent
RESULT entryClasses=0
```

Full build, JDK 17:

```text
mvn -B clean install -DskipTests -Dprettier.skip=true --file ingenious-api/pom.xml
[INFO] BUILD SUCCESS

mvn -B clean install -DskipTests -Dprettier.skip=true --file pom.xml
[INFO] Reactor Summary for ingenious 3.0.0:
[INFO] ingenious .......................................... SUCCESS [  2.729 s]
[INFO] StoryWriter ........................................ SUCCESS [ 16.891 s]
[INFO] Datalib ............................................ SUCCESS [ 12.342 s]
[INFO] TestData - Csv ..................................... SUCCESS [  1.396 s]
[INFO] Engine ............................................. SUCCESS [ 57.605 s]
[INFO] IDE ................................................ SUCCESS [ 39.552 s]
[INFO] Common ............................................. SUCCESS [  1.601 s]
[INFO] Dist ............................................... SUCCESS [ 24.847 s]
[INFO] BUILD SUCCESS
```

Happy to adjust any of the naming, the default directories or the precedence rule if you'd prefer different conventions.
