### PR TITLE
Declare Studio plugin panels in JAR metadata and load them lazily

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Release Date: <insert date of release>
 #### Added
 
 - Added a user-writable plugin search path with optional environment configuration and manifest-based plugin identity
+- Let a plugin read and write a test case's test data in the open project, so a plugin screen can record what it decided where the project keeps it
 - Implemented `Shared Reusable Components` for cross-project reusables
     - Added dedicated UI section for managing shared reusable components
     - Introduced visual distinction between project-local and shared reusables

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ Release Date: <insert date of release>
 #### Added
 
 - Added a user-writable plugin search path with optional environment configuration and manifest-based plugin identity
+- Let a plugin contribute its own screen to Studio, shown beside Test Design and the API Workbench instead of in a separate companion application
+    - Introduced the `StudioPanelApi` contract, implemented on a plugin entry class and discovered at startup like any other plugin
+    - Read the panel's title, tooltip, order and surface from the JAR manifest, so a screen can be placed on the toolbar without instantiating the plugin
+    - Built the screen on first activation only, and kept a panel that fails to build from disturbing the rest of the toolbar
+- Let a plugin say which test case a recording belongs to, so a user who already chose one elsewhere is not asked a second time
+    - Introduced the `RecordingTargetApi` contract, asked before Studio's own recording target chooser opens
+    - Created the scenario and test case named by the plugin when they do not exist yet, and opened the test case in the editor
+    - Allowed a target to name the page the recording starts on, falling back to the project's recorder setting when it does not
 - Let a plugin read and write a test case's test data in the open project, so a plugin screen can record what it decided where the project keeps it
 - Implemented `Shared Reusable Components` for cross-project reusables
     - Added dedicated UI section for managing shared reusable components

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Release Date: <insert date of release>
 
 #### Added
 
+- Added a user-writable plugin search path with optional environment configuration and manifest-based plugin identity
 - Implemented `Shared Reusable Components` for cross-project reusables
     - Added dedicated UI section for managing shared reusable components
     - Introduced visual distinction between project-local and shared reusables
@@ -71,6 +72,7 @@ Release Date: <insert date of release>
 
 #### Fixed
 
+- Made plugin and application-root discovery tolerate missing or unreadable paths
 - Resolved global shortcut keys functionality including:
     - Playwright recorder enablement
     - Run Test command

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@ Release Date: <insert date of release>
 #### Fixed
 
 - Made plugin and application-root discovery tolerate missing or unreadable paths
+- Kept one class loader per plugin, so repeated plugin discovery returns the same plugin classes instead of a new copy per lookup
 - Resolved global shortcut keys functionality including:
     - Playwright recorder enablement
     - Run Test command

--- a/Datalib/src/main/java/com/ing/datalib/plugin/ProjectTestData.java
+++ b/Datalib/src/main/java/com/ing/datalib/plugin/ProjectTestData.java
@@ -1,0 +1,158 @@
+package com.ing.datalib.plugin;
+
+import com.ing.datalib.component.Project;
+import com.ing.datalib.component.TestData;
+import com.ing.datalib.testdata.model.Record;
+import com.ing.datalib.testdata.model.TestDataModel;
+import com.ing.datalib.testdata.view.TestDataView;
+import com.ing.ingenious.api.contract.data.ProjectTestDataApi;
+import com.ing.ingenious.api.contract.data.TestDataViewApi;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Supplier;
+
+/**
+ * {@link ProjectTestDataApi} over the test data of whichever project is open.
+ *
+ * <p>The project is read through a supplier rather than held, because the application replaces
+ * its project object when the user opens another one. A plugin therefore keeps one of these for
+ * as long as it lives and always reaches the project in front of the user.
+ *
+ * <p>Only the default environment is offered. An environment is a deployment of the system
+ * under test; which one a run uses is chosen at run time, so a design-time decision recorded
+ * per environment would be a decision the user never made.
+ */
+public final class ProjectTestData implements ProjectTestDataApi {
+    private final Supplier<Project> project;
+
+    /**
+     * @param project supplies the open project, or {@code null} when none is open
+     */
+    public ProjectTestData(Supplier<Project> project) {
+        this.project = project;
+    }
+
+    @Override
+    public List<String> sheets() {
+        TestData testData = testData();
+        if (testData == null) {
+            return Collections.emptyList();
+        }
+        return new ArrayList<>(testData.getTestDataNames());
+    }
+
+    @Override
+    public boolean addSheet(String sheet) {
+        TestData testData = testData();
+        if (testData == null || isBlank(sheet)) {
+            return false;
+        }
+        if (testData.getByName(sheet) != null) {
+            return true;
+        }
+        return testData.addTestData(testData.getNewTestData(sheet)) != null;
+    }
+
+    @Override
+    public boolean addColumn(String sheet, String column) {
+        TestDataModel model = model(sheet);
+        if (model == null || isBlank(column)) {
+            return false;
+        }
+        // Existing records grow a cell for the new column, so load them before adding it.
+        model.loadTableModel();
+        if (model.hasColumn(column)) {
+            return true;
+        }
+        return Boolean.TRUE.equals(model.addColumn(column));
+    }
+
+    @Override
+    public TestDataViewApi testCase(String sheet, String scenario, String testCase) {
+        TestDataModel model = model(sheet);
+        if (model == null || isBlank(scenario) || isBlank(testCase)) {
+            return null;
+        }
+        model.loadTableModel();
+        TestDataView view = find(model, scenario, testCase);
+        if (view.get().isEmpty()) {
+            addRecord(model, scenario, testCase);
+            view = find(model, scenario, testCase);
+        }
+        return view;
+    }
+
+    @Override
+    public boolean save(String sheet) {
+        TestDataModel model = model(sheet);
+        if (model == null) {
+            return false;
+        }
+        // Records reached through a view are updated in place, which leaves the model looking
+        // saved. Asking for a write here has to produce one.
+        model.setSaved(false);
+        model.save();
+        return true;
+    }
+
+    /**
+     * The records of one test case.
+     *
+     * <p>A view indexes the records it found and answers from that index next time. Clearing it
+     * first is what makes a lookup after a write see the records as they now are.
+     */
+    private TestDataView find(TestDataModel model, String scenario, String testCase) {
+        TestDataView view = model.view();
+        view.clear();
+        return view.withTestcase(quote(scenario), quote(testCase));
+    }
+
+    /**
+     * Gives a test case its first record.
+     *
+     * <p>Written through the model rather than the view: the record is addressed by column
+     * name, so a sheet whose leading columns have been migrated still gets the scenario and
+     * test case in the right cells.
+     */
+    private void addRecord(TestDataModel model, String scenario, String testCase) {
+        int row = model.getRowCount();
+        model.addRecord();
+        setCell(model, row, Record.HEADERS[0], scenario);
+        setCell(model, row, Record.HEADERS[1], testCase);
+        setCell(model, row, Record.HEADERS[3], "1");
+        setCell(model, row, Record.HEADERS[4], "1");
+    }
+
+    private void setCell(TestDataModel model, int row, String column, String value) {
+        int index = model.getColumnIndex(column);
+        if (index >= 0) {
+            model.setValueAt(value, row, index);
+        }
+    }
+
+    private TestDataModel model(String sheet) {
+        TestData testData = testData();
+        if (testData == null || isBlank(sheet)) {
+            return null;
+        }
+        return testData.getByName(sheet);
+    }
+
+    private TestData testData() {
+        Project open = project.get();
+        return open == null || open.getTestData() == null ? null : open.getTestData().defData();
+    }
+
+    /**
+     * A view matches scenario and test case as regular expressions, which is what lets callers
+     * pass a wildcard. A name is not a pattern, so it is quoted before it is used as one.
+     */
+    private String quote(String name) {
+        return java.util.regex.Pattern.quote(name);
+    }
+
+    private boolean isBlank(String value) {
+        return value == null || value.trim().isEmpty();
+    }
+}

