### PR TITLE
Document the two-step build in CONTRIBUTING.md so a fresh clone works

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,10 +26,15 @@ cd INGenious
 ```
 
 ### 2. Install Dependencies
-Install the necessary dependencies using:
+`ingenious-api` is not part of the root reactor and is not published to Maven Central, so build it
+first and then the rest of the project:
 ```bash
-mvn install
+mvn clean install --file ./ingenious-api/pom.xml
+mvn clean install
 ```
+This is the same two-step the CI workflow runs. On a machine that already has
+`com.ing:ingenious-api` in its local Maven repository from an earlier build, `mvn install` on its
+own is enough.
 
 ### 3. Create a Branch
 Always create a new branch for your contributions:


### PR DESCRIPTION
On a machine that has never built this project, the `mvn install` in step 2 of CONTRIBUTING.md fails:

```
[WARNING] The POM for com.ing:ingenious-api:jar:3.0 is missing, no dependency information available
[INFO] BUILD FAILURE
[ERROR] Failed to execute goal on project ingenious-datalib: Could not resolve dependencies
[ERROR]   dependency: com.ing:ingenious-api:jar:3.0 (compile)
[ERROR]   Could not find artifact com.ing:ingenious-api:jar:3.0 in central
```

`ingenious-api` is a compile dependency of Datalib, Engine and Dist, but it is not in the root pom's
`<modules>` and it is not on Maven Central, so a first build has no way to obtain it.

The CI workflow already handles this -- `.github/workflows/maven.yml` builds it as a separate first
step:

```yaml
- run: mvn clean install --file ./ingenious-api/pom.xml
- run: mvn clean install --file pom.xml
```

CONTRIBUTING.md documents only the second command. This change documents both.

Worth mentioning because it makes the report hard to check: it only fails when
`com.ing:ingenious-api:3.0` is absent from the local repository. Once anything has installed it, it
is cached and plain `mvn install` succeeds from then on -- so it does not reproduce for anyone who
has built before, and CI never sees it. To reproduce, remove `~/.m2/repository/com/ing` first.

Verified on `release/3.1.0` at `7bc763b6` with Temurin 17 and Maven 3.9.9, clearing
`~/.m2/repository/com/ing` first: the documented single command fails as above, and the two
documented here build all modules. Also reproduced on macOS arm64 (Maven 3.9.16, no settings.xml).

I have kept this to the documentation because `ingenious-api` looks deliberately separate: it has no
parent, carries its own `3.0` version, and is pinned through `<ingenious-api.version>` alongside the
third-party dependencies rather than inheriting the project version like the other modules.

If you would rather fix it in the build, adding `<module>ingenious-api</module>` to the root reactor
also works -- a single `mvn clean install` then builds all 9 modules from an empty cache. That is on
`wladefanting:fix/ingenious-api-reactor` and I am happy to send it instead of, or as well as, this.

Targeting `release/3.1.0` since that is where current development is -- happy to retarget.
