### PR TITLE
Adding to INGenious the capability to handle response body's that have security prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -309,7 +309,7 @@ Release Date: <insert date of release>
 ### Contribution
 
 #### Added
-- by Bulearca, C.I. (Cristian - Irinel) [cristianbulearca-0588](https://github.com/cristianbulearca-0588): Added support for JSON responses containing the security prefix `)]}'` by automatically stripping the prefix before processing.
+- by Bulearca, C.I. (Cristian - Irinel) [@cristianbulearca-0588](https://github.com/cristianbulearca-0588): Added support for JSON responses containing the security prefix `)]}'` by automatically stripping the prefix before processing.
 #### Changed
 #### Deprecated
 #### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -184,6 +184,7 @@ Release Date: <insert date of release>
 - Strengthened SSL/TLS certificate validation
 - Enhanced credential handling in API proxy configuration
 - Introduced API Workbench Environment Management to fully manage and use environments and environment variables
+- Added support for JSON responses containing the security prefix `)]}'`
 
 #### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -184,7 +184,6 @@ Release Date: <insert date of release>
 - Strengthened SSL/TLS certificate validation
 - Enhanced credential handling in API proxy configuration
 - Introduced API Workbench Environment Management to fully manage and use environments and environment variables
-- Added support for JSON responses containing the security prefix `)]}'`
 
 #### Changed
 
@@ -310,6 +309,7 @@ Release Date: <insert date of release>
 ### Contribution
 
 #### Added
+- by Bulearca, C.I. (Cristian - Irinel) [cristianbulearca-0588](https://github.com/cristianbulearca-0588): Added support for JSON responses containing the security prefix `)]}'` by automatically stripping the prefix before processing.
 #### Changed
 #### Deprecated
 #### Removed

--- a/Engine/src/main/java/com/ing/engine/commands/webservice/GeneralWebservice.java
+++ b/Engine/src/main/java/com/ing/engine/commands/webservice/GeneralWebservice.java
@@ -281,10 +281,15 @@ public class GeneralWebservice extends Command implements WebservicePluginApi {
             httpClient.get(key).send(httpRequest.get(key), HttpResponse.BodyHandlers.ofString())
         );
 
-        responsebodies.put(key, (String) response.get(key).body());
+		String responseBody = (String)response.get(key).body();
+        if(responseBody.startsWith(")]}',")) {
+            responsebodies.put(key, responseBody.replace(")]}',", "").trim());
+        } else {
+            responsebodies.put(key, responseBody);
+        }
 
         after.put(key, Instant.now());
-        savePayload("response", (String) response.get(key).body());
+        savePayload("response", responseBody);
 
         responsecodes.put(key, Integer.toString(response.get(key).statusCode()));
     }

--- a/Engine/src/main/java/com/ing/engine/commands/webservice/GeneralWebservice.java
+++ b/Engine/src/main/java/com/ing/engine/commands/webservice/GeneralWebservice.java
@@ -281,8 +281,8 @@ public class GeneralWebservice extends Command implements WebservicePluginApi {
             httpClient.get(key).send(httpRequest.get(key), HttpResponse.BodyHandlers.ofString())
         );
 
-		String responseBody = (String)response.get(key).body();
-        if(responseBody.startsWith(")]}',")) {
+        String responseBody = (String) response.get(key).body();
+        if (responseBody.startsWith(")]}',")) {
             responsebodies.put(key, responseBody.replace(")]}',", "").trim());
         } else {
             responsebodies.put(key, responseBody);

--- a/Engine/src/main/java/com/ing/engine/commands/webservice/GeneralWebservice.java
+++ b/Engine/src/main/java/com/ing/engine/commands/webservice/GeneralWebservice.java
@@ -212,10 +212,15 @@ public class GeneralWebservice extends Command implements WebservicePluginApi {
         httpRequest.put(key, httpRequestBuilder.get(key).build());
         response.put(key, httpClient.get(key).send(httpRequest.get(key), HttpResponse.BodyHandlers.ofString()));
 
-        responsebodies.put(key, (String) response.get(key).body());
+		String responseBody = (String)response.get(key).body();
+        if(responseBody.startsWith(")]}',")) {
+            responsebodies.put(key, responseBody.replace(")]}',", "").trim());
+        } else {
+            responsebodies.put(key, responseBody);
+        }
 
         after.put(key, Instant.now());
-        savePayload("response", (String) response.get(key).body());
+        savePayload("response", responseBody);
 
         responsecodes.put(key, Integer.toString(response.get(key).statusCode()));
 


### PR DESCRIPTION
One of ING Romania's API body responses has a prefix that starts with )]}'.

This prefix is a security feature designed to prevent Cross-Site Scripting (XSS) and Cross-Site Request Forgery (CSRF) attacks, specifically via a technique known as JSON Hijacking.

The fix involves searching if the response body has the prefix  )]}'  and then removing it from the response body before saving it, ensuring that the application can process the JSON data correctly without being affected by the security prefix. If I do not have the prefix save directly the response body.