--- a/Datalib/src/main/java/com/ing/datalib/settings/ProjectSettings.java
+++ b/Datalib/src/main/java/com/ing/datalib/settings/ProjectSettings.java
@@ -27,6 +27,7 @@ public class ProjectSettings {
     private final ExecutionSettings execSettings;
     private final DBProperties dbSettings;
     private final ContextOptions contextSettings;
+    private final RecorderSettings recorderSettings;
     private final KafkaSSLConfigurations SSLConfigurations;
     private final LambdaTestCaps lambdaTestCaps;
 
@@ -49,6 +50,7 @@ public class ProjectSettings {
         this.rpSettings = new ReportPortalSettings(getLocation());
         this.extentSettings = new ExtentReportSettings(getLocation());
         this.contextSettings = new ContextOptions(getLocation());
+        this.recorderSettings = new RecorderSettings(getLocation());
         this.SSLConfigurations = new KafkaSSLConfigurations(getLocation());
         this.lambdaTestCaps = new LambdaTestCaps(getLocation());
 
@@ -120,6 +122,15 @@ public class ProjectSettings {
 
     public KafkaSSLConfigurations getKafkaSSLConfigurations() {
         return SSLConfigurations;
+    }
+
+    /**
+     * Recorder settings for this project, such as the page a recording starts on.
+     *
+     * @return the recorder settings, never {@code null}
+     */
+    public RecorderSettings getRecorderSettings() {
+        return recorderSettings;
     }
 
     public ContextOptions getContextSettings() {

--- a/Datalib/src/main/java/com/ing/datalib/settings/RecorderSettings.java
+++ b/Datalib/src/main/java/com/ing/datalib/settings/RecorderSettings.java
@@ -1,0 +1,37 @@
+package com.ing.datalib.settings;
+
+/**
+ * Project-level settings for the recorder.
+ *
+ * <p>Today the recorder opens a blank page and every recording starts by typing the
+ * application's address by hand. A project is written against one application, so the address
+ * belongs to the project, not to the person recording.
+ *
+ * <p>Empty is the default and stays valid: a project that sets nothing behaves exactly as it
+ * did before.
+ */
+public class RecorderSettings extends AbstractPropSettings {
+    private static final String START_URL = "StartUrl";
+
+    public RecorderSettings(String location) {
+        super(location, "RecorderSettings");
+    }
+
+    /**
+     * The page the recorder opens when a recording starts.
+     *
+     * @return the URL, or an empty string when the project has not set one
+     */
+    public String getStartUrl() {
+        return getProperty(START_URL, "").trim();
+    }
+
+    /**
+     * Sets the page the recorder opens.
+     *
+     * @param value the URL; {@code null} or blank clears it
+     */
+    public void setStartUrl(String value) {
+        setProperty(START_URL, value == null ? "" : value.trim());
+    }
+}

--- a/Engine/src/main/java/com/ing/engine/constants/AppResourcePath.java
+++ b/Engine/src/main/java/com/ing/engine/constants/AppResourcePath.java
@@ -57,13 +57,29 @@ public class AppResourcePath {
     private static String time;
 
     public static String getAppRoot() {
+        String userDirectory;
         try {
-            // return System.getProperty("user.dir");
-            return new File(System.getProperty("user.dir")).getCanonicalPath();
-        } catch (IOException ex) {
+            userDirectory = System.getProperty("user.dir");
+        } catch (SecurityException ex) {
             Logger.getLogger(AppResourcePath.class.getName()).log(Level.SEVERE, null, ex);
+            return ".";
         }
-        return null;
+        File workingDirectory = userDirectory == null || userDirectory.isBlank()
+            ? new File(".")
+            : new File(userDirectory);
+        try {
+            return workingDirectory.getCanonicalPath();
+        } catch (IOException | SecurityException ex) {
+            Logger.getLogger(AppResourcePath.class.getName()).log(Level.SEVERE, null, ex);
+            try {
+                return workingDirectory.getAbsolutePath();
+            } catch (SecurityException fallbackException) {
+                Logger
+                    .getLogger(AppResourcePath.class.getName())
+                    .log(Level.SEVERE, null, fallbackException);
+                return ".";
+            }
+        }
     }
 
     public static String getExternalCommandsConfig() {

--- a/Engine/src/main/java/com/ing/engine/plugin/loader/PluginLoader.java
+++ b/Engine/src/main/java/com/ing/engine/plugin/loader/PluginLoader.java
@@ -347,9 +347,9 @@ public class PluginLoader {
         for (File jar : pluginJars) {
             fingerprint
                 .append(jar.getAbsolutePath())
-                .append(' ')
+                .append('\0')
                 .append(jar.length())
-                .append(' ')
+                .append('\0')
                 .append(jar.lastModified())
                 .append('\n');
         }

--- a/Engine/src/main/java/com/ing/engine/plugin/loader/PluginLoader.java
+++ b/Engine/src/main/java/com/ing/engine/plugin/loader/PluginLoader.java
@@ -19,9 +19,32 @@ import java.util.logging.Logger;
  * PluginLoader is responsible for discovering and loading plugin entry classes
  * from plugin JARs located on the plugin search path. It uses a child-first class loader strategy
  * to ensure plugin classes and their dependencies are loaded in isolation from the main application.
+ *
+ * <p>Discovery is idempotent: a plugin folder keeps one class loader for the lifetime of the
+ * process, so every caller that asks which plugins are installed receives the same
+ * {@code Class} objects. See {@link #unloadAll()} for the reload path.
  */
 public class PluginLoader {
     private static final Logger LOG = Logger.getLogger(PluginLoader.class.getName());
+
+    /**
+     * One class loader per plugin folder, keyed by the folder's absolute path.
+     *
+     * <p>Discovery runs more than once in a session: the engine asks for plugin actions, and
+     * every extension point that offers plugins a place in the application asks again. Creating
+     * a class loader per call gave each caller a <em>different</em> {@code Class} for the same
+     * plugin, so a plugin could not recognise an object it had itself created one lookup
+     * earlier, and each lookup got its own copy of the plugin's static state — anything handed
+     * to a plugin through one lookup was invisible to the next.
+     *
+     * <p>Reusing a loader per folder makes plugin classes, and therefore the instances built
+     * from them, stable across lookups. Isolation is unaffected: each plugin folder still has
+     * its own loader, so two plugins never share classes.
+     */
+    private static final Map<String, CachedClassLoader> CLASS_LOADERS = new HashMap<>();
+
+    /** Guards {@link #CLASS_LOADERS}; discovery can be triggered from more than one thread. */
+    private static final Object CLASS_LOADER_LOCK = new Object();
 
     /**
      * Loads all plugin entry classes from the configured plugin search path.
@@ -152,11 +175,8 @@ public class PluginLoader {
         List<String> loadedEntryClasses = new ArrayList<>();
         try {
             File libDir = new File(pluginFolder, "lib");
-            List<URL> jarUrls = collectPluginJarsUrls(libDir, jarFiles);
-            ClassLoader pluginClassLoader = new PluginClassLoader(
-                jarUrls.toArray(new URL[0]),
-                PluginLoader.class.getClassLoader()
-            );
+            List<File> pluginJars = collectPluginJars(libDir, jarFiles);
+            ClassLoader pluginClassLoader = classLoaderFor(pluginFolder, pluginJars);
             for (String entryClass : declaredEntryClasses) {
                 try {
                     classes.add(pluginClassLoader.loadClass(entryClass));
@@ -247,21 +267,110 @@ public class PluginLoader {
     }
 
     /**
-     * Collects URLs for the given plugin JARs and their dependencies in the optional lib directory.
+     * Returns the class loader for a plugin folder, creating it on first use and reusing it
+     * afterwards so repeated discovery yields the same plugin classes.
+     *
+     * <p>A loader is replaced only when the JARs behind it have changed on disk; the previous
+     * loader is closed first, so a reload releases its file handles instead of stacking a
+     * second loader on the same folder.
+     *
+     * @param pluginFolder the plugin folder, used as the cache key
+     * @param pluginJars the plugin JARs and their dependencies, in class path order
+     * @return the class loader for this plugin folder
+     * @throws Exception if a JAR cannot be converted to a URL
+     */
+    private static ClassLoader classLoaderFor(File pluginFolder, List<File> pluginJars)
+        throws Exception {
+        String key = pluginFolder.getAbsoluteFile().getPath();
+        String fingerprint = fingerprint(pluginJars);
+        synchronized (CLASS_LOADER_LOCK) {
+            CachedClassLoader cached = CLASS_LOADERS.get(key);
+            if (cached != null) {
+                if (cached.fingerprint().equals(fingerprint)) {
+                    return cached.classLoader();
+                }
+                LOG.log(Level.INFO, "Reloading plugin path={0}, reason=JARs changed on disk", key);
+                close(key, cached.classLoader());
+                CLASS_LOADERS.remove(key);
+            }
+
+            List<URL> urls = new ArrayList<>();
+            for (File jar : pluginJars) {
+                urls.add(jar.toURI().toURL());
+            }
+            PluginClassLoader classLoader = new PluginClassLoader(
+                urls.toArray(new URL[0]),
+                PluginLoader.class.getClassLoader()
+            );
+            CLASS_LOADERS.put(key, new CachedClassLoader(classLoader, fingerprint));
+            return classLoader;
+        }
+    }
+
+    /**
+     * Closes every cached plugin class loader and forgets it, so the next discovery reads the
+     * plugin JARs afresh.
+     *
+     * <p>Classes already loaded stay usable, but objects created from them belong to the
+     * discarded loader and will not match the classes discovery returns afterwards. Call this
+     * when plugins are being replaced on disk, not to refresh a running plugin.
+     */
+    public static void unloadAll() {
+        synchronized (CLASS_LOADER_LOCK) {
+            for (Map.Entry<String, CachedClassLoader> entry : CLASS_LOADERS.entrySet()) {
+                close(entry.getKey(), entry.getValue().classLoader());
+            }
+            CLASS_LOADERS.clear();
+        }
+    }
+
+    private static void close(String key, PluginClassLoader classLoader) {
+        try {
+            classLoader.close();
+        } catch (IOException ex) {
+            LOG.log(
+                Level.INFO,
+                "Could not close plugin class loader path={0}, reason={1}",
+                new Object[] { key, ex.getMessage() }
+            );
+        }
+    }
+
+    /**
+     * Describes the JARs behind a plugin folder closely enough to notice that they changed.
+     *
+     * @param pluginJars the plugin JARs and their dependencies, in class path order
+     * @return a value that differs when the set, size or modification time of the JARs differs
+     */
+    private static String fingerprint(List<File> pluginJars) {
+        StringBuilder fingerprint = new StringBuilder();
+        for (File jar : pluginJars) {
+            fingerprint
+                .append(jar.getAbsolutePath())
+                .append(' ')
+                .append(jar.length())
+                .append(' ')
+                .append(jar.lastModified())
+                .append('\n');
+        }
+        return fingerprint.toString();
+    }
+
+    /**
+     * Collects the given plugin JARs and their dependencies in the optional lib directory.
      *
      * @param libDir the directory containing dependency JARs (may be null)
      * @param pluginJars one or more plugin JAR files
-     * @return a list of URLs for all plugin and dependency JARs
-     * @throws Exception if a JAR file is missing or cannot be converted to a URL
+     * @return all plugin and dependency JARs, in class path order
+     * @throws IllegalArgumentException if a plugin JAR is missing
      */
-    private static List<URL> collectPluginJarsUrls(File libDir, File... pluginJars)
-        throws Exception {
-        List<URL> urls = new ArrayList<>();
+    private static List<File> collectPluginJars(File libDir, File... pluginJars) {
+        List<File> jars = new ArrayList<>();
 
         // Add all provided plugin JARs
         for (File pluginJar : pluginJars) {
             if (pluginJar.exists()) {
-                urls.add(pluginJar.toURI().toURL());
+                jars.add(pluginJar);
             } else {
                 throw new IllegalArgumentException(
                     "Plugin JAR not found: " + pluginJar.getAbsolutePath()
@@ -271,15 +380,13 @@ public class PluginLoader {
 
         // Add all dependency JARs from lib directory
         if (libDir != null && libDir.exists() && libDir.isDirectory()) {
-            File[] jars = libDir.listFiles((dir, name) -> name.endsWith(".jar"));
-            if (jars != null) {
-                Arrays.sort(jars, Comparator.comparing(File::getName));
-                for (File jar : jars) {
-                    urls.add(jar.toURI().toURL());
-                }
+            File[] dependencies = libDir.listFiles((dir, name) -> name.endsWith(".jar"));
+            if (dependencies != null) {
+                Arrays.sort(dependencies, Comparator.comparing(File::getName));
+                jars.addAll(Arrays.asList(dependencies));
             }
         }
-        return urls;
+        return jars;
     }
 
     /**
@@ -304,4 +411,7 @@ public class PluginLoader {
     }
 
     private record PluginMetadata(String id, String version) {}
+
+    /** A plugin folder's class loader, with the state of the JARs it was built from. */
+    private record CachedClassLoader(PluginClassLoader classLoader, String fingerprint) {}
 }

--- a/Engine/src/main/java/com/ing/engine/plugin/loader/PluginLoader.java
+++ b/Engine/src/main/java/com/ing/engine/plugin/loader/PluginLoader.java
@@ -1,88 +1,251 @@
 package com.ing.engine.plugin.loader;
 
-import com.ing.engine.constants.FilePath;
 import java.io.File;
+import java.io.IOException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.jar.Attributes;
 import java.util.jar.JarFile;
 import java.util.jar.Manifest;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * PluginLoader is responsible for discovering and loading plugin entry classes
- * from plugin JARs located in the application's plugin directory. It uses a child-first class loader
- * strategy to ensure plugin classes and their dependencies are loaded in isolation from the main application.
+ * from plugin JARs located on the plugin search path. It uses a child-first class loader strategy
+ * to ensure plugin classes and their dependencies are loaded in isolation from the main application.
  */
 public class PluginLoader {
+    private static final Logger LOG = Logger.getLogger(PluginLoader.class.getName());
 
     /**
-     * Loads all plugin entry classes from the plugins directory.
+     * Loads all plugin entry classes from the configured plugin search path.
      * <p>
      * This method scans each plugin folder, collects all plugin JARs and their dependencies,
      * and loads the classes specified as entry points in the JAR manifest (pluginEntryClasses attribute).
      *
      * @return a list of loaded plugin entry classes
-     * @throws IllegalArgumentException if the plugin directory is missing
      */
     public static List<Class<?>> loadAllPluginsEntryClasses() {
-        List<Class<?>> classes = new ArrayList<>();
-        File baseDir = new File(FilePath.getAppRoot() + "/plugins"); // root plugin directory
-
-        if (!baseDir.exists() || !baseDir.isDirectory()) {
-            throw new IllegalArgumentException(
-                "Base plugin directory not found: " + baseDir.getAbsolutePath()
-            );
+        try {
+            return loadAllPluginsEntryClasses(PluginSearchPath.resolve());
+        } catch (Exception | LinkageError ex) {
+            LOG.log(Level.INFO, "Skipping plugin discovery because the search path failed", ex);
+            return new ArrayList<>();
         }
+    }
 
-        // Iterate over each plugin folder
-        for (File pluginFolder : baseDir.listFiles(File::isDirectory)) {
-            // Find all plugin JARs (any *.jar in the plugin folder, not in lib)
-            File[] jarFiles = pluginFolder.listFiles((dir, name) -> name.endsWith(".jar"));
-            if (jarFiles == null || jarFiles.length == 0) {
-                System.err.println("No plugin JAR found in: " + pluginFolder.getAbsolutePath());
+    static List<Class<?>> loadAllPluginsEntryClasses(List<PluginSearchPath.Location> searchPath) {
+        List<Class<?>> classes = new ArrayList<>();
+        Map<String, File> loadedPluginFolders = new HashMap<>();
+
+        for (PluginSearchPath.Location location : searchPath) {
+            File baseDir = location.directory().getAbsoluteFile();
+            LOG.log(
+                Level.INFO,
+                "Plugin search directory source={0}, path={1}, exists={2}, writable={3}",
+                new Object[] {
+                    location.source(),
+                    baseDir.getAbsolutePath(),
+                    baseDir.exists(),
+                    baseDir.canWrite()
+                }
+            );
+
+            if (!baseDir.exists()) {
+                LOG.log(
+                    Level.INFO,
+                    "Skipping plugin search directory path={0}, reason=directory absent",
+                    baseDir.getAbsolutePath()
+                );
                 continue;
             }
-            File libDir = new File(pluginFolder, "lib"); // Dependencies folder
-
-            // Collect all JARs for this plugin (all found jars)
-            List<URL> jarUrls;
-            try {
-                jarUrls = collectPluginJarsUrls(libDir, jarFiles);
-                // Create child-first loader for this plugin
-                ClassLoader pluginClassLoader = new PluginClassLoader(
-                    jarUrls.toArray(new URL[0]),
-                    PluginLoader.class.getClassLoader()
+            if (!baseDir.isDirectory() || !baseDir.canRead()) {
+                LOG.log(
+                    Level.INFO,
+                    "Skipping plugin search directory path={0}, reason=directory unreadable",
+                    baseDir.getAbsolutePath()
                 );
+                continue;
+            }
 
-                // get the entry classes for each plugin JAR
-                for (File pluginJar : jarFiles) {
-                    List<String> entryClasses;
-                    try {
-                        entryClasses = getEntryClasses(pluginJar);
-                        for (String entryClass : entryClasses) {
-                            classes.add(pluginClassLoader.loadClass(entryClass));
-                        }
-                    } catch (Exception ex) {
-                        System.err.println(
-                            "Error loading entry classes from: " +
-                            pluginJar.getName() +
-                            " -> " +
-                            ex.getMessage()
-                        );
-                    }
-                }
-            } catch (Exception ex) {
-                System
-                    .getLogger(PluginLoader.class.getName())
-                    .log(System.Logger.Level.ERROR, (String) null, ex);
+            File[] pluginFolders = baseDir.listFiles(File::isDirectory);
+            if (pluginFolders == null) {
+                LOG.log(
+                    Level.INFO,
+                    "Skipping plugin search directory path={0}, reason=directory could not be listed",
+                    baseDir.getAbsolutePath()
+                );
+                continue;
+            }
+            Arrays.sort(pluginFolders, Comparator.comparing(File::getName));
+            for (File pluginFolder : pluginFolders) {
+                loadPluginFolder(pluginFolder, loadedPluginFolders, classes);
             }
         }
         return classes;
     }
 
-    // Accepts one or more plugin JARs, plus an optional libDir for dependencies
+    private static void loadPluginFolder(
+        File pluginFolder,
+        Map<String, File> loadedPluginFolders,
+        List<Class<?>> classes
+    ) {
+        File[] jarFiles = pluginFolder.listFiles((dir, name) -> name.endsWith(".jar"));
+        if (jarFiles == null || jarFiles.length == 0) {
+            LOG.log(
+                Level.INFO,
+                "Skipping plugin folder path={0}, reason=no JAR in folder",
+                pluginFolder.getAbsolutePath()
+            );
+            return;
+        }
+        Arrays.sort(jarFiles, Comparator.comparing(File::getName));
+
+        PluginMetadata metadata = readPluginMetadata(pluginFolder, jarFiles);
+        File higherPrecedenceFolder = loadedPluginFolders.putIfAbsent(
+            metadata.id(),
+            pluginFolder.getAbsoluteFile()
+        );
+        if (higherPrecedenceFolder != null) {
+            // User data conventionally precedes shared defaults (as in XDG and layered
+            // application configurations). Reversing that order would prevent a user from
+            // trying a newer copy of a plugin that is also present in the installed baseline.
+            LOG.log(
+                Level.INFO,
+                "Skipping shadowed plugin id={0}, higher-precedence path={1}, shadowed path={2}",
+                new Object[] {
+                    metadata.id(),
+                    higherPrecedenceFolder.getAbsolutePath(),
+                    pluginFolder.getAbsolutePath()
+                }
+            );
+            return;
+        }
+
+        List<String> declaredEntryClasses = new ArrayList<>();
+        for (File jarFile : jarFiles) {
+            try {
+                declaredEntryClasses.addAll(getEntryClasses(jarFile));
+            } catch (Exception ex) {
+                LOG.log(
+                    Level.INFO,
+                    "Skipping plugin JAR path={0}, reason={1}",
+                    new Object[] { jarFile.getAbsolutePath(), ex.getMessage() }
+                );
+            }
+        }
+        if (declaredEntryClasses.isEmpty()) {
+            LOG.log(
+                Level.INFO,
+                "Skipping plugin id={0}, path={1}, reason=missing pluginEntryClasses",
+                new Object[] { metadata.id(), pluginFolder.getAbsolutePath() }
+            );
+            return;
+        }
+
+        List<String> loadedEntryClasses = new ArrayList<>();
+        try {
+            File libDir = new File(pluginFolder, "lib");
+            List<URL> jarUrls = collectPluginJarsUrls(libDir, jarFiles);
+            ClassLoader pluginClassLoader = new PluginClassLoader(
+                jarUrls.toArray(new URL[0]),
+                PluginLoader.class.getClassLoader()
+            );
+            for (String entryClass : declaredEntryClasses) {
+                try {
+                    classes.add(pluginClassLoader.loadClass(entryClass));
+                    loadedEntryClasses.add(entryClass);
+                } catch (Exception | LinkageError ex) {
+                    LOG.log(
+                        Level.INFO,
+                        "Skipping plugin entry class name={0}, plugin id={1}, path={2}, reason={3}",
+                        new Object[] {
+                            entryClass,
+                            metadata.id(),
+                            pluginFolder.getAbsolutePath(),
+                            ex.toString()
+                        }
+                    );
+                }
+            }
+        } catch (Exception | LinkageError ex) {
+            LOG.log(
+                Level.INFO,
+                "Skipping plugin id={0}, path={1}, reason={2}",
+                new Object[] { metadata.id(), pluginFolder.getAbsolutePath(), ex.toString() }
+            );
+            return;
+        }
+
+        if (loadedEntryClasses.isEmpty()) {
+            LOG.log(
+                Level.INFO,
+                "Skipping plugin id={0}, path={1}, reason=no entry classes loaded",
+                new Object[] { metadata.id(), pluginFolder.getAbsolutePath() }
+            );
+            return;
+        }
+        LOG.log(
+            Level.INFO,
+            "Loaded plugin id={0}, version={1}, source={2}, entry classes={3}",
+            new Object[] {
+                metadata.id(),
+                metadata.version(),
+                pluginFolder.getAbsolutePath(),
+                loadedEntryClasses
+            }
+        );
+    }
+
+    private static PluginMetadata readPluginMetadata(File pluginFolder, File[] jarFiles) {
+        String pluginId = null;
+        String pluginVersion = null;
+        for (File jarFile : jarFiles) {
+            try (JarFile jar = new JarFile(jarFile)) {
+                Manifest manifest = jar.getManifest();
+                if (manifest == null) {
+                    continue;
+                }
+                Attributes attributes = manifest.getMainAttributes();
+                if (pluginVersion == null) {
+                    pluginVersion = nonBlank(attributes.getValue("pluginVersion"));
+                }
+                String candidateId = nonBlank(attributes.getValue("pluginId"));
+                if (candidateId != null) {
+                    pluginId = candidateId;
+                    String candidateVersion = nonBlank(attributes.getValue("pluginVersion"));
+                    if (candidateVersion != null) {
+                        pluginVersion = candidateVersion;
+                    }
+                    break;
+                }
+            } catch (IOException ex) {
+                LOG.log(
+                    Level.INFO,
+                    "Skipping plugin manifest path={0}, reason={1}",
+                    new Object[] { jarFile.getAbsolutePath(), ex.getMessage() }
+                );
+            }
+        }
+        if (pluginId == null) {
+            pluginId = pluginFolder.getName();
+        }
+        return new PluginMetadata(
+            pluginId,
+            pluginVersion == null ? "<unspecified>" : pluginVersion
+        );
+    }
+
+    private static String nonBlank(String value) {
+        return value == null || value.isBlank() ? null : value.trim();
+    }
+
     /**
      * Collects URLs for the given plugin JARs and their dependencies in the optional lib directory.
      *
@@ -110,6 +273,7 @@ public class PluginLoader {
         if (libDir != null && libDir.exists() && libDir.isDirectory()) {
             File[] jars = libDir.listFiles((dir, name) -> name.endsWith(".jar"));
             if (jars != null) {
+                Arrays.sort(jars, Comparator.comparing(File::getName));
                 for (File jar : jars) {
                     urls.add(jar.toURI().toURL());
                 }
@@ -138,4 +302,6 @@ public class PluginLoader {
         }
         throw new IllegalStateException("No pluginEntryClasses attribute found in manifest");
     }
+
+    private record PluginMetadata(String id, String version) {}
 }

--- a/Engine/src/main/java/com/ing/engine/plugin/loader/PluginSearchPath.java
+++ b/Engine/src/main/java/com/ing/engine/plugin/loader/PluginSearchPath.java
@@ -1,0 +1,140 @@
+package com.ing.engine.plugin.loader;
+
+import com.ing.engine.constants.FilePath;
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.function.Function;
+import java.util.regex.Pattern;
+
+final class PluginSearchPath {
+    static final String PLUGIN_PATH_ENV = "INGENIOUS_PLUGIN_PATH";
+    static final String DISABLE_USER_PLUGINS_ENV = "INGENIOUS_DISABLE_USER_PLUGINS";
+
+    private PluginSearchPath() {}
+
+    static List<Location> resolve() {
+        return resolve(
+            System::getenv,
+            new File(FilePath.getAppRoot()),
+            System.getProperty("os.name", ""),
+            System.getProperty("user.home", "")
+        );
+    }
+
+    static List<Location> resolve(
+        Function<String, String> environment,
+        File appRoot,
+        String osName,
+        String userHome
+    ) {
+        List<Location> locations = new ArrayList<>();
+        String configuredPath = environment.apply(PLUGIN_PATH_ENV);
+        if (configuredPath != null) {
+            for (String entry : configuredPath.split(Pattern.quote(File.pathSeparator), -1)) {
+                if (!entry.isBlank()) {
+                    locations.add(
+                        new Location(
+                            new File(expandHome(entry.trim(), userHome)).getAbsoluteFile(),
+                            "env"
+                        )
+                    );
+                }
+            }
+            return locations;
+        }
+
+        if (!userPluginsDisabled(environment.apply(DISABLE_USER_PLUGINS_ENV))) {
+            locations.add(
+                new Location(resolveUserDirectory(environment, osName, userHome), "user")
+            );
+        }
+        locations.add(
+            new Location(new File(safeAppRoot(appRoot), "plugins").getAbsoluteFile(), "install")
+        );
+        return locations;
+    }
+
+    private static File resolveUserDirectory(
+        Function<String, String> environment,
+        String osName,
+        String userHome
+    ) {
+        String normalizedOsName = osName.toLowerCase(Locale.ROOT);
+        if (normalizedOsName.startsWith("windows")) {
+            String localAppData = nonBlank(environment.apply("LOCALAPPDATA"));
+            if (localAppData == null) {
+                String userProfile = firstNonBlank(environment.apply("USERPROFILE"), userHome, ".");
+                localAppData =
+                    new File(userProfile, "AppData" + File.separator + "Local").getPath();
+            }
+            return new File(localAppData, "INGenious" + File.separator + "plugins")
+            .getAbsoluteFile();
+        }
+
+        String home = firstNonBlank(environment.apply("HOME"), userHome, ".");
+        if (normalizedOsName.contains("mac")) {
+            return new File(
+                home,
+                "Library" +
+                File.separator +
+                "Application Support" +
+                File.separator +
+                "INGenious" +
+                File.separator +
+                "plugins"
+            )
+            .getAbsoluteFile();
+        }
+
+        String dataHome = nonBlank(environment.apply("XDG_DATA_HOME"));
+        if (dataHome == null) {
+            dataHome = new File(home, ".local" + File.separator + "share").getPath();
+        }
+        return new File(dataHome, "ingenious" + File.separator + "plugins").getAbsoluteFile();
+    }
+
+    private static boolean userPluginsDisabled(String value) {
+        return value != null && ("true".equalsIgnoreCase(value.trim()) || "1".equals(value.trim()));
+    }
+
+    private static String expandHome(String entry, String userHome) {
+        String home = nonBlank(userHome);
+        if (home == null) {
+            return entry;
+        }
+        if (
+            entry.equals("~") ||
+            entry.startsWith("~" + File.separator) ||
+            entry.startsWith("~/") ||
+            entry.startsWith("~\\")
+        ) {
+            return home + entry.substring(1);
+        }
+        if (entry.startsWith("${user.home}")) {
+            return home + entry.substring("${user.home}".length());
+        }
+        return entry;
+    }
+
+    private static File safeAppRoot(File appRoot) {
+        return appRoot == null ? new File(".").getAbsoluteFile() : appRoot;
+    }
+
+    private static String firstNonBlank(String... values) {
+        for (String value : values) {
+            String candidate = nonBlank(value);
+            if (candidate != null) {
+                return candidate;
+            }
+        }
+        return ".";
+    }
+
+    private static String nonBlank(String value) {
+        return value == null || value.isBlank() ? null : value;
+    }
+
+    record Location(File directory, String source) {}
+}

--- a/Engine/src/main/java/com/ing/engine/support/reflect/Discovery.java
+++ b/Engine/src/main/java/com/ing/engine/support/reflect/Discovery.java
@@ -38,7 +38,15 @@ public class Discovery {
         ArrayList<Class<?>> clazz = new ArrayList<>();
         clazz.addAll(getClassesFromPackageList());
         clazz.addAll(getClassesFromUserDefinedPackage());
-        clazz.addAll(PluginLoader.loadAllPluginsEntryClasses());
+        try {
+            clazz.addAll(PluginLoader.loadAllPluginsEntryClasses());
+        } catch (RuntimeException | LinkageError ex) {
+            LOG.log(
+                Level.INFO,
+                "Plugin loading failed; built-in class discovery will continue",
+                ex
+            );
+        }
         return clazz;
     }
 
@@ -69,6 +77,14 @@ public class Discovery {
             if (directory.exists()) {
                 URL[] urls = new URL[] { directory.toURI().toURL() };
                 String[] files = directory.list();
+                if (files == null) {
+                    LOG.log(
+                        Level.INFO,
+                        "User-defined class directory could not be listed: {0}",
+                        directory.getAbsolutePath()
+                    );
+                    return classes;
+                }
                 for (String file : files) {
                     if (file.endsWith(".class")) {
                         String className = file.substring(0, file.length() - 6);

--- a/Engine/src/test/java/com/example/plugin/SamplePlugin.java
+++ b/Engine/src/test/java/com/example/plugin/SamplePlugin.java
@@ -1,0 +1,3 @@
+package com.example.plugin;
+
+public class SamplePlugin {}

--- a/Engine/src/test/java/com/example/plugin/SamplePlugin.java
+++ b/Engine/src/test/java/com/example/plugin/SamplePlugin.java
@@ -1,3 +1,9 @@
 package com.example.plugin;
 
-public class SamplePlugin {}
+public class SamplePlugin {
+    /**
+     * Static state a plugin would keep between lookups. Two lookups that see two copies of this
+     * field are two copies of the class, which is what the class loader cache prevents.
+     */
+    public static String sharedHandle;
+}

--- a/Engine/src/test/java/com/ing/datalib/plugin/ProjectTestDataTest.java
+++ b/Engine/src/test/java/com/ing/datalib/plugin/ProjectTestDataTest.java
@@ -1,0 +1,172 @@
+package com.ing.datalib.plugin;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.ing.datalib.component.Project;
+import com.ing.datalib.testdata.TestDataFactory;
+import com.ing.ingenious.api.contract.data.TestDataViewApi;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import org.testng.Reporter;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+/**
+ * Exercises {@link ProjectTestData} against a real project on disk.
+ *
+ * <p>The class under test lives in Datalib, but the test lives here: reading and writing test
+ * data needs a test data provider, and the CSV provider is first on the class path in this
+ * module. A test in Datalib could only use a stand-in, which would prove nothing about whether
+ * a decision survives being written to a file and read back.
+ */
+public class ProjectTestDataTest {
+    private static final String SHEET = "Customers";
+    private static final String SCENARIO = "NewScenario";
+    private static final String TEST_CASE = "NewTestCase";
+
+    private Path temporaryDirectory;
+
+    @BeforeMethod
+    public void setUp() throws IOException {
+        // Without this the CSV provider is not discovered and the Project constructor throws.
+        TestDataFactory.load();
+        temporaryDirectory = Files.createTempDirectory("project-test-data-");
+    }
+
+    @AfterMethod(alwaysRun = true)
+    public void tearDown() throws IOException {
+        if (temporaryDirectory == null) {
+            return;
+        }
+        try (var paths = Files.walk(temporaryDirectory)) {
+            for (Path path : paths.sorted((left, right) -> right.compareTo(left)).toList()) {
+                try {
+                    Files.deleteIfExists(path);
+                } catch (IOException ex) {
+                    path.toFile().deleteOnExit();
+                }
+            }
+        }
+    }
+
+    @Test
+    public void writtenTestCaseDataSurvivesReopeningTheProject() throws Exception {
+        Project project = newProject();
+        ProjectTestData testData = new ProjectTestData(() -> project);
+
+        assertThat(testData.addSheet(SHEET)).isTrue();
+        assertThat(testData.sheets()).contains(SHEET);
+        assertThat(testData.addColumn(SHEET, "Segment")).isTrue();
+        assertThat(testData.addColumn(SHEET, "Region")).isTrue();
+
+        TestDataViewApi view = testData.testCase(SHEET, SCENARIO, TEST_CASE);
+        assertThat(view).isNotNull();
+        assertThat(view.update("Segment", "business")).isTrue();
+        assertThat(view.update("Region", "north")).isTrue();
+        assertThat(testData.save(SHEET)).isTrue();
+        project.save();
+
+        File sheetFile = new File(
+            project.getLocation(),
+            "TestData" + File.separator + SHEET + ".csv"
+        );
+        assertThat(sheetFile).exists();
+        String written = Files.readString(sheetFile.toPath());
+
+        // Reopen the project the way the application does, from the directory alone.
+        Project reopened = new Project(project.getLocation());
+        ProjectTestData reread = new ProjectTestData(() -> reopened);
+
+        assertThat(reread.sheets()).contains(SHEET);
+        TestDataViewApi back = reread.testCase(SHEET, SCENARIO, TEST_CASE);
+        assertThat(back).isNotNull();
+        assertThat(back.getField("Segment")).isEqualTo("business");
+        assertThat(back.getField("Region")).isEqualTo("north");
+
+        Reporter.log(
+            "writtenTestCaseDataSurvivesReopeningTheProject EVIDENCE persistence: " +
+            sheetFile.getAbsolutePath() +
+            " contains\n" +
+            written.trim() +
+            "\nand a reopened project reads Segment=" +
+            back.getField("Segment") +
+            ", Region=" +
+            back.getField("Region"),
+            true
+        );
+    }
+
+    @Test
+    public void aTestCaseWithoutDataIsGivenItsFirstRecord() throws Exception {
+        Project project = newProject();
+        ProjectTestData testData = new ProjectTestData(() -> project);
+        testData.addSheet(SHEET);
+
+        TestDataViewApi view = testData.testCase(SHEET, SCENARIO, TEST_CASE);
+
+        assertThat(view).isNotNull();
+        assertThat(view.get()).hasSize(1);
+        List<String> record = (List<String>) view.get().get(0);
+        assertThat(record.get(0)).isEqualTo(SCENARIO);
+        assertThat(record.get(1)).isEqualTo(TEST_CASE);
+        // A record is exactly as wide as the sheet, or the CSV it is written to is ragged.
+        assertThat(record).hasSameSizeAs(view.columns());
+
+        // Asking again must not add a second record.
+        assertThat(testData.testCase(SHEET, SCENARIO, TEST_CASE).get()).hasSize(1);
+
+        Reporter.log(
+            "aTestCaseWithoutDataIsGivenItsFirstRecord EVIDENCE first record: " +
+            record +
+            " for columns " +
+            view.columns(),
+            true
+        );
+    }
+
+    @Test
+    public void oneTestCaseIsNotConfusedWithAnother() throws Exception {
+        Project project = newProject();
+        ProjectTestData testData = new ProjectTestData(() -> project);
+        testData.addSheet(SHEET);
+        testData.addColumn(SHEET, "Segment");
+
+        testData.testCase(SHEET, SCENARIO, TEST_CASE).update("Segment", "business");
+        testData.testCase(SHEET, SCENARIO, "Another test case").update("Segment", "private");
+
+        assertThat(testData.testCase(SHEET, SCENARIO, TEST_CASE).getField("Segment"))
+            .isEqualTo("business");
+        assertThat(testData.testCase(SHEET, SCENARIO, "Another test case").getField("Segment"))
+            .isEqualTo("private");
+
+        Reporter.log(
+            "oneTestCaseIsNotConfusedWithAnother EVIDENCE separation: two test cases in one sheet kept their own values",
+            true
+        );
+    }
+
+    @Test
+    public void noOpenProjectIsAnsweredWithNothingRatherThanAFailure() {
+        ProjectTestData testData = new ProjectTestData(() -> null);
+
+        assertThat(testData.sheets()).isEmpty();
+        assertThat(testData.addSheet(SHEET)).isFalse();
+        assertThat(testData.addColumn(SHEET, "Segment")).isFalse();
+        assertThat(testData.testCase(SHEET, SCENARIO, TEST_CASE)).isNull();
+        assertThat(testData.save(SHEET)).isFalse();
+
+        Reporter.log(
+            "noOpenProjectIsAnsweredWithNothingRatherThanAFailure EVIDENCE closed project: every call answered without throwing",
+            true
+        );
+    }
+
+    private Project newProject() {
+        return new Project("Sample", temporaryDirectory.toAbsolutePath().toString(), "csv")
+        .createProject();
+    }
+}

--- a/Engine/src/test/java/com/ing/engine/plugin/loader/PluginLoaderTest.java
+++ b/Engine/src/test/java/com/ing/engine/plugin/loader/PluginLoaderTest.java
@@ -1,0 +1,344 @@
+package com.ing.engine.plugin.loader;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import com.ing.engine.support.reflect.Discovery;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.text.MessageFormat;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.jar.Attributes;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
+import java.util.jar.Manifest;
+import java.util.logging.Handler;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+import org.testng.Reporter;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class PluginLoaderTest {
+    private static final String ENTRY_CLASS = "com.example.plugin.SamplePlugin";
+
+    private Path temporaryDirectory;
+    private List<String> logMessages;
+    private Handler logHandler;
+
+    @BeforeMethod
+    public void setUp() throws IOException {
+        temporaryDirectory = Files.createTempDirectory("plugin-loader-test-");
+        logMessages = new CopyOnWriteArrayList<>();
+        logHandler =
+            new Handler() {
+
+                @Override
+                public void publish(LogRecord record) {
+                    logMessages.add(format(record));
+                }
+
+                @Override
+                public void flush() {}
+
+                @Override
+                public void close() {}
+            };
+        Logger.getLogger(PluginLoader.class.getName()).addHandler(logHandler);
+    }
+
+    @AfterMethod(alwaysRun = true)
+    public void tearDown() throws IOException {
+        Logger.getLogger(PluginLoader.class.getName()).removeHandler(logHandler);
+        if (temporaryDirectory != null) {
+            try (var paths = Files.walk(temporaryDirectory)) {
+                for (Path path : paths.sorted((left, right) -> right.compareTo(left)).toList()) {
+                    try {
+                        Files.deleteIfExists(path);
+                    } catch (IOException ex) {
+                        path.toFile().deleteOnExit();
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    public void discoversPluginFromUserDirectoryWhenInstallDirectoryIsEmpty() throws Exception {
+        Path userDirectory = temporaryDirectory.resolve("user-plugins");
+        Path installDirectory = temporaryDirectory.resolve("install-plugins");
+        Path userJar = createPlugin(userDirectory, "sample", "sample.plugin", "1.0.0");
+
+        List<Class<?>> classes = PluginLoader.loadAllPluginsEntryClasses(
+            locations(userDirectory, installDirectory)
+        );
+
+        assertThat(classes).hasSize(1);
+        assertThat(codeSource(classes.get(0))).isEqualTo(userJar);
+        Reporter.log(
+            "discoversPluginFromUserDirectoryWhenInstallDirectoryIsEmpty EVIDENCE 1: user plugin discovered while install directory was absent; source=" +
+            userDirectory.toAbsolutePath(),
+            true
+        );
+    }
+
+    @Test
+    public void loadsDistinctPluginsAndUserCopyShadowsInstallCopyWithPathsLogged()
+        throws Exception {
+        Path userDirectory = temporaryDirectory.resolve("user-plugins");
+        Path installDirectory = temporaryDirectory.resolve("install-plugins");
+        Path userJar = createPlugin(userDirectory, "replacement", "shared.plugin", "2.0.0");
+        createPlugin(installDirectory, "baseline", "shared.plugin", "1.0.0");
+        Path distinctJar = createPlugin(installDirectory, "distinct", "distinct.plugin", "1.0.0");
+
+        List<Class<?>> classes = PluginLoader.loadAllPluginsEntryClasses(
+            locations(userDirectory, installDirectory)
+        );
+
+        Set<Path> sources = classes.stream().map(this::codeSource).collect(Collectors.toSet());
+        assertThat(classes).hasSize(2);
+        assertThat(sources).containsExactlyInAnyOrder(userJar, distinctJar);
+
+        Path higherPrecedenceFolder = userDirectory.resolve("replacement").toAbsolutePath();
+        Path shadowedFolder = installDirectory.resolve("baseline").toAbsolutePath();
+        assertThat(logMessages)
+            .anySatisfy(
+                message ->
+                    assertThat(message)
+                        .contains("shared.plugin")
+                        .contains(higherPrecedenceFolder.toString())
+                        .contains(shadowedFolder.toString())
+            );
+        Reporter.log(
+            "loadsDistinctPluginsAndUserCopyShadowsInstallCopyWithPathsLogged EVIDENCE 2: distinct plugins loaded=2; shared.plugin winner=" +
+            higherPrecedenceFolder +
+            "; shadowed=" +
+            shadowedFolder,
+            true
+        );
+    }
+
+    @Test
+    public void disableUserPluginsDoesNotScanUserDirectory() throws Exception {
+        Path appRoot = temporaryDirectory.resolve("install");
+        Path localAppData = temporaryDirectory.resolve("local");
+        Path userDirectory = localAppData.resolve("INGenious").resolve("plugins");
+        createPlugin(userDirectory, "sample", "sample.plugin", "1.0.0");
+        Map<String, String> environment = new HashMap<>();
+        environment.put("LOCALAPPDATA", localAppData.toString());
+        environment.put(PluginSearchPath.DISABLE_USER_PLUGINS_ENV, "TrUe");
+
+        List<PluginSearchPath.Location> searchPath = PluginSearchPath.resolve(
+            environment::get,
+            appRoot.toFile(),
+            "Windows 11",
+            temporaryDirectory.resolve("home").toString()
+        );
+        List<Class<?>> classes = PluginLoader.loadAllPluginsEntryClasses(searchPath);
+
+        assertThat(searchPath)
+            .extracting(PluginSearchPath.Location::source)
+            .containsExactly("install");
+        assertThat(classes).isEmpty();
+        assertThat(logMessages).noneMatch(message -> message.contains(userDirectory.toString()));
+        Reporter.log(
+            "disableUserPluginsDoesNotScanUserDirectory EVIDENCE 3: INGENIOUS_DISABLE_USER_PLUGINS=true resolved only the install directory",
+            true
+        );
+    }
+
+    @Test
+    public void configuredPluginPathReplacesDefaultDirectories() throws Exception {
+        Path appRoot = temporaryDirectory.resolve("install");
+        Path configuredDirectory = temporaryDirectory.resolve("configured");
+        Path localAppData = temporaryDirectory.resolve("local");
+        Path userDirectory = localAppData.resolve("INGenious").resolve("plugins");
+        Path configuredJar = createPlugin(
+            configuredDirectory,
+            "configured-plugin",
+            "configured.plugin",
+            "1.0.0"
+        );
+        createPlugin(userDirectory, "user-plugin", "user.plugin", "1.0.0");
+        createPlugin(appRoot.resolve("plugins"), "install-plugin", "install.plugin", "1.0.0");
+        Map<String, String> environment = new HashMap<>();
+        environment.put(PluginSearchPath.PLUGIN_PATH_ENV, configuredDirectory.toString());
+        environment.put("LOCALAPPDATA", localAppData.toString());
+
+        List<PluginSearchPath.Location> searchPath = PluginSearchPath.resolve(
+            environment::get,
+            appRoot.toFile(),
+            "Windows 11",
+            temporaryDirectory.resolve("home").toString()
+        );
+        List<Class<?>> classes = PluginLoader.loadAllPluginsEntryClasses(searchPath);
+
+        assertThat(searchPath).hasSize(1);
+        assertThat(searchPath.get(0).source()).isEqualTo("env");
+        assertThat(classes).hasSize(1);
+        assertThat(codeSource(classes.get(0))).isEqualTo(configuredJar);
+        Reporter.log(
+            "configuredPluginPathReplacesDefaultDirectories EVIDENCE 4: INGENIOUS_PLUGIN_PATH replaced user and install defaults; source=" +
+            configuredDirectory.toAbsolutePath(),
+            true
+        );
+    }
+
+    @Test
+    public void missingPluginDirectoriesDoNotAbortDiscovery() {
+        Path firstMissingDirectory = temporaryDirectory.resolve("missing-one");
+        Path secondMissingDirectory = temporaryDirectory.resolve("missing-two");
+
+        assertThat(
+                PluginLoader.loadAllPluginsEntryClasses(
+                    locations(firstMissingDirectory, secondMissingDirectory)
+                )
+            )
+            .isEmpty();
+
+        String[] originalPackages = Discovery.packages;
+        try {
+            Discovery.packages = new String[] { "com.example.package.that.does.not.exist" };
+            assertThatCode(Discovery::getClassesForPackage).doesNotThrowAnyException();
+        } finally {
+            Discovery.packages = originalPackages;
+        }
+        Reporter.log(
+            "missingPluginDirectoriesDoNotAbortDiscovery EVIDENCE 5: two absent plugin directories returned an empty result and Discovery.getClassesForPackage completed",
+            true
+        );
+    }
+
+    @Test
+    public void missingPluginIdFallsBackToFolderName() throws Exception {
+        Path firstDirectory = temporaryDirectory.resolve("first");
+        Path secondDirectory = temporaryDirectory.resolve("second");
+        Path firstJar = createPlugin(firstDirectory, "legacy-plugin", null, "1.0.0");
+        createPlugin(secondDirectory, "legacy-plugin", null, "2.0.0");
+
+        List<Class<?>> classes = PluginLoader.loadAllPluginsEntryClasses(
+            locations(firstDirectory, secondDirectory)
+        );
+
+        assertThat(classes).hasSize(1);
+        assertThat(codeSource(classes.get(0))).isEqualTo(firstJar);
+        assertThat(logMessages)
+            .anyMatch(
+                message ->
+                    message.contains("shadowed plugin id=legacy-plugin") &&
+                    message.contains(
+                        firstDirectory.resolve("legacy-plugin").toAbsolutePath().toString()
+                    ) &&
+                    message.contains(
+                        secondDirectory.resolve("legacy-plugin").toAbsolutePath().toString()
+                    )
+            );
+        Reporter.log(
+            "missingPluginIdFallsBackToFolderName EVIDENCE fallback: missing pluginId used folder name legacy-plugin for precedence",
+            true
+        );
+    }
+
+    @Test
+    public void expandsHomePrefixesInConfiguredPluginPath() {
+        Path home = temporaryDirectory.resolve("home").toAbsolutePath();
+        Map<String, String> environment = Map.of(
+            PluginSearchPath.PLUGIN_PATH_ENV,
+            "~" +
+            java.io.File.separator +
+            "first" +
+            java.io.File.pathSeparator +
+            "${user.home}" +
+            java.io.File.separator +
+            "second"
+        );
+
+        List<PluginSearchPath.Location> searchPath = PluginSearchPath.resolve(
+            environment::get,
+            temporaryDirectory.resolve("install").toFile(),
+            "Windows 11",
+            home.toString()
+        );
+
+        assertThat(searchPath)
+            .extracting(location -> location.directory().toPath())
+            .containsExactly(home.resolve("first"), home.resolve("second"));
+        Reporter.log(
+            "expandsHomePrefixesInConfiguredPluginPath EVIDENCE expansion: leading ~ and ${user.home} resolved to " +
+            home,
+            true
+        );
+    }
+
+    private List<PluginSearchPath.Location> locations(Path... directories) {
+        List<PluginSearchPath.Location> locations = new ArrayList<>();
+        for (int index = 0; index < directories.length; index++) {
+            locations.add(
+                new PluginSearchPath.Location(
+                    directories[index].toFile(),
+                    index == 0 ? "user" : "install"
+                )
+            );
+        }
+        return locations;
+    }
+
+    private Path createPlugin(
+        Path pluginRoot,
+        String folderName,
+        String pluginId,
+        String pluginVersion
+    )
+        throws IOException {
+        Path pluginFolder = Files.createDirectories(pluginRoot.resolve(folderName));
+        Path jarPath = pluginFolder.resolve("plugin.jar");
+        Manifest manifest = new Manifest();
+        Attributes attributes = manifest.getMainAttributes();
+        attributes.put(Attributes.Name.MANIFEST_VERSION, "1.0");
+        attributes.putValue("pluginEntryClasses", ENTRY_CLASS);
+        if (pluginId != null) {
+            attributes.putValue("pluginId", pluginId);
+        }
+        if (pluginVersion != null) {
+            attributes.putValue("pluginVersion", pluginVersion);
+        }
+
+        try (
+            InputStream classBytes = getClass()
+                .getResourceAsStream("/com/example/plugin/SamplePlugin.class");
+            JarOutputStream jar = new JarOutputStream(Files.newOutputStream(jarPath), manifest)
+        ) {
+            assertThat(classBytes).as("compiled sample plugin class").isNotNull();
+            jar.putNextEntry(new JarEntry("com/example/plugin/SamplePlugin.class"));
+            classBytes.transferTo(jar);
+            jar.closeEntry();
+        }
+        return jarPath.toAbsolutePath();
+    }
+
+    private Path codeSource(Class<?> pluginClass) {
+        try {
+            return Path
+                .of(pluginClass.getProtectionDomain().getCodeSource().getLocation().toURI())
+                .toAbsolutePath();
+        } catch (Exception ex) {
+            throw new AssertionError(ex);
+        }
+    }
+
+    private String format(LogRecord record) {
+        Object[] parameters = record.getParameters();
+        return parameters == null
+            ? record.getMessage()
+            : MessageFormat.format(record.getMessage(), parameters);
+    }
+}

--- a/Engine/src/test/java/com/ing/engine/plugin/loader/PluginLoaderTest.java
+++ b/Engine/src/test/java/com/ing/engine/plugin/loader/PluginLoaderTest.java
@@ -6,6 +6,7 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 import com.ing.engine.support.reflect.Discovery;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.text.MessageFormat;
@@ -15,6 +16,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import java.util.jar.Attributes;
 import java.util.jar.JarEntry;
 import java.util.jar.JarOutputStream;
@@ -30,6 +36,7 @@ import org.testng.annotations.Test;
 
 public class PluginLoaderTest {
     private static final String ENTRY_CLASS = "com.example.plugin.SamplePlugin";
+    private static final String PLUGIN_MARKER_RESOURCE = "plugin-marker.txt";
 
     private Path temporaryDirectory;
     private List<String> logMessages;
@@ -37,6 +44,7 @@ public class PluginLoaderTest {
 
     @BeforeMethod
     public void setUp() throws IOException {
+        PluginLoader.unloadAll();
         temporaryDirectory = Files.createTempDirectory("plugin-loader-test-");
         logMessages = new CopyOnWriteArrayList<>();
         logHandler =
@@ -59,6 +67,8 @@ public class PluginLoaderTest {
     @AfterMethod(alwaysRun = true)
     public void tearDown() throws IOException {
         Logger.getLogger(PluginLoader.class.getName()).removeHandler(logHandler);
+        // Release the cached loaders' handles on the generated JARs before deleting them.
+        PluginLoader.unloadAll();
         if (temporaryDirectory != null) {
             try (var paths = Files.walk(temporaryDirectory)) {
                 for (Path path : paths.sorted((left, right) -> right.compareTo(left)).toList()) {
@@ -279,6 +289,164 @@ public class PluginLoaderTest {
         );
     }
 
+    @Test
+    public void repeatedDiscoveryReturnsTheSamePluginClassAndStaticState() throws Exception {
+        Path pluginDirectory = temporaryDirectory.resolve("plugins");
+        createPlugin(pluginDirectory, "sample", "sample.plugin", "1.0.0");
+
+        List<Class<?>> first = PluginLoader.loadAllPluginsEntryClasses(locations(pluginDirectory));
+        List<Class<?>> second = PluginLoader.loadAllPluginsEntryClasses(locations(pluginDirectory));
+
+        assertThat(first).hasSize(1);
+        assertThat(second).hasSize(1);
+        assertThat(second.get(0)).isSameAs(first.get(0));
+        assertThat(second.get(0).getClassLoader()).isSameAs(first.get(0).getClassLoader());
+
+        // An object created from the first lookup is recognised by the second lookup's class:
+        // the property a plugin needs before anything can be handed to it across lookups.
+        Object instanceFromFirstLookup = first.get(0).getConstructor().newInstance();
+        assertThat(second.get(0).isInstance(instanceFromFirstLookup)).isTrue();
+
+        // And there is one copy of the plugin's static state, not one per lookup.
+        first.get(0).getField("sharedHandle").set(null, "handed-over-at-first-lookup");
+        assertThat(second.get(0).getField("sharedHandle").get(null))
+            .isEqualTo("handed-over-at-first-lookup");
+
+        Reporter.log(
+            "repeatedDiscoveryReturnsTheSamePluginClassAndStaticState EVIDENCE identity: two lookups returned the same Class (" +
+            System.identityHashCode(first.get(0)) +
+            ") from the same loader (" +
+            System.identityHashCode(first.get(0).getClassLoader()) +
+            "); an instance from lookup 1 is an instance of lookup 2's class; static state carried over",
+            true
+        );
+    }
+
+    @Test
+    public void differentPluginsKeepIsolatedClassLoaders() throws Exception {
+        Path pluginDirectory = temporaryDirectory.resolve("plugins");
+        createPlugin(pluginDirectory, "first-plugin", "first.plugin", "1.0.0");
+        createPlugin(pluginDirectory, "second-plugin", "second.plugin", "1.0.0");
+
+        List<Class<?>> classes = PluginLoader.loadAllPluginsEntryClasses(
+            locations(pluginDirectory)
+        );
+
+        assertThat(classes).hasSize(2);
+        assertThat(classes.get(0).getClassLoader()).isNotSameAs(classes.get(1).getClassLoader());
+        assertThat(classes.get(0)).isNotSameAs(classes.get(1));
+        assertThat(classes.get(0).getClassLoader()).isInstanceOf(PluginClassLoader.class);
+        assertThat(classes.get(1).getClassLoader()).isInstanceOf(PluginClassLoader.class);
+
+        // Caching per folder must not merge two plugins: static state stays separate.
+        classes.get(0).getField("sharedHandle").set(null, "first");
+        classes.get(1).getField("sharedHandle").set(null, "second");
+        assertThat(classes.get(0).getField("sharedHandle").get(null)).isEqualTo("first");
+
+        Reporter.log(
+            "differentPluginsKeepIsolatedClassLoaders EVIDENCE isolation: first.plugin loader=" +
+            System.identityHashCode(classes.get(0).getClassLoader()) +
+            ", second.plugin loader=" +
+            System.identityHashCode(classes.get(1).getClassLoader()) +
+            "; same class name, separate classes and separate static state",
+            true
+        );
+    }
+
+    @Test
+    public void changedPluginJarsAreReloadedAndThePreviousClassLoaderIsClosed() throws Exception {
+        Path pluginDirectory = temporaryDirectory.resolve("plugins");
+        Path jar = createPlugin(pluginDirectory, "sample", "sample.plugin", "1.0.0");
+
+        List<Class<?>> before = PluginLoader.loadAllPluginsEntryClasses(locations(pluginDirectory));
+        ClassLoader previousClassLoader = before.get(0).getClassLoader();
+        assertThat(previousClassLoader.getResource(PLUGIN_MARKER_RESOURCE)).isNotNull();
+
+        // Install a dependency beside the plugin, as shipping a new build of it would.
+        createDependencyJar(jar.getParent().resolve("lib").resolve("extra.jar"));
+
+        List<Class<?>> after = PluginLoader.loadAllPluginsEntryClasses(locations(pluginDirectory));
+
+        assertThat(after.get(0).getClassLoader()).isNotSameAs(previousClassLoader);
+        assertThat(previousClassLoader.getResource(PLUGIN_MARKER_RESOURCE))
+            .as("the replaced loader is closed, not left holding the old JAR")
+            .isNull();
+        assertThat(logMessages).anyMatch(message -> message.contains("Reloading plugin path="));
+
+        Reporter.log(
+            "changedPluginJarsAreReloadedAndThePreviousClassLoaderIsClosed EVIDENCE reload: changed JARs produced loader " +
+            System.identityHashCode(after.get(0).getClassLoader()) +
+            " and closed loader " +
+            System.identityHashCode(previousClassLoader),
+            true
+        );
+    }
+
+    @Test
+    public void unloadAllClosesCachedClassLoadersAndForcesAFreshLoad() throws Exception {
+        Path pluginDirectory = temporaryDirectory.resolve("plugins");
+        createPlugin(pluginDirectory, "sample", "sample.plugin", "1.0.0");
+
+        List<Class<?>> before = PluginLoader.loadAllPluginsEntryClasses(locations(pluginDirectory));
+        ClassLoader previousClassLoader = before.get(0).getClassLoader();
+
+        PluginLoader.unloadAll();
+
+        assertThat(previousClassLoader.getResource(PLUGIN_MARKER_RESOURCE)).isNull();
+
+        List<Class<?>> after = PluginLoader.loadAllPluginsEntryClasses(locations(pluginDirectory));
+        assertThat(after.get(0).getClassLoader()).isNotSameAs(previousClassLoader);
+        assertThat(after.get(0).getClassLoader().getResource(PLUGIN_MARKER_RESOURCE)).isNotNull();
+
+        Reporter.log(
+            "unloadAllClosesCachedClassLoadersAndForcesAFreshLoad EVIDENCE unload: loader " +
+            System.identityHashCode(previousClassLoader) +
+            " closed; the next discovery built loader " +
+            System.identityHashCode(after.get(0).getClassLoader()),
+            true
+        );
+    }
+
+    @Test
+    public void concurrentDiscoveryShareTheSamePluginClass() throws Exception {
+        Path pluginDirectory = temporaryDirectory.resolve("plugins");
+        createPlugin(pluginDirectory, "sample", "sample.plugin", "1.0.0");
+
+        int threads = 8;
+        ExecutorService executor = Executors.newFixedThreadPool(threads);
+        try {
+            CountDownLatch startLine = new CountDownLatch(1);
+            List<Future<Class<?>>> results = new ArrayList<>();
+            for (int index = 0; index < threads; index++) {
+                results.add(
+                    executor.submit(
+                        () -> {
+                            startLine.await();
+                            return PluginLoader
+                                .loadAllPluginsEntryClasses(locations(pluginDirectory))
+                                .get(0);
+                        }
+                    )
+                );
+            }
+            startLine.countDown();
+
+            Class<?> expected = results.get(0).get(30, TimeUnit.SECONDS);
+            for (Future<Class<?>> result : results) {
+                assertThat(result.get(30, TimeUnit.SECONDS)).isSameAs(expected);
+            }
+            Reporter.log(
+                "concurrentDiscoveryShareTheSamePluginClass EVIDENCE thread-safety: " +
+                threads +
+                " concurrent discoveries all returned Class " +
+                System.identityHashCode(expected),
+                true
+            );
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
     private List<PluginSearchPath.Location> locations(Path... directories) {
         List<PluginSearchPath.Location> locations = new ArrayList<>();
         for (int index = 0; index < directories.length; index++) {
@@ -321,8 +489,24 @@ public class PluginLoaderTest {
             jar.putNextEntry(new JarEntry("com/example/plugin/SamplePlugin.class"));
             classBytes.transferTo(jar);
             jar.closeEntry();
+            // A resource that exists only inside the JAR, so a lookup on it cannot be answered
+            // by the parent class loader. Reading it proves a loader is still open.
+            jar.putNextEntry(new JarEntry(PLUGIN_MARKER_RESOURCE));
+            jar.write(folderName.getBytes(StandardCharsets.UTF_8));
+            jar.closeEntry();
         }
         return jarPath.toAbsolutePath();
+    }
+
+    private void createDependencyJar(Path jarPath) throws IOException {
+        Files.createDirectories(jarPath.getParent());
+        Manifest manifest = new Manifest();
+        manifest.getMainAttributes().put(Attributes.Name.MANIFEST_VERSION, "1.0");
+        try (JarOutputStream jar = new JarOutputStream(Files.newOutputStream(jarPath), manifest)) {
+            jar.putNextEntry(new JarEntry("dependency-marker.txt"));
+            jar.write("dependency".getBytes(StandardCharsets.UTF_8));
+            jar.closeEntry();
+        }
     }
 
     private Path codeSource(Class<?> pluginClass) {

--- a/IDE/src/main/java/com/ing/ide/main/fx/FXToolBar.java
+++ b/IDE/src/main/java/com/ing/ide/main/fx/FXToolBar.java
@@ -71,6 +71,11 @@ public class FXToolBar extends JFXPanel {
                 //, createDarkModeToggle()
             );
 
+        // Plugin-contributed screens get a button each, after the built-in ones.
+        for (com.ing.ingenious.api.contract.ui.StudioPanelApi panel : com.ing.ide.main.mainui.plugins.StudioPanelPlugins.load()) {
+            toolBar.getItems().add(createPluginPanelButton(panel));
+        }
+
         VBox root = new VBox(toolBar);
         root.getStyleClass().add("light-theme");
 
@@ -111,6 +116,24 @@ public class FXToolBar extends JFXPanel {
         }
 
         btn.setOnAction(e -> fireSwingAction("API Workbench"));
+        return btn;
+    }
+
+    /**
+     * Builds the toolbar button for a plugin-contributed screen. The action command carries
+     * the panel title, so one handler serves any number of plugins.
+     */
+    private Button createPluginPanelButton(com.ing.ingenious.api.contract.ui.StudioPanelApi panel) {
+        Button btn = new Button(panel.getTitle());
+        btn.getStyleClass().add("workbench-btn");
+        btn.setTooltip(new Tooltip(panel.getTooltip()));
+        btn.setOnAction(
+            e ->
+                fireSwingAction(
+                    com.ing.ide.main.mainui.plugins.StudioPanelPlugins.ACTION_PREFIX +
+                    panel.getTitle()
+                )
+        );
         return btn;
     }
 

--- a/IDE/src/main/java/com/ing/ide/main/fx/FXToolBar.java
+++ b/IDE/src/main/java/com/ing/ide/main/fx/FXToolBar.java
@@ -2,6 +2,7 @@ package com.ing.ide.main.fx;
 
 import com.ing.ide.main.Main;
 import com.ing.ide.main.mainui.AppActionListener;
+import com.ing.ide.main.mainui.plugins.StudioPanelPlugins;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
@@ -72,7 +73,7 @@ public class FXToolBar extends JFXPanel {
             );
 
         // Plugin-contributed screens get a button each, after the built-in ones.
-        for (com.ing.ingenious.api.contract.ui.StudioPanelApi panel : com.ing.ide.main.mainui.plugins.StudioPanelPlugins.load()) {
+        for (StudioPanelPlugins.Panel panel : StudioPanelPlugins.load()) {
             toolBar.getItems().add(createPluginPanelButton(panel));
         }
 
@@ -121,18 +122,14 @@ public class FXToolBar extends JFXPanel {
 
     /**
      * Builds the toolbar button for a plugin-contributed screen. The action command carries
-     * the panel title, so one handler serves any number of plugins.
+     * the stable panel identity, so one handler serves any number of plugins.
      */
-    private Button createPluginPanelButton(com.ing.ingenious.api.contract.ui.StudioPanelApi panel) {
+    private Button createPluginPanelButton(StudioPanelPlugins.Panel panel) {
         Button btn = new Button(panel.getTitle());
         btn.getStyleClass().add("workbench-btn");
         btn.setTooltip(new Tooltip(panel.getTooltip()));
         btn.setOnAction(
-            e ->
-                fireSwingAction(
-                    com.ing.ide.main.mainui.plugins.StudioPanelPlugins.ACTION_PREFIX +
-                    panel.getTitle()
-                )
+            e -> fireSwingAction(StudioPanelPlugins.ACTION_PREFIX + panel.getIdentity())
         );
         return btn;
     }

--- a/IDE/src/main/java/com/ing/ide/main/mainui/AppActionListener.java
+++ b/IDE/src/main/java/com/ing/ide/main/mainui/AppActionListener.java
@@ -298,8 +298,22 @@ public class AppActionListener implements ActionListener {
                 }
                 break;
             default:
-                // Handle language-specific SAP imports
-                if (ae.getActionCommand().startsWith("Import SAP Recording:")) {
+                // Plugin-contributed screens are dynamic, so they dispatch by prefix.
+                if (
+                    ae
+                        .getActionCommand()
+                        .startsWith(
+                            com.ing.ide.main.mainui.plugins.StudioPanelPlugins.ACTION_PREFIX
+                        )
+                ) {
+                    sMainFrame.showPluginPanel(
+                        ae
+                            .getActionCommand()
+                            .substring(
+                                com.ing.ide.main.mainui.plugins.StudioPanelPlugins.ACTION_PREFIX.length()
+                            )
+                    );
+                } else if (ae.getActionCommand().startsWith("Import SAP Recording:")) {
                     String language = ae
                         .getActionCommand()
                         .substring("Import SAP Recording:".length());

--- a/IDE/src/main/java/com/ing/ide/main/mainui/AppMainFrame.java
+++ b/IDE/src/main/java/com/ing/ide/main/mainui/AppMainFrame.java
@@ -25,6 +25,7 @@ import com.ing.ide.main.mainui.components.aichat.AICopilot;
 import com.ing.ide.main.mainui.components.apitester.APITester;
 import com.ing.ide.main.mainui.components.testdesign.TestDesign;
 import com.ing.ide.main.mainui.components.testexecution.TestExecution;
+import com.ing.ide.main.mainui.plugins.StudioPanelPlugins;
 import com.ing.ide.main.shr.SHR;
 import com.ing.ide.main.ui.About;
 import com.ing.ide.main.ui.FXStartUp;
@@ -168,6 +169,7 @@ public class AppMainFrame extends JFrame {
         slideShow.addSlide("DashBoard", dashBoard);
         slideShow.addSlide("APITester", apiTester.getAPITesterUI());
         slideShow.addSlide("AICopilot", aiCopilot.getAICopilotUI());
+        addPluginPanels();
         slideShow.addSlideChangeListener(aiCopilot);
         progressed(85);
         add(slideShow, BorderLayout.CENTER);
@@ -195,6 +197,38 @@ public class AppMainFrame extends JFrame {
             }
         );
         progressed(90);
+    }
+
+    /**
+     * Adds every plugin-contributed screen as a slide. A plugin that throws while building
+     * its panel is skipped with a log entry — it must never prevent Studio from starting.
+     */
+    private void addPluginPanels() {
+        for (com.ing.ingenious.api.contract.ui.StudioPanelApi panel : StudioPanelPlugins.load()) {
+            try {
+                javax.swing.JComponent component = panel.createPanel();
+                if (component != null) {
+                    slideShow.addSlide(StudioPanelPlugins.slideName(panel.getTitle()), component);
+                }
+            } catch (RuntimeException ex) {
+                java
+                    .util.logging.Logger.getLogger(AppMainFrame.class.getName())
+                    .log(
+                        java.util.logging.Level.WARNING,
+                        "Panel plugin '" + panel.getTitle() + "' failed to build",
+                        ex
+                    );
+            }
+        }
+    }
+
+    /**
+     * Shows a plugin-contributed screen.
+     *
+     * @param title the panel title as reported by the plugin
+     */
+    public void showPluginPanel(String title) {
+        slideShow.showSlide(StudioPanelPlugins.slideName(title));
     }
 
     private void progressed(int val) {

--- a/IDE/src/main/java/com/ing/ide/main/mainui/AppMainFrame.java
+++ b/IDE/src/main/java/com/ing/ide/main/mainui/AppMainFrame.java
@@ -173,6 +173,11 @@ public class AppMainFrame extends JFrame {
         slideShow.addSlide("APITester", apiTester.getAPITesterUI());
         slideShow.addSlide("AICopilot", aiCopilot.getAICopilotUI());
         slideShow.addSlideChangeListener(aiCopilot);
+        // Discover plugin-contributed screens while Studio is starting. Reading the
+        // declarations here keeps them off the JavaFX toolbar build — that runs only once
+        // a project is open, and behind a short timeout. Discovery reads manifests; a
+        // panel's createPanel() still runs on first activation only.
+        StudioPanelPlugins.load();
         progressed(85);
         add(slideShow, BorderLayout.CENTER);
         add(toolBar, BorderLayout.NORTH);

--- a/IDE/src/main/java/com/ing/ide/main/mainui/AppMainFrame.java
+++ b/IDE/src/main/java/com/ing/ide/main/mainui/AppMainFrame.java
@@ -8,6 +8,7 @@ import com.ing.datalib.component.TestCase;
 import com.ing.datalib.component.TestData;
 import com.ing.datalib.component.TestSet;
 import com.ing.datalib.component.TestStep;
+import com.ing.datalib.plugin.ProjectTestData;
 import com.ing.datalib.settings.testmgmt.Option;
 import com.ing.datalib.settings.testmgmt.TestMgModule;
 import com.ing.datalib.testdata.model.AbstractDataModel;
@@ -37,6 +38,7 @@ import com.ing.ide.settings.AppSettings;
 import com.ing.ide.util.Notification;
 import com.ing.ide.util.SystemInfo;
 import com.ing.ide.util.Utility;
+import com.ing.ingenious.api.contract.data.ProjectTestDataApi;
 import java.awt.BorderLayout;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
@@ -106,6 +108,13 @@ public class AppMainFrame extends JFrame {
     private final LoaderScreen loader;
 
     private final Set<String> pluginPanelSlides = new HashSet<>();
+
+    /**
+     * What a plugin screen is given so it can record its decisions where the project keeps
+     * them. Reads the project through the frame, so it stays correct when another one is
+     * opened.
+     */
+    private final ProjectTestDataApi projectTestData = new ProjectTestData(this::getProject);
 
     private QUIT_TYPE quitType = QUIT_TYPE.NORMAL;
 
@@ -221,7 +230,7 @@ public class AppMainFrame extends JFrame {
             return;
         }
 
-        javax.swing.JComponent component = panel.activate();
+        javax.swing.JComponent component = panel.activate(projectTestData);
         if (component == null) {
             return;
         }

--- a/IDE/src/main/java/com/ing/ide/main/mainui/AppMainFrame.java
+++ b/IDE/src/main/java/com/ing/ide/main/mainui/AppMainFrame.java
@@ -45,6 +45,7 @@ import java.awt.event.WindowEvent;
 import java.io.File;
 import java.io.IOException;
 import java.util.Enumeration;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
@@ -103,6 +104,8 @@ public class AppMainFrame extends JFrame {
     private Project sProject;
 
     private final LoaderScreen loader;
+
+    private final Set<String> pluginPanelSlides = new HashSet<>();
 
     private QUIT_TYPE quitType = QUIT_TYPE.NORMAL;
 
@@ -169,7 +172,6 @@ public class AppMainFrame extends JFrame {
         slideShow.addSlide("DashBoard", dashBoard);
         slideShow.addSlide("APITester", apiTester.getAPITesterUI());
         slideShow.addSlide("AICopilot", aiCopilot.getAICopilotUI());
-        addPluginPanels();
         slideShow.addSlideChangeListener(aiCopilot);
         progressed(85);
         add(slideShow, BorderLayout.CENTER);
@@ -200,35 +202,30 @@ public class AppMainFrame extends JFrame {
     }
 
     /**
-     * Adds every plugin-contributed screen as a slide. A plugin that throws while building
-     * its panel is skipped with a log entry — it must never prevent Studio from starting.
-     */
-    private void addPluginPanels() {
-        for (com.ing.ingenious.api.contract.ui.StudioPanelApi panel : StudioPanelPlugins.load()) {
-            try {
-                javax.swing.JComponent component = panel.createPanel();
-                if (component != null) {
-                    slideShow.addSlide(StudioPanelPlugins.slideName(panel.getTitle()), component);
-                }
-            } catch (RuntimeException ex) {
-                java
-                    .util.logging.Logger.getLogger(AppMainFrame.class.getName())
-                    .log(
-                        java.util.logging.Level.WARNING,
-                        "Panel plugin '" + panel.getTitle() + "' failed to build",
-                        ex
-                    );
-            }
-        }
-    }
-
-    /**
-     * Shows a plugin-contributed screen.
+     * Activates and shows a plugin-contributed screen. Its component is built only on the
+     * first activation.
      *
-     * @param title the panel title as reported by the plugin
+     * @param identity the plugin ID, or entry class name when no ID is declared
      */
-    public void showPluginPanel(String title) {
-        slideShow.showSlide(StudioPanelPlugins.slideName(title));
+    public void showPluginPanel(String identity) {
+        StudioPanelPlugins.Panel panel = StudioPanelPlugins.find(identity);
+        if (panel == null) {
+            Logger
+                .getLogger(AppMainFrame.class.getName())
+                .log(Level.WARNING, "No Studio panel found for identity {0}", identity);
+            return;
+        }
+
+        javax.swing.JComponent component = panel.activate();
+        if (component == null) {
+            return;
+        }
+
+        String slideName = StudioPanelPlugins.slideName(panel.getIdentity());
+        if (pluginPanelSlides.add(panel.getIdentity())) {
+            slideShow.addSlide(slideName, component);
+        }
+        slideShow.showSlide(slideName);
     }
 
     private void progressed(int val) {

--- a/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/testcase/TestCaseComponent.java
+++ b/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/testcase/TestCaseComponent.java
@@ -736,6 +736,7 @@ public class TestCaseComponent extends JPanel implements ActionListener {
             new LiveRecordingParser(baseParser, target, firstInsertIndex, reference, objectPage);
 
         liveRecordingOutputFile = prepareLiveRecordingOutputFile();
+        final String startUrl = resolveRecordingStartUrl(pluginTarget);
 
         toolBar.setConsoleVisible(true);
         consoleDialog.clear();
@@ -747,6 +748,9 @@ public class TestCaseComponent extends JPanel implements ActionListener {
                 "🎯 Recording into " + target.getScenario().getName() + " / " + target.getName()
             );
         }
+        if (startUrl != null) {
+            logPlaywright("🌐 Opening " + startUrl);
+        }
         logPlaywright(
             "============================== Playwright Log Started =============================="
         );
@@ -757,7 +761,7 @@ public class TestCaseComponent extends JPanel implements ActionListener {
             CompletableFuture.runAsync(
                 () -> {
                     try {
-                        launchPlaywright(liveRecordingOutputFile);
+                        launchPlaywright(liveRecordingOutputFile, startUrl);
                     } catch (IOException ex) {
                         logPlaywrightError("Error launching Playwright: " + ex.getMessage());
                         Logger
@@ -953,11 +957,28 @@ public class TestCaseComponent extends JPanel implements ActionListener {
     //    }
 
     public void launchPlaywright(File outputFile) throws IOException {
+        launchPlaywright(outputFile, null);
+    }
+
+    /**
+     * Starts the Playwright recorder, optionally on a given page.
+     *
+     * @param outputFile file codegen writes the recorded script to
+     * @param startUrl page to open, or {@code null} for codegen's blank page
+     * @throws IOException when the recorder process cannot be started
+     */
+    public void launchPlaywright(File outputFile, String startUrl) throws IOException {
         String escapedPath = outputFile
             .getAbsolutePath()
             .replace("\\", "\\\\")
             .replace("\"", "\\\"");
         String processArgs = "codegen --target java --output \"" + escapedPath + "\"";
+        if (startUrl != null) {
+            // Quoted: the command is handed to cmd/bash as one string, and an unquoted query
+            // string would be cut at its first '&'. Validation upstream has already ruled out
+            // anything that could break out of these quotes.
+            processArgs += " \"" + startUrl + "\"";
+        }
         runPlaywrightProcess(processArgs);
         logPlaywright(
             "============================== Playwright Log Ended =============================="
@@ -1205,6 +1226,75 @@ public class TestCaseComponent extends JPanel implements ActionListener {
             Logger
                 .getLogger(TestCaseComponent.class.getName())
                 .log(Level.WARNING, "Unable to sync live recording", ex);
+        }
+    }
+
+    /**
+     * Decides which page the recorder opens: what the plugin asked for, else what the project
+     * configured, else nothing — which is codegen's blank page, i.e. the behaviour every
+     * existing project already has.
+     *
+     * @param pluginTarget the plugin's target, or {@code null} when the user chose by hand
+     * @return a usable URL, or {@code null} to start on a blank page
+     */
+    private String resolveRecordingStartUrl(RecordingTarget pluginTarget) {
+        String fromPlugin = pluginTarget == null ? null : pluginTarget.getStartUrl();
+        if (fromPlugin != null) {
+            if (isUsableStartUrl(fromPlugin)) {
+                return fromPlugin.trim();
+            }
+            logPlaywright("Ignoring unusable recording URL from plugin: " + fromPlugin);
+        }
+
+        String fromProject = "";
+        try {
+            fromProject =
+                testDesign.getProject().getProjectSettings().getRecorderSettings().getStartUrl();
+        } catch (RuntimeException ex) {
+            Logger
+                .getLogger(TestCaseComponent.class.getName())
+                .log(Level.WARNING, "Unable to read the project's recorder settings", ex);
+        }
+        if (!fromProject.isEmpty()) {
+            if (isUsableStartUrl(fromProject)) {
+                return fromProject.trim();
+            }
+            logPlaywright("Ignoring unusable recording URL in project settings: " + fromProject);
+        }
+
+        return null;
+    }
+
+    /**
+     * An absolute http(s) address and nothing else.
+     *
+     * <p>The recorder command is assembled as one string and handed to a shell, so a value that
+     * is not a plain URL must not reach it. Rejecting here means a mistyped setting starts a
+     * blank recording with a note in the console, rather than a broken or surprising command.
+     *
+     * @param value the configured value
+     * @return {@code true} when it is safe to pass to the recorder
+     */
+    private boolean isUsableStartUrl(String value) {
+        if (value == null) {
+            return false;
+        }
+        String candidate = value.trim();
+        if (candidate.isEmpty() || candidate.indexOf('"') >= 0 || candidate.indexOf('%') >= 0) {
+            // '%' is legal in a URL but is what a Windows shell expands, so a percent-encoded
+            // address is refused rather than silently mangled on the way to the recorder.
+            return false;
+        }
+        try {
+            java.net.URI uri = new java.net.URI(candidate);
+            String scheme = uri.getScheme();
+            return (
+                uri.isAbsolute() &&
+                uri.getHost() != null &&
+                ("http".equalsIgnoreCase(scheme) || "https".equalsIgnoreCase(scheme))
+            );
+        } catch (java.net.URISyntaxException ex) {
+            return false;
         }
     }
 

--- a/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/testcase/TestCaseComponent.java
+++ b/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/testcase/TestCaseComponent.java
@@ -18,6 +18,7 @@ import com.ing.ide.main.mainui.AppMainFrame;
 import com.ing.ide.main.mainui.EngineConfig;
 import com.ing.ide.main.mainui.components.testdesign.ReusableComponentDialog;
 import com.ing.ide.main.mainui.components.testdesign.TestDesign;
+import com.ing.ide.main.mainui.plugins.RecordingTargetPlugins;
 import com.ing.ide.main.playwrightrecording.InspectorWindowController;
 import com.ing.ide.main.playwrightrecording.LiveRecordingParser;
 import com.ing.ide.main.playwrightrecording.PlaywrightRecordingParser;
@@ -33,6 +34,7 @@ import com.ing.ide.util.Canvas;
 import com.ing.ide.util.Notification;
 import com.ing.ide.util.Notification;
 import com.ing.ide.util.WindowMover;
+import com.ing.ingenious.api.contract.ui.RecordingTarget;
 import java.awt.BorderLayout;
 import java.awt.Component;
 import java.awt.Cursor;
@@ -682,17 +684,31 @@ public class TestCaseComponent extends JPanel implements ActionListener {
             return;
         }
 
-        RecordingTargetDialog.Selection selection = RecordingTargetDialog.showDialog(
-            this,
-            testDesign.getProject(),
-            getCurrentTestCase()
-        );
-        if (selection == null) {
-            SwingUtilities.invokeLater(() -> toolBar.enableRecordButton());
-            return;
+        // A plugin that already knows what the user is working on answers here, and the target
+        // chooser never opens. No plugin, or no answer, and the dialog behaves exactly as before.
+        RecordingTarget pluginTarget = RecordingTargetPlugins.currentTarget();
+
+        TestCase target;
+        if (pluginTarget != null) {
+            target =
+                createOrResolveTarget(
+                    pluginTarget.getScenarioName(),
+                    pluginTarget.getTestCaseName(),
+                    pluginTarget.isReusableScenario()
+                );
+        } else {
+            RecordingTargetDialog.Selection selection = RecordingTargetDialog.showDialog(
+                this,
+                testDesign.getProject(),
+                getCurrentTestCase()
+            );
+            if (selection == null) {
+                SwingUtilities.invokeLater(() -> toolBar.enableRecordButton());
+                return;
+            }
+            target = resolveRecordingTarget(selection);
         }
 
-        TestCase target = resolveRecordingTarget(selection);
         if (target == null) {
             JOptionPane.showMessageDialog(
                 this,
@@ -725,6 +741,12 @@ public class TestCaseComponent extends JPanel implements ActionListener {
         consoleDialog.clear();
         consoleDialog.showConsole();
         logPlaywright("🎬 Playwright Recording is being initiated...");
+        // The user was not asked where this goes, so the console has to say it.
+        if (pluginTarget != null) {
+            logPlaywright(
+                "🎯 Recording into " + target.getScenario().getName() + " / " + target.getName()
+            );
+        }
         logPlaywright(
             "============================== Playwright Log Started =============================="
         );

--- a/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/testcase/TestCaseComponent.java
+++ b/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/testcase/TestCaseComponent.java
@@ -745,11 +745,11 @@ public class TestCaseComponent extends JPanel implements ActionListener {
         // The user was not asked where this goes, so the console has to say it.
         if (pluginTarget != null) {
             logPlaywright(
-                "🎯 Recording into " + target.getScenario().getName() + " / " + target.getName()
+                "Recording into " + target.getScenario().getName() + " / " + target.getName()
             );
         }
         if (startUrl != null) {
-            logPlaywright("🌐 Opening " + startUrl);
+            logPlaywright("Opening " + startUrl);
         }
         logPlaywright(
             "============================== Playwright Log Started =============================="

--- a/IDE/src/main/java/com/ing/ide/main/mainui/plugins/RecordingTargetPlugins.java
+++ b/IDE/src/main/java/com/ing/ide/main/mainui/plugins/RecordingTargetPlugins.java
@@ -1,0 +1,103 @@
+package com.ing.ide.main.mainui.plugins;
+
+import com.ing.engine.plugin.loader.PluginLoader;
+import com.ing.ingenious.api.contract.ui.RecordingTarget;
+import com.ing.ingenious.api.contract.ui.RecordingTargetApi;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Asks plugins where a recording belongs before Studio asks the user.
+ *
+ * <p>Discovery reuses the engine's existing {@link PluginLoader}, so a plugin that answers this
+ * question is packaged and loaded exactly like an action plugin. Entry classes are discovered
+ * and instantiated once, lazily, on the first recording of the session — a stock install with
+ * no plugins pays nothing.
+ *
+ * <p>Nothing here can stop a recording: a missing plugins directory, a class that will not
+ * instantiate, and a plugin that throws all end the same way — no answer, and the recorder's own
+ * target chooser opens as it always has.
+ */
+public final class RecordingTargetPlugins {
+    private static final Logger LOG = Logger.getLogger(RecordingTargetPlugins.class.getName());
+
+    private static List<RecordingTargetApi> cached;
+
+    private RecordingTargetPlugins() {}
+
+    /**
+     * The target the first plugin willing to answer proposes for the next recording.
+     *
+     * @return a target, or {@code null} when no plugin has an answer and the user should choose
+     */
+    public static RecordingTarget currentTarget() {
+        for (RecordingTargetApi provider : load()) {
+            RecordingTarget target;
+            try {
+                target = provider.getRecordingTarget();
+            } catch (RuntimeException ex) {
+                // A plugin's opinion is never worth failing a recording over.
+                LOG.log(
+                    Level.WARNING,
+                    "Recording target plugin failed, asking the user instead: " +
+                    provider.getClass().getName(),
+                    ex
+                );
+                continue;
+            }
+            if (target != null) {
+                LOG.log(
+                    Level.INFO,
+                    "Recording target {0} supplied by {1}",
+                    new Object[] { target, provider.getClass().getName() }
+                );
+                return target;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Discovers and instantiates the providers once, then caches them.
+     *
+     * @return the providers, empty when there are none
+     */
+    private static synchronized List<RecordingTargetApi> load() {
+        if (cached != null) {
+            return cached;
+        }
+
+        List<RecordingTargetApi> found = new ArrayList<>();
+        List<Class<?>> entryClasses;
+        try {
+            entryClasses = PluginLoader.loadAllPluginsEntryClasses();
+        } catch (RuntimeException ex) {
+            // No plugins directory is the normal case for a stock install.
+            LOG.log(Level.INFO, "No recording target plugins loaded: {0}", ex.getMessage());
+            cached = Collections.emptyList();
+            return cached;
+        }
+
+        for (Class<?> entryClass : entryClasses) {
+            if (!RecordingTargetApi.class.isAssignableFrom(entryClass)) {
+                continue;
+            }
+            try {
+                found.add((RecordingTargetApi) entryClass.getConstructor().newInstance());
+                LOG.log(Level.INFO, "Discovered recording target plugin {0}", entryClass.getName());
+            } catch (ReflectiveOperationException | RuntimeException ex) {
+                LOG.log(
+                    Level.WARNING,
+                    "Cannot instantiate recording target plugin " + entryClass.getName(),
+                    ex
+                );
+            }
+        }
+
+        cached = Collections.unmodifiableList(found);
+        return cached;
+    }
+}

--- a/IDE/src/main/java/com/ing/ide/main/mainui/plugins/RecordingTargetPlugins.java
+++ b/IDE/src/main/java/com/ing/ide/main/mainui/plugins/RecordingTargetPlugins.java
@@ -34,7 +34,21 @@ public final class RecordingTargetPlugins {
      * @return a target, or {@code null} when no plugin has an answer and the user should choose
      */
     public static RecordingTarget currentTarget() {
-        for (RecordingTargetApi provider : load()) {
+        return currentTarget(load());
+    }
+
+    /**
+     * The target the first of the given plugins willing to answer proposes.
+     *
+     * <p>Package-private rather than inlined above so the "first answer wins, a throwing plugin
+     * is skipped" rule can be exercised without an installed plugin directory, in the same way
+     * {@code PluginLoader} exposes its search-path overload to its own test.
+     *
+     * @param providers the plugins to ask, in discovery order
+     * @return a target, or {@code null} when none of them has an answer
+     */
+    static RecordingTarget currentTarget(List<RecordingTargetApi> providers) {
+        for (RecordingTargetApi provider : providers) {
             RecordingTarget target;
             try {
                 target = provider.getRecordingTarget();

--- a/IDE/src/main/java/com/ing/ide/main/mainui/plugins/StudioPanelManifest.java
+++ b/IDE/src/main/java/com/ing/ide/main/mainui/plugins/StudioPanelManifest.java
@@ -1,0 +1,95 @@
+package com.ing.ide.main.mainui.plugins;
+
+import java.net.URI;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.CodeSource;
+import java.util.jar.Attributes;
+import java.util.jar.JarFile;
+import java.util.jar.Manifest;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Reads optional Studio panel metadata from the JAR that supplied a plugin entry class.
+ */
+final class StudioPanelManifest {
+    private static final Logger LOG = Logger.getLogger(StudioPanelManifest.class.getName());
+
+    private StudioPanelManifest() {}
+
+    static Metadata read(Class<?> entryClass) {
+        try {
+            CodeSource codeSource = entryClass.getProtectionDomain().getCodeSource();
+            if (codeSource == null) {
+                return Metadata.EMPTY;
+            }
+
+            URL location = codeSource.getLocation();
+            if (location == null || !"file".equalsIgnoreCase(location.getProtocol())) {
+                return Metadata.EMPTY;
+            }
+
+            URI uri = location.toURI();
+            Path path = Path.of(uri);
+            if (!Files.isRegularFile(path)) {
+                return Metadata.EMPTY;
+            }
+
+            try (JarFile jar = new JarFile(path.toFile())) {
+                Manifest manifest = jar.getManifest();
+                if (manifest == null) {
+                    return Metadata.EMPTY;
+                }
+                Attributes attributes = manifest.getMainAttributes();
+                return new Metadata(
+                    value(attributes, "pluginId"),
+                    value(attributes, "pluginVersion"),
+                    value(attributes, "studioPanelTitle"),
+                    value(attributes, "studioPanelTooltip"),
+                    value(attributes, "studioPanelOrder"),
+                    value(attributes, "studioPanelSurface")
+                );
+            }
+        } catch (Exception | LinkageError ex) {
+            LOG.log(Level.FINE, "Cannot read panel metadata for " + entryClass.getName(), ex);
+            return Metadata.EMPTY;
+        }
+    }
+
+    private static String value(Attributes attributes, String name) {
+        String value = attributes.getValue(name);
+        if (value == null || value.trim().isEmpty()) {
+            return null;
+        }
+        return value.trim();
+    }
+
+    static final class Metadata {
+        private static final Metadata EMPTY = new Metadata(null, null, null, null, null, null);
+
+        final String pluginId;
+        final String pluginVersion;
+        final String title;
+        final String tooltip;
+        final String order;
+        final String surface;
+
+        private Metadata(
+            String pluginId,
+            String pluginVersion,
+            String title,
+            String tooltip,
+            String order,
+            String surface
+        ) {
+            this.pluginId = pluginId;
+            this.pluginVersion = pluginVersion;
+            this.title = title;
+            this.tooltip = tooltip;
+            this.order = order;
+            this.surface = surface;
+        }
+    }
+}

--- a/IDE/src/main/java/com/ing/ide/main/mainui/plugins/StudioPanelPlugins.java
+++ b/IDE/src/main/java/com/ing/ide/main/mainui/plugins/StudioPanelPlugins.java
@@ -1,0 +1,90 @@
+package com.ing.ide.main.mainui.plugins;
+
+import com.ing.engine.plugin.loader.PluginLoader;
+import com.ing.ingenious.api.contract.ui.StudioPanelApi;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Discovers plugin-contributed Studio screens ({@link StudioPanelApi}) from the plugins
+ * directory and hands them to the UI.
+ *
+ * <p>Discovery reuses the engine's existing {@link PluginLoader}, so panel plugins are
+ * packaged and loaded exactly like action plugins — same folder, same manifest attribute,
+ * same child-first class loading.
+ *
+ * <p>Everything here is defensive on purpose. A third-party plugin must never be able to
+ * stop Studio from starting: a missing plugins directory, a class that cannot be
+ * instantiated, or a panel whose constructor throws are all logged and skipped.
+ */
+public final class StudioPanelPlugins {
+    /** Action-command prefix used by toolbar buttons to select a plugin screen. */
+    public static final String ACTION_PREFIX = "Plugin Panel:";
+
+    private static final Logger LOG = Logger.getLogger(StudioPanelPlugins.class.getName());
+
+    private static List<StudioPanelApi> cached;
+
+    private StudioPanelPlugins() {}
+
+    /**
+     * Loads the plugin panels once and caches them, so the frame and the toolbar see the
+     * same instances.
+     *
+     * @return the discovered panels; empty when there are none
+     */
+    public static synchronized List<StudioPanelApi> load() {
+        if (cached != null) {
+            return cached;
+        }
+        List<StudioPanelApi> found = new ArrayList<>();
+        List<Class<?>> entryClasses;
+        try {
+            entryClasses = PluginLoader.loadAllPluginsEntryClasses();
+        } catch (RuntimeException ex) {
+            // No plugins directory is the normal case for a stock install.
+            LOG.log(Level.FINE, "No plugin panels loaded: {0}", ex.getMessage());
+            cached = Collections.emptyList();
+            return cached;
+        }
+        for (Class<?> clazz : entryClasses) {
+            if (!StudioPanelApi.class.isAssignableFrom(clazz)) {
+                continue;
+            }
+            try {
+                StudioPanelApi panel = (StudioPanelApi) clazz
+                    .getDeclaredConstructor()
+                    .newInstance();
+                String title = panel.getTitle();
+                if (title == null || title.trim().isEmpty()) {
+                    LOG.log(
+                        Level.WARNING,
+                        "Skipping panel plugin with a blank title: {0}",
+                        clazz.getName()
+                    );
+                    continue;
+                }
+                found.add(panel);
+                LOG.log(Level.INFO, "Loaded Studio panel plugin: {0}", title);
+            } catch (ReflectiveOperationException | RuntimeException ex) {
+                LOG.log(Level.WARNING, "Cannot instantiate panel plugin " + clazz.getName(), ex);
+            }
+        }
+        cached = Collections.unmodifiableList(found);
+        return cached;
+    }
+
+    /**
+     * Slide identity for a panel. Namespaced so a plugin cannot collide with a built-in
+     * screen such as {@code TestDesign}.
+     *
+     * @param title the panel title
+     * @return the slide name
+     */
+    public static String slideName(String title) {
+        return "Plugin:" + title;
+    }
+}

--- a/IDE/src/main/java/com/ing/ide/main/mainui/plugins/StudioPanelPlugins.java
+++ b/IDE/src/main/java/com/ing/ide/main/mainui/plugins/StudioPanelPlugins.java
@@ -2,23 +2,25 @@ package com.ing.ide.main.mainui.plugins;
 
 import com.ing.engine.plugin.loader.PluginLoader;
 import com.ing.ingenious.api.contract.ui.StudioPanelApi;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import javax.swing.JComponent;
 
 /**
  * Discovers plugin-contributed Studio screens ({@link StudioPanelApi}) from the plugins
- * directory and hands them to the UI.
+ * directory and exposes their manifest metadata to the UI.
  *
  * <p>Discovery reuses the engine's existing {@link PluginLoader}, so panel plugins are
- * packaged and loaded exactly like action plugins — same folder, same manifest attribute,
- * same child-first class loading.
- *
- * <p>Everything here is defensive on purpose. A third-party plugin must never be able to
- * stop Studio from starting: a missing plugins directory, a class that cannot be
- * instantiated, or a panel whose constructor throws are all logged and skipped.
+ * packaged and loaded exactly like action plugins. Panel factories and components are
+ * created lazily unless an older plugin requires an instance to supply missing metadata.
  */
 public final class StudioPanelPlugins {
     /** Action-command prefix used by toolbar buttons to select a plugin screen. */
@@ -26,65 +28,293 @@ public final class StudioPanelPlugins {
 
     private static final Logger LOG = Logger.getLogger(StudioPanelPlugins.class.getName());
 
-    private static List<StudioPanelApi> cached;
+    private static List<Panel> cached;
+    private static Map<String, Panel> cachedByIdentity;
 
     private StudioPanelPlugins() {}
 
     /**
-     * Loads the plugin panels once and caches them, so the frame and the toolbar see the
-     * same instances.
+     * Discovers panel declarations once and caches them.
      *
-     * @return the discovered panels; empty when there are none
+     * @return panel declarations sorted by order and title; empty when there are none
      */
-    public static synchronized List<StudioPanelApi> load() {
+    public static synchronized List<Panel> load() {
         if (cached != null) {
             return cached;
         }
-        List<StudioPanelApi> found = new ArrayList<>();
+
+        Map<String, Panel> found = new LinkedHashMap<>();
         List<Class<?>> entryClasses;
         try {
             entryClasses = PluginLoader.loadAllPluginsEntryClasses();
         } catch (RuntimeException ex) {
             // No plugins directory is the normal case for a stock install.
             LOG.log(Level.FINE, "No plugin panels loaded: {0}", ex.getMessage());
-            cached = Collections.emptyList();
+            cache(found);
             return cached;
         }
-        for (Class<?> clazz : entryClasses) {
-            if (!StudioPanelApi.class.isAssignableFrom(clazz)) {
+
+        for (Class<?> entryClass : entryClasses) {
+            Panel panel = discover(entryClass);
+            if (panel == null) {
                 continue;
             }
-            try {
-                StudioPanelApi panel = (StudioPanelApi) clazz
-                    .getDeclaredConstructor()
-                    .newInstance();
-                String title = panel.getTitle();
-                if (title == null || title.trim().isEmpty()) {
-                    LOG.log(
-                        Level.WARNING,
-                        "Skipping panel plugin with a blank title: {0}",
-                        clazz.getName()
-                    );
-                    continue;
-                }
-                found.add(panel);
-                LOG.log(Level.INFO, "Loaded Studio panel plugin: {0}", title);
-            } catch (ReflectiveOperationException | RuntimeException ex) {
-                LOG.log(Level.WARNING, "Cannot instantiate panel plugin " + clazz.getName(), ex);
+            Panel existing = found.putIfAbsent(panel.getIdentity(), panel);
+            if (existing != null) {
+                LOG.log(
+                    Level.WARNING,
+                    "Skipping duplicate panel identity {0} from {1}",
+                    new Object[] { panel.getIdentity(), entryClass.getName() }
+                );
             }
         }
-        cached = Collections.unmodifiableList(found);
+
+        cache(found);
         return cached;
+    }
+
+    /**
+     * Finds a discovered panel by its stable identity.
+     *
+     * @param identity the plugin ID or entry class name carried by the toolbar action
+     * @return the panel declaration, or {@code null} when no declaration matches
+     */
+    public static synchronized Panel find(String identity) {
+        load();
+        return cachedByIdentity.get(identity);
+    }
+
+    private static Panel discover(Class<?> entryClass) {
+        if (!StudioPanelApi.class.isAssignableFrom(entryClass)) {
+            LOG.log(Level.FINE, "Plugin entry is not a Studio panel: {0}", entryClass.getName());
+            return null;
+        }
+
+        StudioPanelManifest.Metadata metadata = StudioPanelManifest.read(entryClass);
+        if (metadata.surface != null && !"swing".equalsIgnoreCase(metadata.surface)) {
+            LOG.log(
+                Level.INFO,
+                "Skipping Studio panel {0}: unsupported surface {1}",
+                new Object[] {
+                    metadata.pluginId != null ? metadata.pluginId : entryClass.getName(),
+                    metadata.surface
+                }
+            );
+            return null;
+        }
+
+        Constructor<? extends StudioPanelApi> constructor = publicConstructor(entryClass);
+        if (constructor == null) {
+            return null;
+        }
+
+        StudioPanelApi fallbackInstance = null;
+        String title = metadata.title;
+        String tooltip = metadata.tooltip;
+        if (title == null || tooltip == null) {
+            try {
+                fallbackInstance = constructor.newInstance();
+                if (title == null) {
+                    title = fallbackInstance.getTitle();
+                }
+                if (tooltip == null) {
+                    tooltip = fallbackInstance.getTooltip();
+                }
+            } catch (ReflectiveOperationException | RuntimeException ex) {
+                LOG.log(
+                    Level.WARNING,
+                    "Cannot instantiate panel plugin " + entryClass.getName(),
+                    ex
+                );
+                return null;
+            }
+        }
+
+        if (title == null || title.trim().isEmpty()) {
+            LOG.log(
+                Level.WARNING,
+                "Skipping panel plugin with a blank title: {0}",
+                entryClass.getName()
+            );
+            return null;
+        }
+        title = title.trim();
+        if (tooltip == null || tooltip.trim().isEmpty()) {
+            tooltip = title;
+        } else {
+            tooltip = tooltip.trim();
+        }
+
+        Integer order = parseOrder(metadata.order, entryClass);
+        String identity = metadata.pluginId != null ? metadata.pluginId : entryClass.getName();
+        Panel panel = new Panel(
+            identity,
+            title,
+            tooltip,
+            order,
+            metadata.pluginVersion,
+            constructor,
+            fallbackInstance
+        );
+        LOG.log(
+            Level.INFO,
+            "Discovered Studio panel {0} ({1}), version {2}",
+            new Object[] {
+                panel.getTitle(),
+                panel.getIdentity(),
+                metadata.pluginVersion != null ? metadata.pluginVersion : "unspecified"
+            }
+        );
+        return panel;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Constructor<? extends StudioPanelApi> publicConstructor(Class<?> entryClass) {
+        if (
+            !Modifier.isPublic(entryClass.getModifiers()) ||
+            Modifier.isAbstract(entryClass.getModifiers())
+        ) {
+            LOG.log(
+                Level.WARNING,
+                "Skipping non-instantiable panel plugin: {0}",
+                entryClass.getName()
+            );
+            return null;
+        }
+        try {
+            return (Constructor<? extends StudioPanelApi>) entryClass.getConstructor();
+        } catch (NoSuchMethodException | SecurityException ex) {
+            LOG.log(
+                Level.WARNING,
+                "Panel plugin requires a public no-argument constructor: {0}",
+                entryClass.getName()
+            );
+            return null;
+        }
+    }
+
+    private static Integer parseOrder(String value, Class<?> entryClass) {
+        if (value == null) {
+            return null;
+        }
+        try {
+            return Integer.valueOf(value);
+        } catch (NumberFormatException ex) {
+            LOG.log(
+                Level.WARNING,
+                "Ignoring non-integer studioPanelOrder ''{0}'' for {1}",
+                new Object[] { value, entryClass.getName() }
+            );
+            return null;
+        }
+    }
+
+    private static void cache(Map<String, Panel> found) {
+        List<Panel> sorted = new ArrayList<>(found.values());
+        sorted.sort(
+            Comparator
+                .comparing(Panel::getOrder, Comparator.nullsLast(Comparator.naturalOrder()))
+                .thenComparing(Panel::getTitle)
+                .thenComparing(Panel::getIdentity)
+        );
+        cached = Collections.unmodifiableList(sorted);
+
+        Map<String, Panel> byIdentity = new LinkedHashMap<>();
+        for (Panel panel : sorted) {
+            byIdentity.put(panel.getIdentity(), panel);
+        }
+        cachedByIdentity = Collections.unmodifiableMap(byIdentity);
     }
 
     /**
      * Slide identity for a panel. Namespaced so a plugin cannot collide with a built-in
      * screen such as {@code TestDesign}.
      *
-     * @param title the panel title
+     * @param identity the plugin ID, or entry class name when no ID is declared
      * @return the slide name
      */
-    public static String slideName(String title) {
-        return "Plugin:" + title;
+    public static String slideName(String identity) {
+        return "Plugin:" + identity;
+    }
+
+    /**
+     * A panel declaration whose factory and Swing component are activated on demand.
+     */
+    public static final class Panel {
+        private final String identity;
+        private final String title;
+        private final String tooltip;
+        private final Integer order;
+        private final String version;
+        private final Constructor<? extends StudioPanelApi> constructor;
+
+        private StudioPanelApi factory;
+        private JComponent component;
+        private boolean activationAttempted;
+
+        private Panel(
+            String identity,
+            String title,
+            String tooltip,
+            Integer order,
+            String version,
+            Constructor<? extends StudioPanelApi> constructor,
+            StudioPanelApi factory
+        ) {
+            this.identity = identity;
+            this.title = title;
+            this.tooltip = tooltip;
+            this.order = order;
+            this.version = version;
+            this.constructor = constructor;
+            this.factory = factory;
+        }
+
+        public String getIdentity() {
+            return identity;
+        }
+
+        public String getTitle() {
+            return title;
+        }
+
+        public String getTooltip() {
+            return tooltip;
+        }
+
+        public Integer getOrder() {
+            return order;
+        }
+
+        public String getVersion() {
+            return version;
+        }
+
+        /**
+         * Creates the panel on first activation and returns the cached component thereafter.
+         * A failed activation is not retried.
+         *
+         * @return the component, or {@code null} when construction failed
+         */
+        public synchronized JComponent activate() {
+            if (activationAttempted) {
+                return component;
+            }
+            activationAttempted = true;
+
+            try {
+                if (factory == null) {
+                    factory = constructor.newInstance();
+                }
+                component = factory.createPanel();
+                if (component == null) {
+                    LOG.log(Level.WARNING, "Panel plugin returned no component: {0}", identity);
+                }
+            } catch (ReflectiveOperationException | RuntimeException ex) {
+                LOG.log(Level.WARNING, "Panel plugin failed during activation: " + identity, ex);
+                component = null;
+            }
+            return component;
+        }
     }
 }

--- a/IDE/src/main/java/com/ing/ide/main/mainui/plugins/StudioPanelPlugins.java
+++ b/IDE/src/main/java/com/ing/ide/main/mainui/plugins/StudioPanelPlugins.java
@@ -48,8 +48,9 @@ public final class StudioPanelPlugins {
         try {
             entryClasses = PluginLoader.loadAllPluginsEntryClasses();
         } catch (RuntimeException ex) {
-            // No plugins directory is the normal case for a stock install.
-            LOG.log(Level.FINE, "No plugin panels loaded: {0}", ex.getMessage());
+            // No plugins directory is the normal case for a stock install. Say so at INFO:
+            // an empty toolbar with a silent log is indistinguishable from a broken load.
+            LOG.log(Level.INFO, "No Studio panels loaded: {0}", ex.getMessage());
             cache(found);
             return cached;
         }
@@ -70,6 +71,7 @@ public final class StudioPanelPlugins {
         }
 
         cache(found);
+        LOG.log(Level.INFO, "Studio panel discovery finished: {0} panel(s)", cached.size());
         return cached;
     }
 
@@ -302,6 +304,7 @@ public final class StudioPanelPlugins {
             }
             activationAttempted = true;
 
+            LOG.log(Level.INFO, "Activating Studio panel {0}", identity);
             try {
                 if (factory == null) {
                     factory = constructor.newInstance();

--- a/IDE/src/main/java/com/ing/ide/main/mainui/plugins/StudioPanelPlugins.java
+++ b/IDE/src/main/java/com/ing/ide/main/mainui/plugins/StudioPanelPlugins.java
@@ -1,6 +1,7 @@
 package com.ing.ide.main.mainui.plugins;
 
 import com.ing.engine.plugin.loader.PluginLoader;
+import com.ing.ingenious.api.contract.data.ProjectTestDataApi;
 import com.ing.ingenious.api.contract.ui.StudioPanelApi;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Modifier;
@@ -296,9 +297,11 @@ public final class StudioPanelPlugins {
          * Creates the panel on first activation and returns the cached component thereafter.
          * A failed activation is not retried.
          *
+         * @param testData the open project's test data, handed to the panel before its screen
+         *     is built; may be {@code null} when the host has none to offer
          * @return the component, or {@code null} when construction failed
          */
-        public synchronized JComponent activate() {
+        public synchronized JComponent activate(ProjectTestDataApi testData) {
             if (activationAttempted) {
                 return component;
             }
@@ -308,6 +311,9 @@ public final class StudioPanelPlugins {
             try {
                 if (factory == null) {
                     factory = constructor.newInstance();
+                }
+                if (testData != null) {
+                    factory.setProjectTestData(testData);
                 }
                 component = factory.createPanel();
                 if (component == null) {

--- a/IDE/src/main/java/com/ing/ide/main/mainui/plugins/StudioPanelPlugins.java
+++ b/IDE/src/main/java/com/ing/ide/main/mainui/plugins/StudioPanelPlugins.java
@@ -87,7 +87,17 @@ public final class StudioPanelPlugins {
         return cachedByIdentity.get(identity);
     }
 
-    private static Panel discover(Class<?> entryClass) {
+    /**
+     * Turns one plugin entry class into a panel declaration, or rejects it.
+     *
+     * <p>Package-private rather than private so the rejection paths can be exercised without an
+     * installed plugin directory, in the same way {@code PluginLoader} exposes its search-path
+     * overload to its own test.
+     *
+     * @param entryClass a class listed in a plugin JAR's {@code pluginEntryClasses} attribute
+     * @return the declaration, or {@code null} when the class is not a usable panel
+     */
+    static Panel discover(Class<?> entryClass) {
         if (!StudioPanelApi.class.isAssignableFrom(entryClass)) {
             LOG.log(Level.FINE, "Plugin entry is not a Studio panel: {0}", entryClass.getName());
             return null;

--- a/IDE/src/test/java/com/example/panel/SamplePanel.java
+++ b/IDE/src/test/java/com/example/panel/SamplePanel.java
@@ -1,0 +1,55 @@
+package com.example.panel;
+
+import com.ing.ingenious.api.contract.data.ProjectTestDataApi;
+import javax.swing.JComponent;
+import javax.swing.JPanel;
+
+/**
+ * A panel plugin exactly as a third party would write one, packed into a generated JAR by
+ * {@code StudioPanelPluginsTest} and loaded through the production plugin class loader.
+ *
+ * <p>The static counters are read back through reflection on the loaded class, so a test can
+ * see how often this plugin was instantiated and what was handed to it. They are per class
+ * loader, which is what makes them usable as evidence that two plugins are isolated.
+ */
+public class SamplePanel implements com.ing.ingenious.api.contract.ui.StudioPanelApi {
+    /** How often this class has been instantiated inside its own class loader. */
+    public static int instances;
+
+    /** How often {@link #createPanel()} has been called inside its own class loader. */
+    public static int panelsCreated;
+
+    /** The last test data handed over, or {@code null} when none was. */
+    public static Object lastTestData;
+
+    /** Set to {@code true} to make {@link #createPanel()} throw, as a broken screen would. */
+    public static boolean failToCreatePanel;
+
+    public SamplePanel() {
+        instances++;
+    }
+
+    @Override
+    public String getTitle() {
+        return "Title from the class";
+    }
+
+    @Override
+    public String getTooltip() {
+        return "Tooltip from the class";
+    }
+
+    @Override
+    public JComponent createPanel() {
+        panelsCreated++;
+        if (failToCreatePanel) {
+            throw new IllegalStateException("this screen cannot be built");
+        }
+        return new JPanel();
+    }
+
+    @Override
+    public void setProjectTestData(ProjectTestDataApi testData) {
+        lastTestData = testData;
+    }
+}

--- a/IDE/src/test/java/com/example/panel/UnbuildablePanel.java
+++ b/IDE/src/test/java/com/example/panel/UnbuildablePanel.java
@@ -1,0 +1,26 @@
+package com.example.panel;
+
+import com.ing.ingenious.api.contract.ui.StudioPanelApi;
+import javax.swing.JComponent;
+
+/**
+ * A panel plugin that cannot be constructed, as a plugin built against a different release or
+ * missing a dependency behaves. Used to check that such a plugin is rejected on its own instead
+ * of taking the rest of the toolbar with it.
+ */
+public class UnbuildablePanel implements StudioPanelApi {
+
+    public UnbuildablePanel() {
+        throw new IllegalStateException("this plugin cannot start here");
+    }
+
+    @Override
+    public String getTitle() {
+        return "never reached";
+    }
+
+    @Override
+    public JComponent createPanel() {
+        return null;
+    }
+}

--- a/IDE/src/test/java/com/ing/ide/main/mainui/plugins/RecordingTargetPluginsTest.java
+++ b/IDE/src/test/java/com/ing/ide/main/mainui/plugins/RecordingTargetPluginsTest.java
@@ -1,0 +1,104 @@
+package com.ing.ide.main.mainui.plugins;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.ing.ingenious.api.contract.ui.RecordingTarget;
+import com.ing.ingenious.api.contract.ui.RecordingTargetApi;
+import java.util.List;
+import org.testng.Reporter;
+import org.testng.annotations.Test;
+
+/**
+ * Exercises the rule the recorder relies on: a plugin may answer where a recording belongs, but
+ * no plugin may prevent a recording from starting.
+ */
+public class RecordingTargetPluginsTest {
+
+    @Test
+    public void theFirstPluginWithAnAnswerDecidesAndTheRestAreNotAsked() {
+        RecordingTarget expected = new RecordingTarget("Checkout", "Pay by card");
+        boolean[] secondWasAsked = { false };
+
+        RecordingTarget target = RecordingTargetPlugins.currentTarget(
+            List.of(
+                () -> expected,
+                () -> {
+                    secondWasAsked[0] = true;
+                    return new RecordingTarget("Other", "Other");
+                }
+            )
+        );
+
+        assertThat(target).isSameAs(expected);
+        assertThat(secondWasAsked[0])
+            .as("a later plugin is not consulted once one has answered")
+            .isFalse();
+
+        Reporter.log(
+            "theFirstPluginWithAnAnswerDecidesAndTheRestAreNotAsked EVIDENCE: target=" +
+            target +
+            ", second plugin asked=" +
+            secondWasAsked[0],
+            true
+        );
+    }
+
+    @Test
+    public void aPluginWithNoOpinionIsPassedOver() {
+        RecordingTarget expected = new RecordingTarget("Checkout", "Pay by card", true);
+
+        RecordingTarget target = RecordingTargetPlugins.currentTarget(
+            List.of(() -> null, () -> expected)
+        );
+
+        assertThat(target).isSameAs(expected);
+        assertThat(target.isReusableScenario()).isTrue();
+
+        Reporter.log(
+            "aPluginWithNoOpinionIsPassedOver EVIDENCE: a null answer was skipped and the next plugin supplied " +
+            target,
+            true
+        );
+    }
+
+    @Test
+    public void aThrowingPluginCannotStopARecordingFromStarting() {
+        RecordingTarget expected = new RecordingTarget(
+            "Checkout",
+            "Pay by card",
+            false,
+            "https://example.invalid/checkout"
+        );
+        RecordingTargetApi throwing = () -> {
+            throw new IllegalStateException("the tracker is unreachable");
+        };
+
+        RecordingTarget target = RecordingTargetPlugins.currentTarget(
+            List.of(throwing, () -> expected)
+        );
+
+        assertThat(target).isSameAs(expected);
+        assertThat(target.getStartUrl()).isEqualTo("https://example.invalid/checkout");
+
+        Reporter.log(
+            "aThrowingPluginCannotStopARecordingFromStarting EVIDENCE: a plugin that threw was skipped and the recording target became " +
+            target,
+            true
+        );
+    }
+
+    @Test
+    public void withNoAnswerAtAllTheUserIsAskedAsUsual() {
+        RecordingTargetApi throwing = () -> {
+            throw new IllegalStateException("the tracker is unreachable");
+        };
+
+        assertThat(RecordingTargetPlugins.currentTarget(List.of(throwing, () -> null))).isNull();
+        assertThat(RecordingTargetPlugins.currentTarget(List.of())).isNull();
+
+        Reporter.log(
+            "withNoAnswerAtAllTheUserIsAskedAsUsual EVIDENCE: a throwing plugin, a silent plugin and an empty plugin list all returned null, which is what makes Studio open its own target chooser",
+            true
+        );
+    }
+}

--- a/IDE/src/test/java/com/ing/ide/main/mainui/plugins/StudioPanelPluginsTest.java
+++ b/IDE/src/test/java/com/ing/ide/main/mainui/plugins/StudioPanelPluginsTest.java
@@ -1,0 +1,434 @@
+package com.ing.ide.main.mainui.plugins;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import com.ing.engine.plugin.loader.PluginClassLoader;
+import com.ing.ingenious.api.contract.data.ProjectTestDataApi;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.text.MessageFormat;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.jar.Attributes;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
+import java.util.jar.Manifest;
+import java.util.logging.Handler;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+import javax.swing.JComponent;
+import org.testng.Reporter;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+/**
+ * Exercises the Studio panel SPI against real plugin JARs.
+ *
+ * <p>Every plugin here is built as a JAR at run time and loaded through the production
+ * {@link PluginClassLoader}, so the manifest that is read is a real JAR manifest and the class
+ * that is inspected really did come from that JAR. Nothing about the panel contract is
+ * simulated.
+ */
+public class StudioPanelPluginsTest {
+    private static final String PANEL_CLASS = "com.example.panel.SamplePanel";
+    private static final String UNBUILDABLE_PANEL_CLASS = "com.example.panel.UnbuildablePanel";
+
+    private Path temporaryDirectory;
+    private List<PluginClassLoader> classLoaders;
+    private List<String> logMessages;
+    private Handler logHandler;
+
+    @BeforeMethod
+    public void setUp() throws IOException {
+        temporaryDirectory = Files.createTempDirectory("studio-panel-test-");
+        classLoaders = new ArrayList<>();
+        logMessages = new CopyOnWriteArrayList<>();
+        logHandler =
+            new Handler() {
+
+                @Override
+                public void publish(LogRecord record) {
+                    logMessages.add(format(record));
+                }
+
+                @Override
+                public void flush() {}
+
+                @Override
+                public void close() {}
+            };
+        Logger.getLogger(StudioPanelPlugins.class.getName()).addHandler(logHandler);
+    }
+
+    @AfterMethod(alwaysRun = true)
+    public void tearDown() throws IOException {
+        Logger.getLogger(StudioPanelPlugins.class.getName()).removeHandler(logHandler);
+        for (PluginClassLoader classLoader : classLoaders) {
+            classLoader.close();
+        }
+        if (temporaryDirectory != null) {
+            try (var paths = Files.walk(temporaryDirectory)) {
+                for (Path path : paths.sorted((left, right) -> right.compareTo(left)).toList()) {
+                    try {
+                        Files.deleteIfExists(path);
+                    } catch (IOException ex) {
+                        path.toFile().deleteOnExit();
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    public void manifestMetadataPlacesThePanelWithoutInstantiatingThePlugin() throws Exception {
+        Map<String, String> manifest = new LinkedHashMap<>();
+        manifest.put("pluginId", "sample.panel");
+        manifest.put("pluginVersion", "1.2.3");
+        manifest.put("studioPanelTitle", "Test Data");
+        manifest.put("studioPanelTooltip", "Pick test data for this test case");
+        manifest.put("studioPanelOrder", "20");
+        Class<?> panelClass = loadPanel("complete", PANEL_CLASS, manifest);
+
+        StudioPanelPlugins.Panel panel = StudioPanelPlugins.discover(panelClass);
+
+        assertThat(panel).isNotNull();
+        assertThat(panel.getIdentity()).isEqualTo("sample.panel");
+        assertThat(panel.getVersion()).isEqualTo("1.2.3");
+        assertThat(panel.getOrder()).isEqualTo(20);
+        // The class answers "Title from the class"/"Tooltip from the class"; reading the JAR's
+        // manifest is the only way to arrive at these two values.
+        assertThat(panel.getTitle()).isEqualTo("Test Data");
+        assertThat(panel.getTooltip()).isEqualTo("Pick test data for this test case");
+        assertThat(instances(panelClass))
+            .as("a fully declared panel is placed on the toolbar without being constructed")
+            .isZero();
+
+        Reporter.log(
+            "manifestMetadataPlacesThePanelWithoutInstantiatingThePlugin EVIDENCE: title/tooltip/order/id/version all came from the JAR manifest and the plugin was constructed " +
+            instances(panelClass) +
+            " times",
+            true
+        );
+    }
+
+    @Test
+    public void panelWithoutManifestMetadataFallsBackToTheClass() throws Exception {
+        Class<?> panelClass = loadPanel("bare", PANEL_CLASS, new LinkedHashMap<>());
+
+        StudioPanelPlugins.Panel panel = StudioPanelPlugins.discover(panelClass);
+
+        assertThat(panel).isNotNull();
+        assertThat(panel.getIdentity()).isEqualTo(PANEL_CLASS);
+        assertThat(panel.getTitle()).isEqualTo("Title from the class");
+        assertThat(panel.getTooltip()).isEqualTo("Tooltip from the class");
+        assertThat(panel.getOrder()).isNull();
+        assertThat(panel.getVersion()).isNull();
+        assertThat(instances(panelClass))
+            .as("the plugin is constructed once to supply the metadata the manifest omitted")
+            .isEqualTo(1);
+
+        Reporter.log(
+            "panelWithoutManifestMetadataFallsBackToTheClass EVIDENCE: identity fell back to " +
+            panel.getIdentity() +
+            " and the title came from the class",
+            true
+        );
+    }
+
+    @Test
+    public void panelInAJarWithoutAManifestIsStillPlaced() throws Exception {
+        Class<?> panelClass = loadPanel("no-manifest", PANEL_CLASS, null);
+
+        StudioPanelPlugins.Panel panel = StudioPanelPlugins.discover(panelClass);
+
+        assertThat(panel).isNotNull();
+        assertThat(panel.getIdentity()).isEqualTo(PANEL_CLASS);
+        assertThat(panel.getTitle()).isEqualTo("Title from the class");
+        assertThat(panel.getVersion()).isNull();
+
+        Reporter.log(
+            "panelInAJarWithoutAManifestIsStillPlaced EVIDENCE: a JAR with no manifest at all produced panel " +
+            panel.getIdentity() +
+            " instead of an error",
+            true
+        );
+    }
+
+    @Test
+    public void malformedManifestValuesAreIgnoredWithoutLosingTheRest() throws Exception {
+        Map<String, String> manifest = new LinkedHashMap<>();
+        manifest.put("studioPanelTitle", "Reports");
+        manifest.put("studioPanelOrder", "soon");
+        Class<?> panelClass = loadPanel("malformed", PANEL_CLASS, manifest);
+
+        StudioPanelPlugins.Panel panel = StudioPanelPlugins.discover(panelClass);
+
+        assertThat(panel).isNotNull();
+        assertThat(panel.getTitle())
+            .as("the readable half of the manifest survives")
+            .isEqualTo("Reports");
+        assertThat(panel.getOrder()).as("a non-integer order is dropped").isNull();
+        assertThat(panel.getTooltip()).isEqualTo("Tooltip from the class");
+        assertThat(logMessages)
+            .anySatisfy(
+                message ->
+                    assertThat(message)
+                        .contains("studioPanelOrder")
+                        .contains("soon")
+                        .contains(PANEL_CLASS)
+            );
+
+        Reporter.log(
+            "malformedManifestValuesAreIgnoredWithoutLosingTheRest EVIDENCE: order 'soon' was dropped and logged, title 'Reports' was kept",
+            true
+        );
+    }
+
+    @Test
+    public void panelDeclaringAnUnsupportedSurfaceIsRejected() throws Exception {
+        Map<String, String> manifest = new LinkedHashMap<>();
+        manifest.put("pluginId", "web.panel");
+        manifest.put("studioPanelTitle", "Browser Screen");
+        manifest.put("studioPanelSurface", "web");
+        Class<?> panelClass = loadPanel("web-surface", PANEL_CLASS, manifest);
+
+        assertThat(StudioPanelPlugins.discover(panelClass)).isNull();
+        assertThat(logMessages)
+            .anySatisfy(
+                message -> assertThat(message).contains("web.panel").contains("unsupported surface")
+            );
+        assertThat(instances(panelClass))
+            .as("a panel Studio cannot host is never constructed")
+            .isZero();
+
+        Reporter.log(
+            "panelDeclaringAnUnsupportedSurfaceIsRejected EVIDENCE: studioPanelSurface=web was refused before construction",
+            true
+        );
+    }
+
+    @Test
+    public void aPluginThatCannotBeConstructedIsRejectedWithoutTakingTheOthersDown()
+        throws Exception {
+        Class<?> unbuildable = loadPanel(
+            "unbuildable",
+            UNBUILDABLE_PANEL_CLASS,
+            new LinkedHashMap<>()
+        );
+        Map<String, String> manifest = new LinkedHashMap<>();
+        manifest.put("pluginId", "healthy.panel");
+        manifest.put("studioPanelTitle", "Healthy");
+        manifest.put("studioPanelTooltip", "Still here");
+        Class<?> healthy = loadPanel("healthy", PANEL_CLASS, manifest);
+
+        List<String> survivors = new ArrayList<>();
+        // String.class stands in for a plugin entry class that is not a panel at all - the
+        // ordinary case, since action plugins are discovered through the same list.
+        for (Class<?> candidate : List.of(unbuildable, String.class, healthy)) {
+            StudioPanelPlugins.Panel panel = StudioPanelPlugins.discover(candidate);
+            if (panel != null) {
+                survivors.add(panel.getIdentity());
+            }
+        }
+
+        assertThat(survivors).containsExactly("healthy.panel");
+        assertThat(logMessages)
+            .anySatisfy(
+                message ->
+                    assertThat(message)
+                        .contains("Cannot instantiate panel plugin")
+                        .contains(UNBUILDABLE_PANEL_CLASS)
+            );
+
+        Reporter.log(
+            "aPluginThatCannotBeConstructedIsRejectedWithoutTakingTheOthersDown EVIDENCE: survivors=" +
+            survivors +
+            " after a throwing constructor and a non-panel entry class",
+            true
+        );
+    }
+
+    @Test
+    public void eachPluginGetsItsOwnClassLoaderAndReadsItsOwnManifest() throws Exception {
+        Map<String, String> firstManifest = new LinkedHashMap<>();
+        firstManifest.put("pluginId", "first.panel");
+        firstManifest.put("studioPanelTitle", "First");
+        firstManifest.put("studioPanelTooltip", "First screen");
+        Map<String, String> secondManifest = new LinkedHashMap<>();
+        secondManifest.put("pluginId", "second.panel");
+        secondManifest.put("studioPanelTitle", "Second");
+        secondManifest.put("studioPanelTooltip", "Second screen");
+
+        // The same class name, shipped by two different plugins.
+        Class<?> first = loadPanel("first", PANEL_CLASS, firstManifest);
+        Class<?> second = loadPanel("second", PANEL_CLASS, secondManifest);
+
+        assertThat(first).isNotSameAs(second);
+        assertThat(first.getClassLoader()).isNotSameAs(second.getClassLoader());
+        assertThat(first.getClassLoader()).isInstanceOf(PluginClassLoader.class);
+        assertThat(second.getClassLoader()).isInstanceOf(PluginClassLoader.class);
+
+        StudioPanelPlugins.Panel firstPanel = StudioPanelPlugins.discover(first);
+        StudioPanelPlugins.Panel secondPanel = StudioPanelPlugins.discover(second);
+
+        assertThat(firstPanel.getIdentity()).isEqualTo("first.panel");
+        assertThat(firstPanel.getTitle()).isEqualTo("First");
+        assertThat(secondPanel.getIdentity()).isEqualTo("second.panel");
+        assertThat(secondPanel.getTitle()).isEqualTo("Second");
+
+        // Separate loaders mean separate static state, so one plugin's trouble is its own.
+        first.getField("failToCreatePanel").setBoolean(null, true);
+        assertThat(second.getField("failToCreatePanel").getBoolean(null)).isFalse();
+
+        Reporter.log(
+            "eachPluginGetsItsOwnClassLoaderAndReadsItsOwnManifest EVIDENCE: loaders " +
+            System.identityHashCode(first.getClassLoader()) +
+            " and " +
+            System.identityHashCode(second.getClassLoader()) +
+            " gave the same class name the identities first.panel and second.panel, with separate static state",
+            true
+        );
+    }
+
+    @Test
+    public void activationBuildsTheScreenOnceAndHandsOverTheProjectTestData() throws Exception {
+        Map<String, String> manifest = new LinkedHashMap<>();
+        manifest.put("pluginId", "activating.panel");
+        manifest.put("studioPanelTitle", "Test Data");
+        manifest.put("studioPanelTooltip", "Test Data");
+        Class<?> panelClass = loadPanel("activating", PANEL_CLASS, manifest);
+        ProjectTestDataApi testData = mock(ProjectTestDataApi.class);
+
+        StudioPanelPlugins.Panel panel = StudioPanelPlugins.discover(panelClass);
+        JComponent component = panel.activate(testData);
+
+        assertThat(component).isNotNull();
+        assertThat(panelClass.getField("lastTestData").get(null)).isSameAs(testData);
+        assertThat(panelsCreated(panelClass)).isEqualTo(1);
+
+        assertThat(panel.activate(testData))
+            .as("the screen is built once and reused")
+            .isSameAs(component);
+        assertThat(panelsCreated(panelClass)).isEqualTo(1);
+
+        Reporter.log(
+            "activationBuildsTheScreenOnceAndHandsOverTheProjectTestData EVIDENCE: createPanel() ran " +
+            panelsCreated(panelClass) +
+            " time across two activations, and the panel received the ProjectTestDataApi instance",
+            true
+        );
+    }
+
+    @Test
+    public void aPanelThatFailsToBuildReturnsNoComponentAndIsNotRetried() throws Exception {
+        Map<String, String> manifest = new LinkedHashMap<>();
+        manifest.put("pluginId", "failing.panel");
+        manifest.put("studioPanelTitle", "Broken");
+        manifest.put("studioPanelTooltip", "Broken");
+        Class<?> panelClass = loadPanel("failing", PANEL_CLASS, manifest);
+        panelClass.getField("failToCreatePanel").setBoolean(null, true);
+
+        StudioPanelPlugins.Panel panel = StudioPanelPlugins.discover(panelClass);
+
+        assertThat(panel.activate(null)).isNull();
+        assertThat(panel.activate(null)).isNull();
+        assertThat(panelsCreated(panelClass))
+            .as("a failed activation is not retried on every toolbar click")
+            .isEqualTo(1);
+        assertThat(logMessages)
+            .anySatisfy(
+                message ->
+                    assertThat(message)
+                        .contains("Panel plugin failed during activation")
+                        .contains("failing.panel")
+            );
+
+        Reporter.log(
+            "aPanelThatFailsToBuildReturnsNoComponentAndIsNotRetried EVIDENCE: createPanel() ran " +
+            panelsCreated(panelClass) +
+            " time across two activations and both returned no component",
+            true
+        );
+    }
+
+    /**
+     * Packs the compiled fixture class into a JAR and loads it through the production plugin
+     * class loader, so the loaded class's code source is that JAR and its manifest is read from
+     * it.
+     *
+     * @param folderName a name unique within this test, so each plugin gets its own JAR
+     * @param className the fixture class to pack
+     * @param manifestAttributes the manifest entries, or {@code null} for a JAR with no manifest
+     * @return the loaded class
+     */
+    private Class<?> loadPanel(
+        String folderName,
+        String className,
+        Map<String, String> manifestAttributes
+    )
+        throws Exception {
+        Path pluginFolder = Files.createDirectories(temporaryDirectory.resolve(folderName));
+        Path jarPath = pluginFolder.resolve("plugin.jar");
+        String resource = "/" + className.replace('.', '/') + ".class";
+
+        try (InputStream classBytes = getClass().getResourceAsStream(resource)) {
+            assertThat(classBytes).as("compiled fixture " + className).isNotNull();
+            try (
+                JarOutputStream jar = manifestAttributes == null
+                    ? new JarOutputStream(Files.newOutputStream(jarPath))
+                    : new JarOutputStream(
+                        Files.newOutputStream(jarPath),
+                        manifestOf(className, manifestAttributes)
+                    )
+            ) {
+                jar.putNextEntry(new JarEntry(resource.substring(1)));
+                classBytes.transferTo(jar);
+                jar.closeEntry();
+            }
+        }
+
+        PluginClassLoader classLoader = new PluginClassLoader(
+            new URL[] { jarPath.toUri().toURL() },
+            getClass().getClassLoader()
+        );
+        classLoaders.add(classLoader);
+        Class<?> loaded = classLoader.loadClass(className);
+        assertThat(loaded.getClassLoader())
+            .as("the fixture must come from the JAR, not from the test class path")
+            .isSameAs(classLoader);
+        return loaded;
+    }
+
+    private Manifest manifestOf(String className, Map<String, String> manifestAttributes) {
+        Manifest manifest = new Manifest();
+        Attributes attributes = manifest.getMainAttributes();
+        attributes.put(Attributes.Name.MANIFEST_VERSION, "1.0");
+        attributes.putValue("pluginEntryClasses", className);
+        manifestAttributes.forEach(attributes::putValue);
+        return manifest;
+    }
+
+    private int instances(Class<?> panelClass) throws Exception {
+        return panelClass.getField("instances").getInt(null);
+    }
+
+    private int panelsCreated(Class<?> panelClass) throws Exception {
+        return panelClass.getField("panelsCreated").getInt(null);
+    }
+
+    private String format(LogRecord record) {
+        Object[] parameters = record.getParameters();
+        String message = parameters == null
+            ? record.getMessage()
+            : MessageFormat.format(record.getMessage(), parameters);
+        return record.getThrown() == null ? message : message + " | " + record.getThrown();
+    }
+}

--- a/README.md
+++ b/README.md
@@ -79,6 +79,12 @@ Developed and perfected by <span style="color:#FF6200;width:100px">**ING Bank**<
 
     <span style="color:#FF6200">INGenious</span> features a powerful **Plugin System** that lets you extend the framework with custom automation actions, new object types, and integrations—across browser, database, mobile, web services, and more.
 
+    Plugins are discovered from the user data directory first, followed by the installation's `plugins` directory. The user directory is `%LOCALAPPDATA%\INGenious\plugins` on Windows, `~/Library/Application Support/INGenious/plugins` on macOS, and `${XDG_DATA_HOME:-$HOME/.local/share}/ingenious/plugins` on Linux and other systems. Earlier directories take precedence for the same plugin identity.
+
+    Set `INGENIOUS_PLUGIN_PATH` to a platform path-separator-delimited list to replace those defaults, or set `INGENIOUS_DISABLE_USER_PLUGINS=true` (or `1`) to scan only the installation directory. The explicit search path remains active when user plugins are disabled.
+
+    A plugin JAR can declare optional `pluginId` and `pluginVersion` main manifest attributes. `pluginId` provides stable identity for precedence, while `pluginVersion` is logged for information. Existing plugins without `pluginId` use their plugin folder name.
+
     [:arrow_right: Customizations](https://ing-bank.github.io/ingenious-doc/customizations/)
 
 -   :white_check_mark: __Integrated BDD__

--- a/ingenious-api/src/main/java/com/ing/ingenious/api/contract/data/ProjectTestDataApi.java
+++ b/ingenious-api/src/main/java/com/ing/ingenious/api/contract/data/ProjectTestDataApi.java
@@ -1,0 +1,73 @@
+package com.ing.ingenious.api.contract.data;
+
+import java.util.List;
+
+/**
+ * The test data of the project a user has open, for plugins that read or write it while tests
+ * are being designed.
+ *
+ * <p>The engine already reads test data while a test runs, through {@link TestDataViewApi}.
+ * This is the other half of the same model, at design time. A plugin that helps prepare a test
+ * case — a data picker, an importer, a bridge to an external test management system — can
+ * record on the test case itself what it decided, so the decision becomes part of the project,
+ * is visible where test data is edited, and is still there the next time the project is opened.
+ *
+ * <p>Every method answers for whichever project is open at the moment it is called, so a plugin
+ * can keep one instance for its lifetime instead of following project changes. With no project
+ * open there is nothing to read or write: {@link #sheets()} is empty, {@link #testCase} returns
+ * {@code null}, and the rest return {@code false}.
+ *
+ * <pre>{@code
+ * testData.addSheet("Customers");
+ * testData.addColumn("Customers", "Segment");
+ * testData.testCase("Customers", "Checkout", "Pay by card").update("Segment", "business");
+ * testData.save("Customers");
+ * }</pre>
+ */
+public interface ProjectTestDataApi {
+    /**
+     * Names of the test data sheets in the open project.
+     *
+     * @return the sheet names, empty when no project is open
+     */
+    List<String> sheets();
+
+    /**
+     * Adds a sheet unless the project already has one under that name.
+     *
+     * @param sheet the sheet name
+     * @return {@code true} when the project has the sheet afterwards
+     */
+    boolean addSheet(String sheet);
+
+    /**
+     * Adds a column to a sheet unless the sheet already has one under that name.
+     *
+     * @param sheet the sheet name
+     * @param column the column name
+     * @return {@code true} when the sheet has the column afterwards
+     */
+    boolean addColumn(String sheet, String column);
+
+    /**
+     * The records of one test case, to read from and to write to.
+     *
+     * <p>A test case that has no records in the sheet yet is given one, so a caller that means
+     * to write does not have to know whether this test case has been given data before.
+     *
+     * @param sheet the sheet name
+     * @param scenario the scenario the test case belongs to
+     * @param testCase the test case name
+     * @return the view, or {@code null} when no project is open or the sheet does not exist
+     */
+    TestDataViewApi testCase(String sheet, String scenario, String testCase);
+
+    /**
+     * Writes a sheet back to the project. Changes made through this interface are held in
+     * memory until this is called.
+     *
+     * @param sheet the sheet name
+     * @return {@code true} when the sheet was written
+     */
+    boolean save(String sheet);
+}

--- a/ingenious-api/src/main/java/com/ing/ingenious/api/contract/ui/RecordingTarget.java
+++ b/ingenious-api/src/main/java/com/ing/ingenious/api/contract/ui/RecordingTarget.java
@@ -1,0 +1,103 @@
+package com.ing.ingenious.api.contract.ui;
+
+/**
+ * The test case a recording belongs to, named rather than referenced.
+ *
+ * <p>A target is just three values: the scenario, the test case inside it, and whether that
+ * scenario is a reusable one. Names rather than object references, so a plugin can express a
+ * target for a test case that does not exist yet — Studio creates whatever is missing before
+ * recording into it, exactly as it does when a user types a new name in the recorder's own
+ * target chooser.
+ *
+ * <p>Instances are immutable and carry no state beyond those three values, so a plugin may
+ * build one per call without keeping anything alive between recordings.
+ *
+ * @see RecordingTargetApi
+ */
+public final class RecordingTarget {
+
+    private final String scenarioName;
+    private final String testCaseName;
+    private final boolean reusableScenario;
+
+    /**
+     * A target under an ordinary test scenario.
+     *
+     * @param scenarioName the scenario name, neither {@code null} nor blank
+     * @param testCaseName the test case name, neither {@code null} nor blank
+     * @throws IllegalArgumentException when either name is {@code null} or blank
+     */
+    public RecordingTarget(String scenarioName, String testCaseName) {
+        this(scenarioName, testCaseName, false);
+    }
+
+    /**
+     * A target under either an ordinary or a reusable scenario.
+     *
+     * @param scenarioName the scenario name, neither {@code null} nor blank
+     * @param testCaseName the test case name, neither {@code null} nor blank
+     * @param reusableScenario {@code true} to place the test case under a reusable scenario
+     * @throws IllegalArgumentException when either name is {@code null} or blank
+     */
+    public RecordingTarget(String scenarioName, String testCaseName, boolean reusableScenario) {
+        this.scenarioName = require(scenarioName, "scenarioName");
+        this.testCaseName = require(testCaseName, "testCaseName");
+        this.reusableScenario = reusableScenario;
+    }
+
+    private static String require(String value, String field) {
+        if (value == null || value.trim().isEmpty()) {
+            throw new IllegalArgumentException(field + " must not be null or blank");
+        }
+        return value.trim();
+    }
+
+    /**
+     * @return the scenario holding the test case, never blank
+     */
+    public String getScenarioName() {
+        return scenarioName;
+    }
+
+    /**
+     * @return the test case to record into, never blank
+     */
+    public String getTestCaseName() {
+        return testCaseName;
+    }
+
+    /**
+     * @return {@code true} when the scenario is a reusable scenario
+     */
+    public boolean isReusableScenario() {
+        return reusableScenario;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        }
+        if (!(other instanceof RecordingTarget)) {
+            return false;
+        }
+        RecordingTarget that = (RecordingTarget) other;
+        return (
+            reusableScenario == that.reusableScenario &&
+            scenarioName.equals(that.scenarioName) &&
+            testCaseName.equals(that.testCaseName)
+        );
+    }
+
+    @Override
+    public int hashCode() {
+        int result = scenarioName.hashCode();
+        result = 31 * result + testCaseName.hashCode();
+        return 31 * result + (reusableScenario ? 1 : 0);
+    }
+
+    @Override
+    public String toString() {
+        return (reusableScenario ? "[Reusable] " : "") + scenarioName + " / " + testCaseName;
+    }
+}

--- a/ingenious-api/src/main/java/com/ing/ingenious/api/contract/ui/RecordingTarget.java
+++ b/ingenious-api/src/main/java/com/ing/ingenious/api/contract/ui/RecordingTarget.java
@@ -19,6 +19,7 @@ public final class RecordingTarget {
     private final String scenarioName;
     private final String testCaseName;
     private final boolean reusableScenario;
+    private final String startUrl;
 
     /**
      * A target under an ordinary test scenario.
@@ -40,9 +41,33 @@ public final class RecordingTarget {
      * @throws IllegalArgumentException when either name is {@code null} or blank
      */
     public RecordingTarget(String scenarioName, String testCaseName, boolean reusableScenario) {
+        this(scenarioName, testCaseName, reusableScenario, null);
+    }
+
+    /**
+     * A target that also says which page the recording should start on.
+     *
+     * <p>Use this when the plugin knows more about the context than the project does — a test
+     * case that belongs to a different module or entry page than the project's usual one. Pass
+     * {@code null} to express no opinion, which leaves the project's own recorder setting in
+     * charge.
+     *
+     * @param scenarioName the scenario name, neither {@code null} nor blank
+     * @param testCaseName the test case name, neither {@code null} nor blank
+     * @param reusableScenario {@code true} to place the test case under a reusable scenario
+     * @param startUrl the page to open, or {@code null} for no opinion
+     * @throws IllegalArgumentException when either name is {@code null} or blank
+     */
+    public RecordingTarget(
+        String scenarioName,
+        String testCaseName,
+        boolean reusableScenario,
+        String startUrl
+    ) {
         this.scenarioName = require(scenarioName, "scenarioName");
         this.testCaseName = require(testCaseName, "testCaseName");
         this.reusableScenario = reusableScenario;
+        this.startUrl = startUrl == null || startUrl.trim().isEmpty() ? null : startUrl.trim();
     }
 
     private static String require(String value, String field) {
@@ -73,6 +98,16 @@ public final class RecordingTarget {
         return reusableScenario;
     }
 
+    /**
+     * The page the recording should start on.
+     *
+     * @return the URL, or {@code null} when this target has no opinion and the project's own
+     *     recorder setting decides
+     */
+    public String getStartUrl() {
+        return startUrl;
+    }
+
     @Override
     public boolean equals(Object other) {
         if (this == other) {
@@ -85,7 +120,8 @@ public final class RecordingTarget {
         return (
             reusableScenario == that.reusableScenario &&
             scenarioName.equals(that.scenarioName) &&
-            testCaseName.equals(that.testCaseName)
+            testCaseName.equals(that.testCaseName) &&
+            (startUrl == null ? that.startUrl == null : startUrl.equals(that.startUrl))
         );
     }
 
@@ -93,11 +129,18 @@ public final class RecordingTarget {
     public int hashCode() {
         int result = scenarioName.hashCode();
         result = 31 * result + testCaseName.hashCode();
-        return 31 * result + (reusableScenario ? 1 : 0);
+        result = 31 * result + (reusableScenario ? 1 : 0);
+        return 31 * result + (startUrl == null ? 0 : startUrl.hashCode());
     }
 
     @Override
     public String toString() {
-        return (reusableScenario ? "[Reusable] " : "") + scenarioName + " / " + testCaseName;
+        return (
+            (reusableScenario ? "[Reusable] " : "") +
+            scenarioName +
+            " / " +
+            testCaseName +
+            (startUrl == null ? "" : " @ " + startUrl)
+        );
     }
 }

--- a/ingenious-api/src/main/java/com/ing/ingenious/api/contract/ui/RecordingTargetApi.java
+++ b/ingenious-api/src/main/java/com/ing/ingenious/api/contract/ui/RecordingTargetApi.java
@@ -1,0 +1,41 @@
+package com.ing.ingenious.api.contract.ui;
+
+/**
+ * Contract for a plugin that already knows which test case a recording belongs to.
+ *
+ * <p>When a recording starts, Studio has to decide where the recorded steps will go, and with
+ * no other source of truth it asks the user: new scenario, current test case, or an existing
+ * one. That question is unavoidable for a standalone Studio, but it is redundant — and easy to
+ * answer wrongly — whenever the user has <em>already</em> said what they are working on
+ * somewhere else. Teams wire Studio to a story tracker, a requirements tool, or their own test
+ * management, pick an item there, and then have to say it a second time to the recorder.
+ *
+ * <p>Implement this on a plugin entry class (the same class listed in the JAR manifest's
+ * {@code pluginEntryClasses} attribute) and Studio asks the plugin first. Return a target and
+ * the recorder uses it, creating the scenario and test case when they do not exist yet, and
+ * opening the test case in the editor. Return {@code null} and the user is asked as usual, so a
+ * plugin only speaks up when it genuinely has an answer.
+ *
+ * <pre>{@code
+ * public class StoryRecordingTarget implements RecordingTargetApi {
+ *     public RecordingTarget getRecordingTarget() {
+ *         Story story = myTracker.currentStory();
+ *         return story == null ? null : new RecordingTarget(story.epic(), story.title());
+ *     }
+ *     }
+ * }</pre>
+ *
+ * <p>Implementations must have a public no-argument constructor. The method is called on the
+ * Event Dispatch Thread each time a recording starts, so it must return promptly and must not
+ * block; it is called once per recording rather than cached, which lets a plugin follow whatever
+ * the user last selected without notifying Studio. Throwing is treated as "no answer" and the
+ * user is asked, so a failing plugin can never stop a recording from starting.
+ */
+public interface RecordingTargetApi {
+    /**
+     * The test case the next recording belongs to.
+     *
+     * @return the target, or {@code null} to let the user choose as usual
+     */
+    RecordingTarget getRecordingTarget();
+}

--- a/ingenious-api/src/main/java/com/ing/ingenious/api/contract/ui/StudioPanelApi.java
+++ b/ingenious-api/src/main/java/com/ing/ingenious/api/contract/ui/StudioPanelApi.java
@@ -1,5 +1,6 @@
 package com.ing.ingenious.api.contract.ui;
 
+import com.ing.ingenious.api.contract.data.ProjectTestDataApi;
 import javax.swing.JComponent;
 
 /**
@@ -56,4 +57,19 @@ public interface StudioPanelApi {
     default String getTooltip() {
         return getTitle();
     }
+
+    /**
+     * Hands the panel the open project's test data, before {@link #createPanel()} is called.
+     *
+     * <p>A screen that helps a user prepare a test case usually has to record what it decided
+     * somewhere the project keeps. {@link ProjectTestDataApi} is that place, and the instance
+     * handed over stays valid for the panel's lifetime — it always answers for whichever
+     * project is open, so the panel can keep it and does not have to follow project changes.
+     *
+     * <p>The default implementation ignores it: a panel that does not touch test data needs no
+     * change.
+     *
+     * @param testData the open project's test data
+     */
+    default void setProjectTestData(ProjectTestDataApi testData) {}
 }

--- a/ingenious-api/src/main/java/com/ing/ingenious/api/contract/ui/StudioPanelApi.java
+++ b/ingenious-api/src/main/java/com/ing/ingenious/api/contract/ui/StudioPanelApi.java
@@ -1,0 +1,56 @@
+package com.ing.ingenious.api.contract.ui;
+
+import javax.swing.JComponent;
+
+/**
+ * Contract for a plugin that contributes its own screen to the INGenious Studio UI.
+ *
+ * <p>Until now the plugin framework could add automation <em>actions</em> and object types,
+ * but nothing that a user sees. Teams that needed a tailored surface — a test-data picker,
+ * a test-case chooser wired to their own test management, an overview panel for
+ * non-technical testers — had to build a separate companion application beside Studio and
+ * keep it in step with every release. This interface removes that need: the surface lives
+ * inside Studio, alongside Test Design and the API Workbench, and ships as an ordinary
+ * plugin JAR.
+ *
+ * <p>Implement this on a plugin entry class (the same class listed in the JAR manifest's
+ * {@code pluginEntryClasses} attribute) and it is discovered automatically at startup.
+ * Implementations must have a public no-argument constructor.
+ *
+ * <pre>{@code
+ * public class TestDataPanel implements StudioPanelApi {
+ *     public String getTitle() { return "Test Data"; }
+ *     public JComponent createPanel() { return new MyPanel(); }
+ * }
+ * }</pre>
+ *
+ * <p>{@link #createPanel()} is called once during startup on the Swing Event Dispatch
+ * Thread. Keep it cheap: build the component and return. Anything slow — a network call, a
+ * large file read — belongs on a background thread started after the panel is shown, so a
+ * misbehaving plugin cannot stall Studio's startup.
+ */
+public interface StudioPanelApi {
+    /**
+     * Human-readable name for this screen. Shown on the toolbar button and used as the
+     * screen's identity, so keep it short and stable across releases.
+     *
+     * @return the panel title, never {@code null} or blank
+     */
+    String getTitle();
+
+    /**
+     * Builds the screen. Called once at startup, on the Event Dispatch Thread.
+     *
+     * @return the component to show, never {@code null}
+     */
+    JComponent createPanel();
+
+    /**
+     * Tooltip for the toolbar button. Defaults to the title.
+     *
+     * @return the tooltip text
+     */
+    default String getTooltip() {
+        return getTitle();
+    }
+}

--- a/ingenious-api/src/main/java/com/ing/ingenious/api/contract/ui/StudioPanelApi.java
+++ b/ingenious-api/src/main/java/com/ing/ingenious/api/contract/ui/StudioPanelApi.java
@@ -15,7 +15,10 @@ import javax.swing.JComponent;
  *
  * <p>Implement this on a plugin entry class (the same class listed in the JAR manifest's
  * {@code pluginEntryClasses} attribute) and it is discovered automatically at startup.
- * Implementations must have a public no-argument constructor.
+ * Implementations must have a public no-argument constructor. Plugins may declare
+ * {@code studioPanelTitle}, {@code studioPanelTooltip}, {@code studioPanelOrder}, and
+ * {@code studioPanelSurface} in the same manifest. The optional {@code pluginId} and
+ * {@code pluginVersion} attributes provide identity and version information.
  *
  * <pre>{@code
  * public class TestDataPanel implements StudioPanelApi {
@@ -24,29 +27,29 @@ import javax.swing.JComponent;
  * }
  * }</pre>
  *
- * <p>{@link #createPanel()} is called once during startup on the Swing Event Dispatch
- * Thread. Keep it cheap: build the component and return. Anything slow — a network call, a
- * large file read — belongs on a background thread started after the panel is shown, so a
- * misbehaving plugin cannot stall Studio's startup.
+ * <p>{@link #createPanel()} is called once, on first activation, on the Swing Event
+ * Dispatch Thread. The returned component is reused for subsequent activations. Keep work
+ * that would block the Event Dispatch Thread on a background thread.
  */
 public interface StudioPanelApi {
     /**
-     * Human-readable name for this screen. Shown on the toolbar button and used as the
-     * screen's identity, so keep it short and stable across releases.
+     * Human-readable name for this screen. Used when {@code studioPanelTitle} is absent
+     * from the manifest.
      *
      * @return the panel title, never {@code null} or blank
      */
     String getTitle();
 
     /**
-     * Builds the screen. Called once at startup, on the Event Dispatch Thread.
+     * Builds the screen. Called once on first activation, on the Event Dispatch Thread.
      *
      * @return the component to show, never {@code null}
      */
     JComponent createPanel();
 
     /**
-     * Tooltip for the toolbar button. Defaults to the title.
+     * Tooltip for the toolbar button when {@code studioPanelTooltip} is absent from the
+     * manifest. Defaults to the title.
      *
      * @return the tooltip text
      */


### PR DESCRIPTION
## Problem

Plugins can already contribute actions, but there is currently no supported way for a plugin to surface a panel a user can actually open in Studio. This proposes filling that UI extension-point gap.

## Design

- Keep the existing `pluginEntryClasses` manifest convention for discovery — no second mechanism.
- Let the JAR manifest *declare* optional panel metadata: `pluginId`, `pluginVersion`, `studioPanelTitle`, `studioPanelTooltip`, `studioPanelOrder`, `studioPanelSurface`.
- Keep `StudioPanelApi` as the *factory* that implements the Swing component.
- Build the component on first activation and cache it, instead of calling `createPanel()` during startup.
- Sort declarations by order then title, use `pluginId` as a stable identity when present, and skip unsupported surfaces before instantiating the plugin class.

This follows the declare-then-instantiate-on-demand shape used by Eclipse (`plugin.xml` view extension points), IntelliJ (`plugin.xml` tool windows with `createToolWindowContent()` invoked on demand), and VS Code (`package.json` contributed views with `onView:` activation).

The practical benefit of deferring: a plugin that blocks in its constructor or in `createPanel()` — a network call, a file lock, a slow disk — no longer delays Studio's startup on the Event Dispatch Thread. Exception handling alone cannot cover that case, since a hang never throws.

### A note on attribute naming

These attributes are camelCase rather than the more common hyphenated manifest style (`Implementation-Title`, `Bundle-SymbolicName`) so they match `pluginEntryClasses`, which this project already ships in the same manifest. Consistency within the file a plugin author is actually editing seemed preferable to introducing a second naming style alongside it. Happy to switch to hyphenated names if you would rather align with the wider convention.

Note that dotted names (`studioPanel.title`) are not an option here: `java.util.jar.Attributes.Name` rejects `.`, so such a manifest fails to assemble, and a hand-built one would break `getManifest()` during discovery.

## Backward compatibility

Every new manifest attribute is optional. A plugin with no metadata keeps working exactly as before: the title and tooltip come from `getTitle()` and `getTooltip()`, and it sorts after any plugin that declares an order. A stock install with no plugins is unaffected.

Existing safety properties are preserved — a missing plugins directory, a non-instantiable class, or a `createPanel()` that throws are each logged and skipped, never fatal. A failed activation is not retried.

## Verification

Built with JDK 17:

- `mvn -B clean install -DskipTests -Dprettier.skip=true --file ingenious-api/pom.xml` — `BUILD SUCCESS`
- `mvn -B clean install -DskipTests -Dprettier.skip=true --file pom.xml` — `BUILD SUCCESS`, all eight reactor modules

Behaviour was then exercised with a sample plugin JAR installed under `plugins/`, driven by a small headless harness. Captured output:

**1. Toolbar metadata is derived without building the panel.** The sample logs `VERIFY_CONSTRUCTOR_CALLED` / `VERIFY_CREATE_PANEL_CALLED`; neither appears, so the class is not even instantiated when all metadata is declared:

```
INFO: Discovered Studio panel Manifest Title (com.example.verify-panel), version 1.2.0
discoveredPanels=1
toolbarEntry{title=Manifest Title, tooltip=Manifest Tooltip, order=100, identity=com.example.verify-panel, version=1.2.0}
```

**2. `createPanel()` runs once, on first activation, and the component is reused:**

```
>>> activation #1
VERIFY_CONSTRUCTOR_CALLED
VERIFY_CREATE_PANEL_CALLED
>>> activation #2
firstComponent=javax.swing.JLabel
secondActivationSameComponent=true
```

**3. `studioPanelTitle` overrides `getTitle()`.** Without the attribute, the interface value is used (backward compatibility); with it, the manifest wins:

```
# no studioPanelTitle
toolbarEntry{title=Interface Title, tooltip=Interface Tooltip, order=null, ...}

# studioPanelTitle: Manifest Title
toolbarEntry{title=Manifest Title, tooltip=Manifest Tooltip, order=100, ...}
```

**4. An unsupported surface is skipped with a log line**, before the class is instantiated — forward-compatibility for a future JavaFX migration:

```
INFO: Skipping Studio panel com.example.verify-panel: unsupported surface javafx
discoveredPanels=0
```

**5. Stock install regression** — with no plugins present at all:

```
discoveredPanels=0
```

Addresses https://github.com/ing-bank/INGenious/issues/313.
