### PR TITLE
Filter the extensionless ingenious launcher so ${project.version} resolves

### DIFF
--- a/Dist/pom.xml
+++ b/Dist/pom.xml
@@ -118,6 +118,7 @@
                                         <include>**/*.command</include>
                                         <include>**/*.txt</include>
                                         <include>**/*.md</include>
+                                        <include>ingenious</include>
                                     </includes>
                                 </resource>
                                 <resource>
@@ -128,6 +129,7 @@
                                         <exclude>**/*.command</exclude>
                                         <exclude>**/*.txt</exclude>
                                         <exclude>**/*.md</exclude>
+                                        <exclude>ingenious</exclude>
                                     </excludes>
                                 </resource>
                             </resources>


### PR DESCRIPTION
Running `./ingenious` with no arguments fails on Linux and macOS:

```
./ingenious: line 20: ingenious-ide-${project.version}.jar:$APP_CLASSPATH: bad substitution
```

The shipped script keeps the literal property:

```
$ grep ingenious-ide Dist/release/ingenious
        -cp "ingenious-ide-${project.version}.jar:$APP_CLASSPATH" \
```

`Dist/pom.xml` filters `**/*.bat`, `**/*.command`, `**/*.txt` and `**/*.md`. `Resources/ingenious`
has no extension, matches none of those, and is copied through unfiltered. `Resources/ingenious.command`
carries the identical `-cp` line and resolves correctly, which places the cause in the resource
filtering rather than in the script.

Only the no-argument branch is affected: the property sits in the `if [ "$#" -eq 0 ]` arm, so
`./ingenious run ...` and `./ingenious --help` both work. It needs a bare `./ingenious` to show up.

Impact is worst on Linux, where `ingenious` is the only terminal launcher for the IDE; on macOS
`ingenious.command` still works, and Windows is unaffected. The script does look intended to work --
the `unix-permissions` profile makes it executable, and `ingenious.command`'s own header points
terminal users at "the no-extension sibling `ingenious`".

Both hunks are needed. The two `<resource>` blocks read the same directory, so adding only the
include copies the file twice and the unfiltered copy can overwrite the filtered one.

Verified on Linux and macOS (arm64), Temurin 17: after the change `Dist/release/ingenious` contains
`-cp "ingenious-ide-3.0.0.jar:$APP_CLASSPATH"` and a bare `./ingenious` opens the IDE.

Unrelated to #310, which is about `ingenious.bat` not honouring JAVA_HOME -- different file, different cause.

Targeting `release/3.1.0` since that is where current development is -- happy to retarget.
