### PR TITLE
Fix scope independent naming and Test Data reference when used in Reusable Components and Param Loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,7 +101,8 @@ Release Date: <insert date of release>
 - Fix context menu options for Reusable Component Test Cases for `New Group` option
 - Added missing Test Manager option under TM Settings dropdown
 - Resolved issues with Test datasheet references in Reusable components.
-- Fixed the delete confirmation message for Impacted Assets to ensure correct notification and confirmation behavior during deletion actions.
+- Fixed the delete confirmation message for Impacted Assets to ensure correct notification and confirmation behavior during deletion actions.- Allow reuse of deleted scenarios in Project Reusable Components
+- Allow reuse of deleted scenarios in Project Reusable Components
 
 ### Browser/Playwright Testing
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,7 @@ Release Date: <insert date of release>
 - Allow reuse of deleted scenarios in Project Reusable Components
 - Fix incorrect reference when executing test cases when resolving test datasheets with reusables components
 - Fix Param Loop error when using reusable compenents with test data
+- Fixed Test Data `Scope` being reset/mismatched on project reload for duplicate scenario/test case names across Test Plan, Project Reusables, and Shared Reusables, and ensured conversions between these locations update `Scope` explicitly.
 
 ### Browser/Playwright Testing
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ Release Date: <insert date of release>
 - Disabled edit mode on `Scope` field in Test datasheet to prevent user edits while maintaining visibility of the configured scope.
 - Updated the list and display order of test cases in Test Data and Test Plan to improve usability and maintain a consistent user experience.
 - Ensured Shared Reusables continue to correctly reference and inherit their associated Test Datasheet scope.
+- 
 
 #### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,7 +70,6 @@ Release Date: <insert date of release>
 - Disabled edit mode on `Scope` field in Test datasheet to prevent user edits while maintaining visibility of the configured scope.
 - Updated the list and display order of test cases in Test Data and Test Plan to improve usability and maintain a consistent user experience.
 - Ensured Shared Reusables continue to correctly reference and inherit their associated Test Datasheet scope.
-- 
 
 #### Deprecated
 
@@ -102,8 +101,10 @@ Release Date: <insert date of release>
 - Fix context menu options for Reusable Component Test Cases for `New Group` option
 - Added missing Test Manager option under TM Settings dropdown
 - Resolved issues with Test datasheet references in Reusable components.
-- Fixed the delete confirmation message for Impacted Assets to ensure correct notification and confirmation behavior during deletion actions.- Allow reuse of deleted scenarios in Project Reusable Components
+- Fixed the delete confirmation message for Impacted Assets to ensure correct notification and confirmation behavior during deletion actions.
 - Allow reuse of deleted scenarios in Project Reusable Components
+- Fix incorrect reference when executing test cases when resolving test datasheets with reusables components
+- Fix Param Loop error when using reusable compenents with test data
 
 ### Browser/Playwright Testing
 

--- a/Datalib/src/main/java/com/ing/datalib/component/EnvTestData.java
+++ b/Datalib/src/main/java/com/ing/datalib/component/EnvTestData.java
@@ -295,6 +295,21 @@ public class EnvTestData {
     }
 
     /**
+     * Updates the Scope of the test data entry for a scenario+testcase across all environments, as
+     * part of an explicit test case conversion between Test Plan / Project Reusables / Shared Reusables.
+     */
+    public void updateScope(
+        String scenarioName,
+        String testCaseName,
+        String oldScope,
+        String newScope
+    ) {
+        for (TestData testData : getAllEnvironments()) {
+            testData.updateScope(scenarioName, testCaseName, oldScope, newScope);
+        }
+    }
+
+    /**
      * Find all environments that contain a datasheet with the given name.
      *
      * @param datasheetName the name of the datasheet to search for

--- a/Datalib/src/main/java/com/ing/datalib/component/Project.java
+++ b/Datalib/src/main/java/com/ing/datalib/component/Project.java
@@ -919,9 +919,10 @@ public class Project {
 
         lastImpactedReusableReferenceUpdates = 0;
 
-        String scenarioName = testCase.getScenario().getName();
+        Scenario sourceScenario = testCase.getScenario();
+        String scenarioName = sourceScenario.getName();
         String testCaseName = testCase.getName();
-        Scenario.Source sourceType = testCase.getScenario().getSource();
+        Scenario.Source sourceType = sourceScenario.getSource();
         String targetName = targetSource == Scenario.Source.REUSABLE_COMPONENTS
             ? "Reusable Components"
             : "Test Plan";
@@ -955,6 +956,24 @@ public class Project {
                 "Failed to move test case: " + ex.getMessage(),
                 ex
             );
+        }
+
+        // When moving TO Test Plan from a reusable source, remove the case from source and cleanup
+        if (sourceType != Scenario.Source.TEST_PLAN && targetSource == Scenario.Source.TEST_PLAN) {
+            sourceScenario.removeTestCase(testCase);
+            if (sourceType == Scenario.Source.REUSABLE_COMPONENTS) {
+                cleanupEmptyScenario(sourceScenario);
+            }
+        }
+
+        // When moving FROM Test Plan TO Project Reusable, remove the case from the Test Plan
+        // and cleanup the scenario if it becomes empty so the scenario name can be reused.
+        if (
+            sourceType == Scenario.Source.TEST_PLAN &&
+            targetSource == Scenario.Source.REUSABLE_COMPONENTS
+        ) {
+            sourceScenario.removeTestCase(testCase);
+            cleanupEmptyScenario(sourceScenario);
         }
 
         lastImpactedReusableReferenceUpdates =
@@ -1008,7 +1027,7 @@ public class Project {
      * @return the created scenario, or null if a scenario with the same name already exists in any scope
      */
     public Scenario addScenario(String scenarioName) {
-        if (getScenarioByName(scenarioName) == null && !scenarioExistsInAnyScope(scenarioName)) {
+        if (getTestPlanScenarioByName(scenarioName) == null) {
             Scenario scn = new Scenario(this, scenarioName, Scenario.Source.TEST_PLAN);
             scenarios.add(scn);
             return scn;
@@ -1019,13 +1038,10 @@ public class Project {
     /**
      * Adds a new scenario to Reusable Components.
      * @param scenarioName name of the scenario to add
-     * @return the created scenario, or null if a scenario with the same name already exists in any scope
+     * @return the created scenario, or null if a scenario with the same name already exists in the Project Reusable scope
      */
     public Scenario addReusableScenario(String scenarioName) {
-        if (
-            getReusableScenarioByName(scenarioName) == null &&
-            !scenarioExistsInAnyScope(scenarioName)
-        ) {
+        if (getReusableScenarioByName(scenarioName) == null) {
             Scenario scn = new Scenario(this, scenarioName, Scenario.Source.REUSABLE_COMPONENTS);
             reusableScenarios.add(scn);
             return scn;
@@ -1035,15 +1051,11 @@ public class Project {
 
     /**
      * Adds a new shared reusable scenario to the project.
-     * Checks for name uniqueness across all scopes before creating.
      * @param scenarioName name of the scenario to add
-     * @return the newly created shared reusable scenario, or null if already exists in any scope
+     * @return the newly created shared reusable scenario, or null if already exists in the Shared Reusable scope
      */
     public Scenario addSharedReusableScenario(String scenarioName) {
-        if (
-            getSharedReusableScenarioByName(scenarioName) == null &&
-            !scenarioExistsInAnyScope(scenarioName)
-        ) {
+        if (getSharedReusableScenarioByName(scenarioName) == null) {
             Scenario scn = new Scenario(
                 this,
                 scenarioName,
@@ -1130,6 +1142,40 @@ public class Project {
                 return true;
             }
         }
+        return false;
+    }
+
+    /**
+     * Checks whether a test case with the given name exists for the specified scenario
+     * name in any scope (Test Plan, Project Reusable, Shared Reusable), excluding an
+     * optional scenario instance.
+     * @param scenarioName the scenario name to search for across scopes
+     * @param excludeScenario scenario instance to exclude from the check (may be null)
+     * @param testCaseName test case name to check
+     * @return true if a test case with the given name exists for the same scenario name in another scope
+     */
+    public boolean testCaseExistsForScenarioNameAcrossScopes(
+        String scenarioName,
+        Scenario excludeScenario,
+        String testCaseName
+    ) {
+        Scenario sc;
+
+        sc = getTestPlanScenarioByName(scenarioName);
+        if (sc != null && sc != excludeScenario && sc.getTestCaseByName(testCaseName) != null) {
+            return true;
+        }
+
+        sc = getReusableScenarioByName(scenarioName);
+        if (sc != null && sc != excludeScenario && sc.getTestCaseByName(testCaseName) != null) {
+            return true;
+        }
+
+        sc = getSharedReusableScenarioByName(scenarioName);
+        if (sc != null && sc != excludeScenario && sc.getTestCaseByName(testCaseName) != null) {
+            return true;
+        }
+
         return false;
     }
 

--- a/Datalib/src/main/java/com/ing/datalib/component/Project.java
+++ b/Datalib/src/main/java/com/ing/datalib/component/Project.java
@@ -1051,7 +1051,6 @@ public class Project {
 
     /**
      * Adds a new shared reusable scenario to the project.
-     * Checks for name uniqueness across all scopes before creating.
      * @param scenarioName name of the scenario to add
      * @return the newly created shared reusable scenario, or null if already exists in the Shared Reusable scope
      */

--- a/Datalib/src/main/java/com/ing/datalib/component/Project.java
+++ b/Datalib/src/main/java/com/ing/datalib/component/Project.java
@@ -1051,6 +1051,7 @@ public class Project {
 
     /**
      * Adds a new shared reusable scenario to the project.
+     * Checks for name uniqueness across all scopes before creating.
      * @param scenarioName name of the scenario to add
      * @return the newly created shared reusable scenario, or null if already exists in the Shared Reusable scope
      */

--- a/Datalib/src/main/java/com/ing/datalib/component/Project.java
+++ b/Datalib/src/main/java/com/ing/datalib/component/Project.java
@@ -462,14 +462,17 @@ public class Project {
     }
 
     /**
-     * Finds a reusable scenario by name.
+     * Finds a reusable scenario by name, excluding deleted scenarios.
      * @param name scenario name to search for (case-insensitive)
-     * @return the reusable scenario if found, null otherwise
+     * @return the reusable scenario if found and active, null otherwise
      */
     public Scenario getReusableScenarioByName(String name) {
         for (Scenario scenario : reusableScenarios) {
             if (scenario.getName().equalsIgnoreCase(name)) {
-                return scenario;
+                // Verify the scenario folder still exists on disk
+                if (new File(scenario.getLocation()).exists()) {
+                    return scenario;
+                }
             }
         }
         return null;
@@ -498,14 +501,17 @@ public class Project {
     }
 
     /**
-     * Finds a shared reusable scenario by name.
+     * Finds a shared reusable scenario by name, excluding deleted scenarios.
      * @param name scenario name to search for (case-insensitive)
-     * @return the shared reusable scenario if found, null otherwise
+     * @return the shared reusable scenario if found and active, null otherwise
      */
     public Scenario getSharedReusableScenarioByName(String name) {
         for (Scenario scenario : sharedReusableScenarios) {
             if (scenario.getName().equalsIgnoreCase(name)) {
-                return scenario;
+                // Verify the scenario folder still exists on disk
+                if (new File(scenario.getLocation()).exists()) {
+                    return scenario;
+                }
             }
         }
         return null;
@@ -1029,6 +1035,7 @@ public class Project {
 
     /**
      * Adds a new shared reusable scenario to the project.
+     * Checks for name uniqueness across all scopes before creating.
      * @param scenarioName name of the scenario to add
      * @return the newly created shared reusable scenario, or null if already exists in any scope
      */

--- a/Datalib/src/main/java/com/ing/datalib/component/Project.java
+++ b/Datalib/src/main/java/com/ing/datalib/component/Project.java
@@ -1085,19 +1085,6 @@ public class Project {
     }
 
     /**
-     * Checks if a scenario with the given name exists in any scope (Test Plan, Reusable, or Shared Reusable).
-     * @param scenarioName name to check
-     * @return true if scenario exists in any scope, false otherwise
-     */
-    private boolean scenarioExistsInAnyScope(String scenarioName) {
-        return (
-            getScenarioByName(scenarioName) != null ||
-            getReusableScenarioByName(scenarioName) != null ||
-            getSharedReusableScenarioByName(scenarioName) != null
-        );
-    }
-
-    /**
      * Checks if a scenario exists in reusable scopes only (project/shared reusable).
      */
     private boolean scenarioExistsInReusableScopes(String scenarioName) {
@@ -1119,64 +1106,6 @@ public class Project {
             return baseName;
         }
         return NamingUtils.generateUniqueName(baseName, this::scenarioExistsInReusableScopes);
-    }
-
-    /**
-     * Checks if a test case with the given name exists in any scenario across all scopes.
-     * @param testCaseName test case name to check
-     * @return true if test case exists in any scenario and any scope, false otherwise
-     */
-    public boolean testCaseExistsInAnyScope(String testCaseName) {
-        for (Scenario scenario : scenarios) {
-            if (scenario.getTestCaseByName(testCaseName) != null) {
-                return true;
-            }
-        }
-        for (Scenario scenario : reusableScenarios) {
-            if (scenario.getTestCaseByName(testCaseName) != null) {
-                return true;
-            }
-        }
-        for (Scenario scenario : sharedReusableScenarios) {
-            if (scenario.getTestCaseByName(testCaseName) != null) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    /**
-     * Checks whether a test case with the given name exists for the specified scenario
-     * name in any scope (Test Plan, Project Reusable, Shared Reusable), excluding an
-     * optional scenario instance.
-     * @param scenarioName the scenario name to search for across scopes
-     * @param excludeScenario scenario instance to exclude from the check (may be null)
-     * @param testCaseName test case name to check
-     * @return true if a test case with the given name exists for the same scenario name in another scope
-     */
-    public boolean testCaseExistsForScenarioNameAcrossScopes(
-        String scenarioName,
-        Scenario excludeScenario,
-        String testCaseName
-    ) {
-        Scenario sc;
-
-        sc = getTestPlanScenarioByName(scenarioName);
-        if (sc != null && sc != excludeScenario && sc.getTestCaseByName(testCaseName) != null) {
-            return true;
-        }
-
-        sc = getReusableScenarioByName(scenarioName);
-        if (sc != null && sc != excludeScenario && sc.getTestCaseByName(testCaseName) != null) {
-            return true;
-        }
-
-        sc = getSharedReusableScenarioByName(scenarioName);
-        if (sc != null && sc != excludeScenario && sc.getTestCaseByName(testCaseName) != null) {
-            return true;
-        }
-
-        return false;
     }
 
     /**

--- a/Datalib/src/main/java/com/ing/datalib/component/Project.java
+++ b/Datalib/src/main/java/com/ing/datalib/component/Project.java
@@ -986,6 +986,29 @@ public class Project {
                 targetSource,
                 testCase
             );
+
+        // Explicitly set Scope to the new location as part of this conversion - this is intentional
+        // and must not be confused with (or blocked by) the reload-time "preserve existing Scope" logic.
+        testData.updateScope(
+            scenarioName,
+            testCaseName,
+            scopeToken(sourceType),
+            scopeToken(targetSource)
+        );
+    }
+
+    /**
+     * Maps a scenario source to the raw Scope token stored against Test Data entries:
+     * "" for Test Plan, "[Project]" for Project Reusables, "[Shared]" for Shared Reusables.
+     */
+    private String scopeToken(Scenario.Source source) {
+        if (source == Scenario.Source.REUSABLE_COMPONENTS) {
+            return "[Project]";
+        }
+        if (source == Scenario.Source.SHARED_REUSABLE_COMPONENTS) {
+            return "[Shared]";
+        }
+        return "";
     }
 
     /**
@@ -1256,6 +1279,16 @@ public class Project {
                     null
                 );
             cleanupEmptyScenario(sourceScenario);
+
+            // Explicitly set Scope to the new location as part of this conversion. Only applies to
+            // moves: a copy leaves the source test case (and its Test Data Scope) exactly where it was.
+            // Move never renames scenario/testcase (see uniqueNameInScenario), so old names still match.
+            testData.updateScope(
+                scenarioName,
+                testCaseName,
+                scopeToken(sourceType),
+                scopeToken(targetSource)
+            );
         }
 
         return targetTestCase;

--- a/Datalib/src/main/java/com/ing/datalib/component/Scenario.java
+++ b/Datalib/src/main/java/com/ing/datalib/component/Scenario.java
@@ -691,16 +691,22 @@ public class Scenario extends DataModel {
     }
 
     /**
-     * Renames this scenario.
+     * Renames this scenario in Reusable Components.
+     * Removes stale scenarios whose directories no longer exist on disk before checking uniqueness.
      * @param newName new scenario name
      * @return true if successful, false if a scenario with the new name already exists
      */
 
     public Boolean renameReusable(String newName) {
-        Scenario existing = getProject().getReusableScenarioByName(newName);
+        Project p = getProject();
+        // Clean up stale reusable scenarios first
+        List<Scenario> reusables = p.getReusableScenarios();
+        reusables.removeIf(s -> !new File(s.getLocation()).exists());
+
+        Scenario existing = p.getReusableScenarioByName(newName);
         if (existing == null || existing == this) {
             if (FileUtils.renameFile(getLocation(), newName)) {
-                getProject().refactorScenario(name, newName);
+                p.refactorScenario(name, newName);
                 name = newName;
                 return true;
             }
@@ -711,13 +717,19 @@ public class Scenario extends DataModel {
 
     /**
      * Renames this shared reusable scenario.
+     * Removes stale scenarios whose directories no longer exist on disk before checking uniqueness.
      * @param newName new scenario name
      * @return true if successful, false if a scenario with the new name already exists
      */
     public Boolean renameSharedReusable(String newName) {
-        if (getProject().getSharedReusableScenarioByName(newName) == null) {
+        Project p = getProject();
+        // Clean up stale shared reusable scenarios first
+        List<Scenario> sharedReusables = p.getSharedScenarios();
+        sharedReusables.removeIf(s -> !new File(s.getLocation()).exists());
+
+        if (p.getSharedReusableScenarioByName(newName) == null) {
             if (FileUtils.renameFile(getLocation(), newName)) {
-                getProject().refactorScenario(name, newName);
+                p.refactorScenario(name, newName);
                 name = newName;
                 return true;
             }

--- a/Datalib/src/main/java/com/ing/datalib/component/Scenario.java
+++ b/Datalib/src/main/java/com/ing/datalib/component/Scenario.java
@@ -268,7 +268,10 @@ public class Scenario extends DataModel {
      * @return the created test case, or null if it already exists in this scenario
      */
     public TestCase addTestCase(String testCaseName) {
-        if (getTestCaseByName(testCaseName) == null) {
+        if (
+            getTestCaseByName(testCaseName) == null &&
+            !getProject().testCaseExistsForScenarioNameAcrossScopes(getName(), this, testCaseName)
+        ) {
             TestCase tc = new TestCase(this, testCaseName);
             testCases.add(tc);
             tc.setSaved(false);

--- a/Datalib/src/main/java/com/ing/datalib/component/Scenario.java
+++ b/Datalib/src/main/java/com/ing/datalib/component/Scenario.java
@@ -124,6 +124,21 @@ public class Scenario extends DataModel {
     }
 
     /**
+     * Returns a short, human-readable label for this scenario's scope, for display purposes
+     * (e.g. the Test Design search box), reflecting which scope is currently active.
+     * @return "TestPlan", "Project", or "Shared"
+     */
+    public String getScopeLabel() {
+        if (source == Source.REUSABLE_COMPONENTS) {
+            return "Project";
+        }
+        if (source == Source.SHARED_REUSABLE_COMPONENTS) {
+            return "Shared";
+        }
+        return "TestPlan";
+    }
+
+    /**
      * Returns the parent project.
      * @return parent project
      */
@@ -268,10 +283,7 @@ public class Scenario extends DataModel {
      * @return the created test case, or null if it already exists in this scenario
      */
     public TestCase addTestCase(String testCaseName) {
-        if (
-            getTestCaseByName(testCaseName) == null &&
-            !getProject().testCaseExistsForScenarioNameAcrossScopes(getName(), this, testCaseName)
-        ) {
+        if (getTestCaseByName(testCaseName) == null) {
             TestCase tc = new TestCase(this, testCaseName);
             testCases.add(tc);
             tc.setSaved(false);

--- a/Datalib/src/main/java/com/ing/datalib/component/TestCase.java
+++ b/Datalib/src/main/java/com/ing/datalib/component/TestCase.java
@@ -1572,7 +1572,12 @@ public class TestCase extends DataModel {
         TestCase existing = getScenario().getTestCaseByName(newName);
         if (
             (existing == null || existing == this) &&
-            getScenario().getReusableTestCaseByName(getScenario().getName(), newName) == null
+            !getProject()
+                .testCaseExistsForScenarioNameAcrossScopes(
+                    getScenario().getName(),
+                    getScenario(),
+                    newName
+                )
         ) {
             if (FileUtils.renameFile(getLocation(), newName + getFormat().extension())) {
                 getProject().refactorTestCase(getScenario().getName(), name, newName);
@@ -1584,11 +1589,15 @@ public class TestCase extends DataModel {
     }
 
     public Boolean renameReusable(String newName) {
-        TestCase existingReusable = getScenario()
-            .getReusableTestCaseByName(getScenario().getName(), newName);
+        TestCase existing = getScenario().getTestCaseByName(newName);
         if (
-            getScenario().getTestCaseByName(getScenario().getName(), newName) == null &&
-            (existingReusable == null || existingReusable == this)
+            (existing == null || existing == this) &&
+            !getProject()
+                .testCaseExistsForScenarioNameAcrossScopes(
+                    getScenario().getName(),
+                    getScenario(),
+                    newName
+                )
         ) {
             if (FileUtils.renameFile(getLocation(), newName + getFormat().extension())) {
                 getProject().refactorTestCase(getScenario().getName(), name, newName);
@@ -1605,7 +1614,16 @@ public class TestCase extends DataModel {
      * @return true if successful, false if a test case with the new name already exists
      */
     public Boolean renameSharedReusable(String newName) {
-        if (getScenario().getTestCaseByName(newName) == null) {
+        TestCase existing = getScenario().getTestCaseByName(newName);
+        if (
+            (existing == null || existing == this) &&
+            !getProject()
+                .testCaseExistsForScenarioNameAcrossScopes(
+                    getScenario().getName(),
+                    getScenario(),
+                    newName
+                )
+        ) {
             if (FileUtils.renameFile(getLocation(), newName + getFormat().extension())) {
                 getProject().refactorTestCase(getScenario().getName(), name, newName);
                 name = newName;

--- a/Datalib/src/main/java/com/ing/datalib/component/TestCase.java
+++ b/Datalib/src/main/java/com/ing/datalib/component/TestCase.java
@@ -1570,15 +1570,7 @@ public class TestCase extends DataModel {
     @Override
     public Boolean rename(String newName) {
         TestCase existing = getScenario().getTestCaseByName(newName);
-        if (
-            (existing == null || existing == this) &&
-            !getProject()
-                .testCaseExistsForScenarioNameAcrossScopes(
-                    getScenario().getName(),
-                    getScenario(),
-                    newName
-                )
-        ) {
+        if (existing == null || existing == this) {
             if (FileUtils.renameFile(getLocation(), newName + getFormat().extension())) {
                 getProject().refactorTestCase(getScenario().getName(), name, newName);
                 name = newName;
@@ -1590,15 +1582,7 @@ public class TestCase extends DataModel {
 
     public Boolean renameReusable(String newName) {
         TestCase existing = getScenario().getTestCaseByName(newName);
-        if (
-            (existing == null || existing == this) &&
-            !getProject()
-                .testCaseExistsForScenarioNameAcrossScopes(
-                    getScenario().getName(),
-                    getScenario(),
-                    newName
-                )
-        ) {
+        if (existing == null || existing == this) {
             if (FileUtils.renameFile(getLocation(), newName + getFormat().extension())) {
                 getProject().refactorTestCase(getScenario().getName(), name, newName);
                 name = newName;
@@ -1615,15 +1599,7 @@ public class TestCase extends DataModel {
      */
     public Boolean renameSharedReusable(String newName) {
         TestCase existing = getScenario().getTestCaseByName(newName);
-        if (
-            (existing == null || existing == this) &&
-            !getProject()
-                .testCaseExistsForScenarioNameAcrossScopes(
-                    getScenario().getName(),
-                    getScenario(),
-                    newName
-                )
-        ) {
+        if (existing == null || existing == this) {
             if (FileUtils.renameFile(getLocation(), newName + getFormat().extension())) {
                 getProject().refactorTestCase(getScenario().getName(), name, newName);
                 name = newName;

--- a/Datalib/src/main/java/com/ing/datalib/component/TestData.java
+++ b/Datalib/src/main/java/com/ing/datalib/component/TestData.java
@@ -190,4 +190,15 @@ public abstract class TestData {
             testDataList1.refactorTestCaseScenario(testCaseName, oldScenarioName, newScenarioName);
         }
     }
+
+    public void updateScope(
+        String scenarioName,
+        String testCaseName,
+        String oldScope,
+        String newScope
+    ) {
+        for (TestDataModel testDataList1 : testDataList) {
+            testDataList1.updateScope(scenarioName, testCaseName, oldScope, newScope);
+        }
+    }
 }

--- a/Datalib/src/main/java/com/ing/datalib/testdata/model/TestDataModel.java
+++ b/Datalib/src/main/java/com/ing/datalib/testdata/model/TestDataModel.java
@@ -10,6 +10,11 @@ import java.util.Queue;
  *
  */
 public abstract class TestDataModel extends AbstractDataModel<Record> {
+    // Deliberately no explicit initializer: AbstractDataModel's constructor calls
+    // migrateColumnsIfNeeded() (via loadMColumns()) before this subclass's own field
+    // initializers would run, so an explicit "= false" here would silently clobber the
+    // value just set during that super-constructor call.
+    private boolean scopeColumnMigrated;
 
     public TestDataModel(String location, Boolean isFromFile) {
         super(location, isFromFile);
@@ -42,8 +47,24 @@ public abstract class TestDataModel extends AbstractDataModel<Record> {
             } else {
                 columns.add(Record.HEADERS[2]);
             }
+            // Row values are still loaded positionally from the (unmigrated) file, so the
+            // loader needs to know a Scope slot must be spliced into each row too - otherwise
+            // every value from Iteration onward silently shifts left by one column.
+            scopeColumnMigrated = true;
         }
         return columns;
+    }
+
+    /**
+     * Whether {@link #migrateColumnsIfNeeded} just inserted the 'Scope' column because the
+     * underlying file predates it. The row loader (e.g. CSV) uses this to splice an empty
+     * Scope value into each loaded row at the same index, keeping row values aligned with
+     * the migrated column list.
+     *
+     * @return true if this file's rows still need a Scope value spliced in at load time
+     */
+    public boolean isScopeColumnMigrated() {
+        return scopeColumnMigrated;
     }
 
     @Override

--- a/Datalib/src/main/java/com/ing/datalib/testdata/model/TestDataModel.java
+++ b/Datalib/src/main/java/com/ing/datalib/testdata/model/TestDataModel.java
@@ -181,4 +181,35 @@ public abstract class TestDataModel extends AbstractDataModel<Record> {
             getRecords().clear();
         }
     }
+
+    /**
+     * Updates the Scope of the test data entry belonging to the given scenario+testcase, as part of
+     * an explicit test case conversion (Test Plan / Project Reusables / Shared Reusables move).
+     * Matches on the entry's current scope too, so that when the same scenario+testcase name exists
+     * in more than one scope, only the entry actually being converted (the one still carrying
+     * {@code oldScope}) is updated - the colliding entry elsewhere is left untouched.
+     */
+    public void updateScope(
+        String scenarioName,
+        String testCaseName,
+        String oldScope,
+        String newScope
+    ) {
+        Boolean clearOnExit = getRecords().isEmpty();
+        loadTableModel();
+        for (Record record : getRecords()) {
+            if (
+                record.getScenario().equals(scenarioName) &&
+                record.getTestcase().equals(testCaseName) &&
+                Objects.toString(record.getScope(), "").equals(oldScope)
+            ) {
+                record.setScope(newScope);
+                fireTableCellUpdated(getRecords().indexOf(record), 2);
+            }
+        }
+        if (clearOnExit) {
+            save();
+            getRecords().clear();
+        }
+    }
 }

--- a/Datalib/src/main/java/com/ing/datalib/testdata/view/TestDataView.java
+++ b/Datalib/src/main/java/com/ing/datalib/testdata/view/TestDataView.java
@@ -313,6 +313,28 @@ public abstract class TestDataView implements TestDataViewApi {
 
     /**
      * finds the records and return view object with that subset of records for
+     * the given query args, filtered by scope.
+     * <br>
+     * use wildcard (.*) if needed
+     * <br>
+     *
+     * @param scn scenario
+     * @param tc testcase
+     * @param iter iteration
+     * @param scope the scope filter ([Project], [Shared], or empty for test plan)
+     * @return the view
+     */
+    public TestDataView withIterAndScope(String scn, String tc, String iter, String scope) {
+        String key = scn + "#" + tc + "#" + iter + "#scope:" + scope;
+        if (!VIEWS.containsKey(key)) {
+            return indexWithScope(key, scn, tc, iter, ALL, scope);
+        } else {
+            return toView(get(key));
+        }
+    }
+
+    /**
+     * finds the records and return view object with that subset of records for
      * the given query args.
      *
      * <br>

--- a/Datalib/src/main/java/com/ing/datalib/testdata/view/TestDataView.java
+++ b/Datalib/src/main/java/com/ing/datalib/testdata/view/TestDataView.java
@@ -176,7 +176,7 @@ public abstract class TestDataView implements TestDataViewApi {
      */
     public Set<String> getIterations() {
         Set<String> iters = new LinkedHashSet<>();
-        for (Object iter : getFields(records(), Record.HEADERS[2])) {
+        for (Object iter : getFields(records(), Record.HEADERS[3])) {
             iters.add((String) iter);
         }
         return iters;
@@ -193,7 +193,7 @@ public abstract class TestDataView implements TestDataViewApi {
      */
     public Set<String> getSubIterations() {
         Set<String> iters = new LinkedHashSet<>();
-        for (Object iter : getFields(records(), Record.HEADERS[3])) {
+        for (Object iter : getFields(records(), Record.HEADERS[4])) {
             iters.add((String) iter);
         }
         return iters;

--- a/Datalib/src/test/java/com/ing/datalib/component/ScenarioTest.java
+++ b/Datalib/src/test/java/com/ing/datalib/component/ScenarioTest.java
@@ -117,6 +117,34 @@ public class ScenarioTest {
         assertThat(scenario.toString()).isEqualTo("LoginScenario");
     }
 
+    // ---- getScopeLabel ----
+
+    @Test
+    public void testGetScopeLabel_testPlan() {
+        Scenario scenario = new Scenario(project, "LoginScenario", Scenario.Source.TEST_PLAN);
+        assertThat(scenario.getScopeLabel()).isEqualTo("TestPlan");
+    }
+
+    @Test
+    public void testGetScopeLabel_reusableComponents() {
+        Scenario scenario = new Scenario(
+            project,
+            "LoginScenario",
+            Scenario.Source.REUSABLE_COMPONENTS
+        );
+        assertThat(scenario.getScopeLabel()).isEqualTo("Project");
+    }
+
+    @Test
+    public void testGetScopeLabel_sharedReusableComponents() {
+        Scenario scenario = new Scenario(
+            project,
+            "LoginScenario",
+            Scenario.Source.SHARED_REUSABLE_COMPONENTS
+        );
+        assertThat(scenario.getScopeLabel()).isEqualTo("Shared");
+    }
+
     // ---- getTestCaseByName ----
 
     @Test

--- a/Engine/src/main/java/com/ing/engine/core/RunContext.java
+++ b/Engine/src/main/java/com/ing/engine/core/RunContext.java
@@ -5,6 +5,14 @@ import com.ing.engine.drivers.PlaywrightDriverFactory.Browser;
 public class RunContext {
     public String Scenario;
     public String TestCase;
+    /**
+     * Which scope the Scenario/TestCase names were resolved from when this run was
+     * requested: "PROJECT", "SHARED", or "" if unknown (e.g. a CLI run by name only).
+     * Lets {@code Task#getTestCase()} look up the exact intended test case directly,
+     * instead of guessing via a Test Plan -> Project -> Shared priority search that
+     * silently picks the wrong one when names collide across scopes.
+     */
+    public String ReusableScope = "";
     public String Description;
     public Browser Browser;
     public String BrowserName;

--- a/Engine/src/main/java/com/ing/engine/core/RunManager.java
+++ b/Engine/src/main/java/com/ing/engine/core/RunManager.java
@@ -72,6 +72,7 @@ public class RunManager {
         RunContext exe = new RunContext();
         exe.Scenario = globalSettings.getScenario();
         exe.TestCase = globalSettings.getTestCase();
+        exe.ReusableScope = globalSettings.getReusableScope();
         exe.Description = "Test Run";
         exe.BrowserName = globalSettings.getBrowser();
         exe.Browser = Browser.fromString(exe.BrowserName);

--- a/Engine/src/main/java/com/ing/engine/core/Task.java
+++ b/Engine/src/main/java/com/ing/engine/core/Task.java
@@ -4,6 +4,7 @@ import static com.ing.engine.commands.browser.Command.faker;
 
 import com.github.javafaker.Faker;
 import com.ing.datalib.component.Project;
+import com.ing.datalib.component.ReusableRef;
 import com.ing.datalib.component.Scenario;
 import com.ing.datalib.component.TestCase;
 import com.ing.datalib.settings.RunSettings;
@@ -57,6 +58,10 @@ public class Task implements Runnable {
         TestCase stc = getTestCase();
         if (stc != null) {
             runner = new TestCaseRunner(Control.exe, stc);
+            // Running a Project/Shared reusable standalone (not nested under an "Execute"
+            // step) makes it its OWN root - without this, its resolved scope would stay
+            // null and data lookups could match a same-named row from the other scope.
+            runner.setResolvedReusableScope(resolvedScopeOf(stc));
         } else {
             runner = new TestCaseRunner(Control.exe, runContext.Scenario, runContext.TestCase);
         }
@@ -110,33 +115,48 @@ public class Task implements Runnable {
 
     private TestCase getTestCase() {
         try {
-            Scenario scn = project().getScenarioByName(runContext.Scenario);
-            if (scn == null) {
-                LOG.log(Level.WARNING, "Scenario [{0}] not found", runContext.Scenario);
-                return null;
+            // When the caller knows exactly which scope this run was requested from
+            // (e.g. the IDE run button on an open Project/Shared reusable tab), look up
+            // that scope directly. This avoids Project.getScenarioByName(), which searches
+            // Test Plan + Project Reusable + Shared Reusable combined and would otherwise
+            // silently return the wrong scope's test case when names collide.
+            if ("PROJECT".equalsIgnoreCase(runContext.ReusableScope)) {
+                return testCaseFrom(
+                    project().getReusableScenarioByName(runContext.Scenario),
+                    "project reusable"
+                );
+            }
+            if ("SHARED".equalsIgnoreCase(runContext.ReusableScope)) {
+                return testCaseFrom(
+                    project().getSharedReusableScenarioByName(runContext.Scenario),
+                    "shared reusable"
+                );
             }
 
-            TestCase stc = scn.getTestCaseByName(runContext.TestCase);
+            // No scope hint (e.g. a CLI run by name only): fall back to an explicit
+            // Test Plan -> Project Reusable -> Shared Reusable priority search.
+            TestCase stc = testCaseFrom(
+                project().getTestPlanScenarioByName(runContext.Scenario),
+                "test plan"
+            );
             if (stc != null) {
                 return stc;
             }
 
-            // If not found in the test plan scenario, try project-scoped reusable scenario
-            Scenario scnR = project().getReusableScenarioByName(runContext.Scenario);
-            if (scnR != null) {
-                TestCase stcR = scnR.getTestCaseByName(runContext.TestCase);
-                if (stcR != null) {
-                    return stcR;
-                }
+            TestCase stcR = testCaseFrom(
+                project().getReusableScenarioByName(runContext.Scenario),
+                "project reusable"
+            );
+            if (stcR != null) {
+                return stcR;
             }
 
-            // If not found, try shared-scoped reusable scenario
-            Scenario scnS = project().getSharedReusableScenarioByName(runContext.Scenario);
-            if (scnS != null) {
-                TestCase stcS = scnS.getTestCaseByName(runContext.TestCase);
-                if (stcS != null) {
-                    return stcS;
-                }
+            TestCase stcS = testCaseFrom(
+                project().getSharedReusableScenarioByName(runContext.Scenario),
+                "shared reusable"
+            );
+            if (stcS != null) {
+                return stcS;
             }
 
             // Nothing matched — produce a clearer warning listing where we looked
@@ -149,6 +169,45 @@ public class Task implements Runnable {
         } catch (Exception ex) {
             LOG.log(Level.WARNING, "Unable to load TestCase", ex);
             return null;
+        }
+    }
+
+    private TestCase testCaseFrom(Scenario scn, String scopeLabel) {
+        if (scn == null) {
+            return null;
+        }
+        TestCase stc = scn.getTestCaseByName(runContext.TestCase);
+        if (stc == null) {
+            LOG.log(
+                Level.FINE,
+                "Testcase [{0}] not found in {1} scenario [{2}]",
+                new Object[] { runContext.TestCase, scopeLabel, runContext.Scenario }
+            );
+        }
+        return stc;
+    }
+
+    /**
+     * Determines the reusable scope of a resolved TestCase from its owning scenario's
+     * source, so a standalone run of a Project/Shared reusable carries the same scope
+     * information that a nested "Execute" call would resolve for it.
+     *
+     * @param stc the resolved test case
+     * @return PROJECT/SHARED for a reusable component, null for a Test Plan test case
+     */
+    private ReusableRef.Scope resolvedScopeOf(TestCase stc) {
+        Scenario scn = stc.getScenario();
+        if (scn == null) {
+            return null;
+        }
+        switch (scn.getSource()) {
+            case REUSABLE_COMPONENTS:
+                return ReusableRef.Scope.PROJECT;
+            case SHARED_REUSABLE_COMPONENTS:
+                return ReusableRef.Scope.SHARED;
+            case TEST_PLAN:
+            default:
+                return null;
         }
     }
 

--- a/Engine/src/main/java/com/ing/engine/execution/data/DataAccess.java
+++ b/Engine/src/main/java/com/ing/engine/execution/data/DataAccess.java
@@ -334,26 +334,34 @@ public class DataAccess extends DataAccessInternal {
         String subIter
     ) {
         String scopeFilter = getScopeFilter(context);
+        // The "root" test case is normally the Test Plan entry (always empty scope), but
+        // when a reusable is executed standalone (no parent Execute step) it IS its own
+        // root, so the root lookup must honor its resolved scope too - otherwise it would
+        // match a same-named row from the other reusable scope before scope filtering
+        // ever gets a chance to apply below.
+        String rootScopeFilter = getScopeFilter(context.getRoot());
 
         if (notNull(env) && env.hasColumn(field)) {
-            // Try root test case first (test plan data - always uses empty scope)
-            Object val = getDataFromModel(
+            // Try root test case first
+            Object val = getDataFromModelWithScope(
                 env,
                 field,
                 context.getRoot().scenario(),
                 context.getRoot().testcase(),
                 iter,
-                subIter
+                subIter,
+                rootScopeFilter
             );
             if (val == null) {
                 val =
-                    getDataFromModel(
+                    getDataFromModelWithScope(
                         def,
                         field,
                         context.getRoot().scenario(),
                         context.getRoot().testcase(),
                         iter,
-                        subIter
+                        subIter,
+                        rootScopeFilter
                     );
                 if (val == null) {
                     // Try reusable data with scope filtering
@@ -454,16 +462,18 @@ public class DataAccess extends DataAccessInternal {
         String subIter
     ) {
         String scopeFilter = getScopeFilter(context);
+        String rootScopeFilter = getScopeFilter(context.getRoot());
 
         if (notNull(def) && def.hasColumn(field)) {
-            // Try root test case first (test plan data)
-            Object rootVal = getDataFromModel(
+            // Try root test case first
+            Object rootVal = getDataFromModelWithScope(
                 def,
                 field,
                 context.getRoot().scenario(),
                 context.getRoot().testcase(),
                 iter,
-                subIter
+                subIter,
+                rootScopeFilter
             );
             if (rootVal != null) {
                 return rootVal;
@@ -503,26 +513,29 @@ public class DataAccess extends DataAccessInternal {
         String subIter
     ) {
         String scopeFilter = getScopeFilter(context);
+        String rootScopeFilter = getScopeFilter(context.getRoot());
 
         if (notNull(env) && env.hasColumn(field)) {
-            // Try root test case first (test plan data)
-            Object val = getDataFromModel(
+            // Try root test case first
+            Object val = getDataFromModelWithScope(
                 env,
                 field,
                 context.getRoot().scenario(),
                 context.getRoot().testcase(),
                 iter,
-                subIter
+                subIter,
+                rootScopeFilter
             );
             if (val == null) {
                 val =
-                    getDataFromModel(
+                    getDataFromModelWithScope(
                         def,
                         field,
                         context.getRoot().scenario(),
                         context.getRoot().testcase(),
                         iter,
-                        subIter
+                        subIter,
+                        rootScopeFilter
                     );
                 if (val == null) {
                     // Try reusable data with scope filtering

--- a/Engine/src/main/java/com/ing/engine/execution/data/DataAccess.java
+++ b/Engine/src/main/java/com/ing/engine/execution/data/DataAccess.java
@@ -90,11 +90,15 @@ public class DataAccess extends DataAccessInternal {
         String nextSubIteration = (Integer.parseInt(subIter) + 1) + "";
         String val = null;
 
-        // Determine if we should use scope filtering:
-        // Only apply scope if querying the CURRENT context (reusable), not the ROOT (test plan)
+        // The root is normally the Test Plan entry (empty scope), but when a reusable is run
+        // standalone (no parent Execute step) it IS its own root, so it must be filtered by
+        // its own resolved scope, not an assumed-empty one - otherwise Param Loop end-of-data
+        // detection could match a same-named row from the other reusable scope.
         boolean isQueryingRoot =
             scn.equals(context.getRoot().scenario()) && tc.equals(context.getRoot().testcase());
-        String scopeFilter = isQueryingRoot ? "" : getScopeFilter(context);
+        String scopeFilter = isQueryingRoot
+            ? getScopeFilter(context.getRoot())
+            : getScopeFilter(context);
 
         TestDataModel env;
         TestDataModel def = getDefModel(context, sheet);
@@ -181,12 +185,13 @@ public class DataAccess extends DataAccessInternal {
         Object val = null;
         TestDataModel env;
         TestDataModel def = getDefModel(context, sheet);
+        String scope = getScopeFilter(context, scn, tc);
         if (validEnv(context)) {
             env = getModel(context, sheet);
-            val = getDataFromModel(env, field, scn, tc, iter, subIter);
+            val = getDataFromModelWithScope(env, field, scn, tc, iter, subIter, scope);
         }
         if (val == null) {
-            val = getDataFromModel(def, field, scn, tc, iter, subIter);
+            val = getDataFromModelWithScope(def, field, scn, tc, iter, subIter, scope);
         }
         if (val == null) {
             throwErrorWithCause(context, sheet, field, subIter);
@@ -226,12 +231,22 @@ public class DataAccess extends DataAccessInternal {
         throws DataNotFoundException {
         boolean updated = false;
         TestDataModel def = getDefModel(context, sheet);
+        String scope = getScopeFilter(context, scn, tc);
         if (validEnv(context)) {
             updated =
-                putDataToModel(getModel(context, sheet), field, newVal, scn, tc, iter, subIter);
+                putDataToModel(
+                    getModel(context, sheet),
+                    field,
+                    newVal,
+                    scn,
+                    tc,
+                    iter,
+                    subIter,
+                    scope
+                );
         }
         if (!updated) {
-            updated = putDataToModel(def, field, newVal, scn, tc, iter, subIter);
+            updated = putDataToModel(def, field, newVal, scn, tc, iter, subIter, scope);
         }
         if (!updated) {
             throwErrorWithCause(context, sheet, field, subIter);
@@ -426,7 +441,8 @@ public class DataAccess extends DataAccessInternal {
                     context.getRoot().scenario(),
                     context.getRoot().testcase(),
                     iter,
-                    subIter
+                    subIter,
+                    getScopeFilter(context.getRoot())
                 ) ||
                 putDataToModel(
                     env,
@@ -436,7 +452,8 @@ public class DataAccess extends DataAccessInternal {
                     context.scenario(),
                     context.testcase(),
                     iter,
-                    subIter
+                    subIter,
+                    getScopeFilter(context)
                 )
             );
         } else {
@@ -631,7 +648,8 @@ public class DataAccess extends DataAccessInternal {
                 context.getRoot().scenario(),
                 context.getRoot().testcase(),
                 iter,
-                subIter
+                subIter,
+                getScopeFilter(context.getRoot())
             ) ||
             putDataToModel(
                 model,
@@ -640,7 +658,8 @@ public class DataAccess extends DataAccessInternal {
                 context.scenario(),
                 context.testcase(),
                 iter,
-                subIter
+                subIter,
+                getScopeFilter(context)
             )
         );
     }

--- a/Engine/src/main/java/com/ing/engine/execution/data/DataAccessInternal.java
+++ b/Engine/src/main/java/com/ing/engine/execution/data/DataAccessInternal.java
@@ -64,24 +64,6 @@ public class DataAccessInternal {
         }
     }
 
-    protected static String getDataFromModel(
-        TestDataModel model,
-        String field,
-        String scn,
-        String tc,
-        String iter,
-        String subIter
-    ) {
-        try {
-            if (notNull(model)) {
-                return model.view().withSubIter(scn, tc, iter, subIter).getField(field);
-            }
-        } catch (Exception ex) {
-            LOG.log(Level.WARNING, ex.getMessage(), ex);
-        }
-        return null;
-    }
-
     /**
      * Get data from test data model with scope filtering.
      * This method is used for reusable components to ensure they only access
@@ -118,6 +100,10 @@ public class DataAccessInternal {
         return null;
     }
 
+    /**
+     * Update test data in the model with scope filtering, so a same-named scenario/testcase
+     * in another reusable scope is never matched/overwritten by mistake.
+     */
     protected static boolean putDataToModel(
         TestDataModel model,
         String field,
@@ -125,12 +111,16 @@ public class DataAccessInternal {
         String scn,
         String tc,
         String iter,
-        String subIter
+        String subIter,
+        String scope
     ) {
         try {
             if (
                 notNull(model) &&
-                model.view().withSubIter(scn, tc, iter, subIter, true).update(field, newVal)
+                model
+                    .view()
+                    .withSubIterAndScope(scn, tc, iter, subIter, scope, true)
+                    .update(field, newVal)
             ) {
                 model.saveChanges();
                 return true;
@@ -151,11 +141,12 @@ public class DataAccessInternal {
         String scn,
         String tc,
         String iter,
-        String subIter
+        String subIter,
+        String scope
     ) {
         return (
-            putDataToModel(env, field, newVal, scn, tc, iter, subIter) ||
-            putDataToModel(def, field, newVal, scn, tc, iter, subIter)
+            putDataToModel(env, field, newVal, scn, tc, iter, subIter, scope) ||
+            putDataToModel(def, field, newVal, scn, tc, iter, subIter, scope)
         );
     }
 
@@ -224,8 +215,11 @@ public class DataAccessInternal {
         TestDataModel def
     ) {
         Set<String> val = null;
-        // Test plan data always has empty scope
-        String testPlanScope = "";
+        // The root is normally the Test Plan entry (empty scope), but when a reusable is
+        // run standalone (no parent Execute step) it IS its own root, so this must honor
+        // its resolved scope too - otherwise it could match a same-named row from the
+        // other reusable scope.
+        String rootScope = getScopeFilter(context.getRoot());
 
         if (notNull(env)) {
             val =
@@ -234,7 +228,7 @@ public class DataAccessInternal {
                     .withTestcaseAndScope(
                         context.getRoot().scenario(),
                         context.getRoot().testcase(),
-                        testPlanScope
+                        rootScope
                     )
                     .getIterations();
         }
@@ -245,7 +239,7 @@ public class DataAccessInternal {
                     .withTestcaseAndScope(
                         context.getRoot().scenario(),
                         context.getRoot().testcase(),
-                        testPlanScope
+                        rootScope
                     )
                     .getIterations();
         }
@@ -290,8 +284,10 @@ public class DataAccessInternal {
      */
     protected static Set<String> getIter(TestCaseRunner context, TestDataModel def) {
         if (notNull(def)) {
-            // Test plan data always has empty scope
-            String testPlanScope = "";
+            // The root is normally the Test Plan entry (empty scope), but when a reusable is
+            // run standalone (no parent Execute step) it IS its own root, so this must honor
+            // its resolved scope too.
+            String rootScope = getScopeFilter(context.getRoot());
             String scopeFilter = getScopeFilter(context);
 
             // Get root testcase view with null-safety check
@@ -300,7 +296,7 @@ public class DataAccessInternal {
                 .withTestcaseAndScope(
                     context.getRoot().scenario(),
                     context.getRoot().testcase(),
-                    testPlanScope
+                    rootScope
                 );
 
             Set<String> val = null;
@@ -351,14 +347,19 @@ public class DataAccessInternal {
         TestDataModel def
     ) {
         Set<String> val = null;
+        // The root is normally the Test Plan entry (empty scope), but when a reusable is
+        // run standalone (no parent Execute step) it IS its own root, so this must honor
+        // its resolved scope too.
+        String rootScope = getScopeFilter(context.getRoot());
         if (notNull(env)) {
             val =
                 env
                     .view()
-                    .withIter(
+                    .withIterAndScope(
                         context.getRoot().scenario(),
                         context.getRoot().testcase(),
-                        context.iteration()
+                        context.iteration(),
+                        rootScope
                     )
                     .getSubIterations();
         }
@@ -366,10 +367,11 @@ public class DataAccessInternal {
             val =
                 def
                     .view()
-                    .withIter(
+                    .withIterAndScope(
                         context.getRoot().scenario(),
                         context.getRoot().testcase(),
-                        context.iteration()
+                        context.iteration(),
+                        rootScope
                     )
                     .getSubIterations();
         }
@@ -382,18 +384,29 @@ public class DataAccessInternal {
         TestDataModel def
     ) {
         Set<String> val = null;
+        String scopeFilter = getScopeFilter(context);
         if (notNull(env)) {
             val =
                 env
                     .view()
-                    .withIter(context.scenario(), context.testcase(), context.iteration())
+                    .withIterAndScope(
+                        context.scenario(),
+                        context.testcase(),
+                        context.iteration(),
+                        scopeFilter
+                    )
                     .getSubIterations();
         }
         if (isNullOrEmpty(val) && notNull(def)) {
             val =
                 def
                     .view()
-                    .withIter(context.scenario(), context.testcase(), context.iteration())
+                    .withIterAndScope(
+                        context.scenario(),
+                        context.testcase(),
+                        context.iteration(),
+                        scopeFilter
+                    )
                     .getSubIterations();
         }
         return val;
@@ -409,19 +422,28 @@ public class DataAccessInternal {
      */
     protected static Set<String> getSubIter(TestCaseRunner context, TestDataModel def) {
         if (notNull(def)) {
+            // The root is normally the Test Plan entry (empty scope), but when a reusable is
+            // run standalone (no parent Execute step) it IS its own root, so this must honor
+            // its resolved scope too.
             Set<String> val = def
                 .view()
-                .withIter(
+                .withIterAndScope(
                     context.getRoot().scenario(),
                     context.getRoot().testcase(),
-                    context.iteration()
+                    context.iteration(),
+                    getScopeFilter(context.getRoot())
                 )
                 .getSubIterations();
             if (isNullOrEmpty(val)) {
                 val =
                     def
                         .view()
-                        .withIter(context.scenario(), context.testcase(), context.iteration())
+                        .withIterAndScope(
+                            context.scenario(),
+                            context.testcase(),
+                            context.iteration(),
+                            getScopeFilter(context)
+                        )
                         .getSubIterations();
             }
             return val;
@@ -605,5 +627,23 @@ public class DataAccessInternal {
             default:
                 return ""; // Empty for backward compatibility
         }
+    }
+
+    /**
+     * Resolves the scope filter to use for an explicitly-named scenario/testcase (as opposed
+     * to the ones implied by {@code context}/{@code context.getRoot()}) - e.g. a user command
+     * reading another sheet's data by name via {@code UserDataAccess}. If the given name pair
+     * matches the root or the current context, that context's own resolved scope is used;
+     * otherwise there is no scope information to go on, so it falls back to unscoped (matching
+     * prior behavior for references to some other scenario/testcase entirely).
+     */
+    protected static String getScopeFilter(TestCaseRunner context, String scn, String tc) {
+        if (scn.equals(context.getRoot().scenario()) && tc.equals(context.getRoot().testcase())) {
+            return getScopeFilter(context.getRoot());
+        }
+        if (scn.equals(context.scenario()) && tc.equals(context.testcase())) {
+            return getScopeFilter(context);
+        }
+        return "";
     }
 }

--- a/Engine/src/main/java/com/ing/engine/execution/data/UserDataAccess.java
+++ b/Engine/src/main/java/com/ing/engine/execution/data/UserDataAccess.java
@@ -117,11 +117,12 @@ public abstract class UserDataAccess implements UserDataAccessApi {
     public TestDataView getTestData(String sheetName) {
         return DataAccess
             .getTestData(context(), sheetName)
-            .withSubIter(
+            .withSubIterAndScope(
                 context().scenario(),
                 context().testcase(),
                 context().iteration(),
-                context().subIteration()
+                context().subIteration(),
+                DataAccessInternal.getScopeFilter(context())
             );
     }
 }

--- a/Engine/src/main/java/com/ing/engine/execution/run/TestStepRunner.java
+++ b/Engine/src/main/java/com/ing/engine/execution/run/TestStepRunner.java
@@ -159,7 +159,7 @@ public class TestStepRunner {
                     validateObjectReferencesForPolicy(context, resolvedScope);
 
                     try {
-                        executeTestCase(context, stc);
+                        executeTestCase(context, stc, resolvedScope);
                     } finally {
                         // Clear scope after reusable execution completes
                         context.setResolvedReusableScope(null);
@@ -194,12 +194,22 @@ public class TestStepRunner {
         );
     }
 
-    private void executeTestCase(TestCaseRunner context, TestCase stc)
+    private void executeTestCase(
+        TestCaseRunner context,
+        TestCase stc,
+        ReusableRef.Scope resolvedScope
+    )
         throws DataNotFoundException {
         try {
             parameter.setSubIteration(getSubIterationFromInput(context));
             context.getReport().startComponent(getStep().getAction(), getStep().getDescription());
-            new TestCaseRunner(context, stc, parameter).run();
+            // The reusable's own steps execute through this new runner instance, so the
+            // resolved scope must be set here too - it is NOT inherited from the parent
+            // context, and without it every data lookup inside the reusable falls back to
+            // unscoped resolution, defeating the Shared/Project data disambiguation.
+            TestCaseRunner reusableRunner = new TestCaseRunner(context, stc, parameter);
+            reusableRunner.setResolvedReusableScope(resolvedScope);
+            reusableRunner.run();
         } finally {
             context.getReport().endComponent(getStep().getAction());
         }

--- a/Engine/src/main/java/com/ing/engine/execution/run/TestStepRunner.java
+++ b/Engine/src/main/java/com/ing/engine/execution/run/TestStepRunner.java
@@ -204,7 +204,9 @@ public class TestStepRunner {
         throws DataNotFoundException {
         try {
             parameter.setSubIteration(getSubIterationFromInput(context));
-            context.getReport().startComponent(getStep().getAction(), getStep().getDescription());
+            context
+                .getReport()
+                .startComponent(getStep().getAction(), getStep().getDescription(), resolvedScope);
             // The reusable's own steps execute through this new runner instance, so the
             // resolved scope must be set here too - it is NOT inherited from the parent
             // context, and without it every data lookup inside the reusable falls back to

--- a/Engine/src/main/java/com/ing/engine/execution/run/TestStepRunner.java
+++ b/Engine/src/main/java/com/ing/engine/execution/run/TestStepRunner.java
@@ -152,18 +152,20 @@ public class TestStepRunner {
                 TestCase stc = scn.getTestCaseByName(testcaseName);
                 if (stc != null) {
                     stc.setParentTestCase(context.getTestCase());
-                    // Set scope metadata in context for downstream consumers
-                    context.setResolvedReusableScope(resolvedScope);
 
                     // Phase 4: Validate object references against policy before execution
                     validateObjectReferencesForPolicy(context, resolvedScope);
 
-                    try {
-                        executeTestCase(context, stc, resolvedScope);
-                    } finally {
-                        // Clear scope after reusable execution completes
-                        context.setResolvedReusableScope(null);
-                    }
+                    // Scope is set on the new reusableRunner only (see executeTestCase) - NOT
+                    // on `context`. `context` is the CALLING runner, which may itself be the
+                    // true root (TestCaseRunner.getRoot() walks the parent chain via this same
+                    // `context` link). Mutating context's scope here - even temporarily - is
+                    // visible through getRoot() to every data lookup made by the nested
+                    // reusable while it runs, corrupting the parent identity's own scope
+                    // (e.g. a Test Plan root becoming "[Project]"-scoped) for the whole nested
+                    // call, which breaks parent-data resolution for nested/looped/multi-level
+                    // reusables.
+                    executeTestCase(context, stc, resolvedScope);
                     return;
                 } else {
                     throw new ForcedException(

--- a/Engine/src/main/java/com/ing/engine/reporting/TestCaseReport.java
+++ b/Engine/src/main/java/com/ing/engine/reporting/TestCaseReport.java
@@ -349,6 +349,17 @@ public final class TestCaseReport implements Report, TestCaseReportApi {
     }
 
     @Override
+    public void startComponent(
+        String component,
+        String desc,
+        com.ing.datalib.component.ReusableRef.Scope resolvedScope
+    ) {
+        for (TestCaseHandler handler : handlers) {
+            handler.startComponent(component, desc, resolvedScope);
+        }
+    }
+
+    @Override
     public void endComponent(String component) {
         for (TestCaseHandler handler : handlers) {
             handler.endComponent(component);

--- a/Engine/src/main/java/com/ing/engine/reporting/impl/html/HtmlTestCaseHandler.java
+++ b/Engine/src/main/java/com/ing/engine/reporting/impl/html/HtmlTestCaseHandler.java
@@ -453,6 +453,32 @@ public class HtmlTestCaseHandler extends TestCaseHandler implements PrimaryHandl
     }
 
     @Override
+    public void startComponent(
+        String component,
+        String desc,
+        com.ing.datalib.component.ReusableRef.Scope resolvedScope
+    ) {
+        startComponent(scopedComponentName(component, resolvedScope), desc);
+    }
+
+    private String scopedComponentName(
+        String component,
+        com.ing.datalib.component.ReusableRef.Scope resolvedScope
+    ) {
+        if (resolvedScope == null) {
+            return component;
+        }
+        switch (resolvedScope) {
+            case PROJECT:
+                return "[Project] " + component;
+            case SHARED:
+                return "[Shared] " + component;
+            default:
+                return component;
+        }
+    }
+
+    @Override
     public void endComponent(String string) {
         reusable.put(RDS.Step.END_TIME, DateTimeUtils.DateTimeNow());
         if (reusable.get(TestCase.STATUS).equals("")) {

--- a/Engine/src/main/java/com/ing/engine/reporting/intf/Report.java
+++ b/Engine/src/main/java/com/ing/engine/reporting/intf/Report.java
@@ -1,5 +1,6 @@
 package com.ing.engine.reporting.intf;
 
+import com.ing.datalib.component.ReusableRef;
 import com.ing.engine.core.RunContext;
 import com.ing.engine.drivers.PlaywrightDriverCreation;
 import com.ing.engine.drivers.WebDriverCreation;
@@ -22,6 +23,14 @@ public interface Report {
     public Status finalizeReport();
 
     public void startComponent(String component, String desc);
+
+    public default void startComponent(
+        String component,
+        String desc,
+        ReusableRef.Scope resolvedScope
+    ) {
+        startComponent(component, desc);
+    }
 
     public void startIteration(int iteration);
 

--- a/Engine/src/main/java/com/ing/engine/settings/GlobalSettings.java
+++ b/Engine/src/main/java/com/ing/engine/settings/GlobalSettings.java
@@ -1,5 +1,6 @@
 package com.ing.engine.settings;
 
+import com.ing.datalib.component.Scenario;
 import com.ing.datalib.component.TestCase;
 import com.ing.datalib.component.TestSet;
 import com.ing.datalib.settings.AbstractPropSettings;
@@ -21,8 +22,28 @@ public class GlobalSettings extends AbstractPropSettings {
         setProjectName(testCase.getProject().getName());
         setScenario(testCase.getScenario().getName());
         setTestCase(testCase.getName());
+        // Capture WHICH scope this exact TestCase was opened from (Test Plan, Project
+        // Reusable, or Shared Reusable) so a standalone run can look it up unambiguously
+        // later, even when a same-named scenario/testcase exists in another scope.
+        setReusableScope(reusableScopeOf(testCase));
         setBrowser(browser);
         save();
+    }
+
+    private String reusableScopeOf(TestCase testCase) {
+        Scenario scn = testCase.getScenario();
+        if (scn == null || scn.getSource() == null) {
+            return "";
+        }
+        switch (scn.getSource()) {
+            case REUSABLE_COMPONENTS:
+                return "PROJECT";
+            case SHARED_REUSABLE_COMPONENTS:
+                return "SHARED";
+            case TEST_PLAN:
+            default:
+                return "";
+        }
     }
 
     public void setFor(TestSet testSet) {
@@ -65,6 +86,10 @@ public class GlobalSettings extends AbstractPropSettings {
 
     public void setScenario(String value) {
         setProperty("Scenario", value);
+        // Reset any stale scope hint from a previous run (e.g. a CLI run that sets the
+        // scenario/testcase by name only, with no TestCase object to derive scope from).
+        // setFor(TestCase, ...) re-applies the correct hint right after calling this.
+        setReusableScope("");
     }
 
     public String getTestCase() {
@@ -73,6 +98,18 @@ public class GlobalSettings extends AbstractPropSettings {
 
     public void setTestCase(String value) {
         setProperty("TestCase", value);
+    }
+
+    /**
+     * Scope of the TestCase last set via {@link #setFor(TestCase, String)}: "PROJECT",
+     * "SHARED", or "" for a Test Plan test case / when unknown (e.g. CLI runs by name).
+     */
+    public String getReusableScope() {
+        return getProperty("ReusableScope", "");
+    }
+
+    public void setReusableScope(String value) {
+        setProperty("ReusableScope", value);
     }
 
     public String getBrowser() {

--- a/Engine/src/test/java/com/ing/engine/execution/data/DataAccessInternalTest.java
+++ b/Engine/src/test/java/com/ing/engine/execution/data/DataAccessInternalTest.java
@@ -85,11 +85,19 @@ public class DataAccessInternalTest {
         assertThat(DataAccessInternal.isNull("hello")).isFalse();
     }
 
-    // ---- getDataFromModel ----
+    // ---- getDataFromModelWithScope ----
 
     @Test
     public void testGetDataFromModelNullModel() {
-        String result = DataAccessInternal.getDataFromModel(null, "field", "scn", "tc", "1", "1");
+        String result = DataAccessInternal.getDataFromModelWithScope(
+            null,
+            "field",
+            "scn",
+            "tc",
+            "1",
+            "1",
+            ""
+        );
         assertThat(result).isNull();
     }
 
@@ -97,16 +105,17 @@ public class DataAccessInternalTest {
     public void testGetDataFromModelReturnsValue() {
         TestDataView subView = mock(TestDataView.class);
         when(envModel.view()).thenReturn(envView);
-        when(envView.withSubIter("scn1", "tc1", "1", "1")).thenReturn(subView);
+        when(envView.withSubIterAndScope("scn1", "tc1", "1", "1", "")).thenReturn(subView);
         when(subView.getField("myField")).thenReturn("foundValue");
 
-        String result = DataAccessInternal.getDataFromModel(
+        String result = DataAccessInternal.getDataFromModelWithScope(
             envModel,
             "myField",
             "scn1",
             "tc1",
             "1",
-            "1"
+            "1",
+            ""
         );
         assertThat(result).isEqualTo("foundValue");
     }
@@ -115,13 +124,14 @@ public class DataAccessInternalTest {
     public void testGetDataFromModelException() {
         when(envModel.view()).thenThrow(new RuntimeException("test error"));
 
-        String result = DataAccessInternal.getDataFromModel(
+        String result = DataAccessInternal.getDataFromModelWithScope(
             envModel,
             "field",
             "scn",
             "tc",
             "1",
-            "1"
+            "1",
+            ""
         );
         assertThat(result).isNull();
     }
@@ -137,7 +147,8 @@ public class DataAccessInternalTest {
             "scn",
             "tc",
             "1",
-            "1"
+            "1",
+            ""
         );
         assertThat(result).isFalse();
     }
@@ -146,7 +157,7 @@ public class DataAccessInternalTest {
     public void testPutDataToModelSuccess() {
         TestDataView subView = mock(TestDataView.class);
         when(envModel.view()).thenReturn(envView);
-        when(envView.withSubIter("scn1", "tc1", "1", "1", true)).thenReturn(subView);
+        when(envView.withSubIterAndScope("scn1", "tc1", "1", "1", "", true)).thenReturn(subView);
         when(subView.update("myField", "newVal")).thenReturn(true);
 
         boolean result = DataAccessInternal.putDataToModel(
@@ -156,7 +167,8 @@ public class DataAccessInternalTest {
             "scn1",
             "tc1",
             "1",
-            "1"
+            "1",
+            ""
         );
         assertThat(result).isTrue();
         verify(envModel).saveChanges();
@@ -166,7 +178,7 @@ public class DataAccessInternalTest {
     public void testPutDataToModelUpdateReturnsFalse() {
         TestDataView subView = mock(TestDataView.class);
         when(envModel.view()).thenReturn(envView);
-        when(envView.withSubIter("scn1", "tc1", "1", "1", true)).thenReturn(subView);
+        when(envView.withSubIterAndScope("scn1", "tc1", "1", "1", "", true)).thenReturn(subView);
         when(subView.update("myField", "newVal")).thenReturn(false);
 
         boolean result = DataAccessInternal.putDataToModel(
@@ -176,7 +188,8 @@ public class DataAccessInternalTest {
             "scn1",
             "tc1",
             "1",
-            "1"
+            "1",
+            ""
         );
         assertThat(result).isFalse();
         verify(envModel, never()).saveChanges();
@@ -192,8 +205,8 @@ public class DataAccessInternalTest {
 
         when(envModel.view()).thenReturn(envView);
         when(defModel.view()).thenReturn(defView);
-        when(envView.withSubIter("scn", "tc", "1", "1", true)).thenReturn(envSub);
-        when(defView.withSubIter("scn", "tc", "1", "1", true)).thenReturn(defSub);
+        when(envView.withSubIterAndScope("scn", "tc", "1", "1", "", true)).thenReturn(envSub);
+        when(defView.withSubIterAndScope("scn", "tc", "1", "1", "", true)).thenReturn(defSub);
         when(envSub.update("field", "val")).thenReturn(false);
         when(defSub.update("field", "val")).thenReturn(true);
 
@@ -205,7 +218,8 @@ public class DataAccessInternalTest {
             "scn",
             "tc",
             "1",
-            "1"
+            "1",
+            ""
         );
         assertThat(result).isTrue();
     }

--- a/Engine/src/test/java/com/ing/engine/execution/data/DataAccessScopeIntegrationTest.java
+++ b/Engine/src/test/java/com/ing/engine/execution/data/DataAccessScopeIntegrationTest.java
@@ -1,0 +1,195 @@
+package com.ing.engine.execution.data;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+import com.ing.datalib.component.ReusableRef;
+import com.ing.testdata.csv.CsvTestData;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.Set;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+/**
+ * End-to-end regression test for scope-aware test data resolution: the same Scenario/TestCase
+ * name ("Login"/"Step1") exists in both the Project and Shared reusable scopes, each with its
+ * own distinct iteration/sub-iteration/data. A standalone run of either reusable must only ever
+ * see its own scope's rows, never the other scope's - exercises the real DataAccessInternal
+ * methods (getIter/getSubIter) rather than mocking them away, unlike DataAccessScopeTest.
+ */
+public class DataAccessScopeIntegrationTest {
+    private Path tempDir;
+    private CsvTestData sharedNameData;
+
+    @BeforeMethod
+    public void setUp() throws IOException {
+        tempDir = Files.createTempDirectory("data-access-scope-test");
+        File csvFile = tempDir.resolve("LoginData.csv").toFile();
+        try (FileWriter fw = new FileWriter(csvFile)) {
+            fw.write("Scenario,Flow,Scope,Iteration,SubIteration,Username\n");
+            fw.write("Login,Step1,[Project],1,1,proj-user-1\n");
+            fw.write("Login,Step1,[Project],1,2,proj-user-2\n");
+            fw.write("Login,Step1,[Shared],1,1,shared-user-1\n");
+        }
+        sharedNameData = new CsvTestData(csvFile.getAbsolutePath());
+        sharedNameData.loadRecords(csvFile);
+    }
+
+    @AfterMethod
+    public void tearDown() throws IOException {
+        Files
+            .walk(tempDir)
+            .sorted(Comparator.reverseOrder())
+            .map(Path::toFile)
+            .forEach(File::delete);
+    }
+
+    private com.ing.engine.execution.run.TestCaseRunner mockStandaloneReusable(
+        ReusableRef.Scope scope
+    ) {
+        com.ing.engine.execution.run.TestCaseRunner context = mock(
+            com.ing.engine.execution.run.TestCaseRunner.class
+        );
+        when(context.scenario()).thenReturn("Login");
+        when(context.testcase()).thenReturn("Step1");
+        when(context.iteration()).thenReturn("1");
+        when(context.getResolvedReusableScope()).thenReturn(scope);
+        // Standalone run: this reusable IS its own root.
+        when(context.getRoot()).thenReturn(context);
+        return context;
+    }
+
+    @Test
+    public void testGetIter_StandaloneProjectReusable_OnlySeesProjectScope() {
+        com.ing.engine.execution.run.TestCaseRunner context = mockStandaloneReusable(
+            ReusableRef.Scope.PROJECT
+        );
+
+        Set<String> subIters = DataAccessInternal.getSubIter(context, sharedNameData);
+
+        assertThat(subIters)
+            .as("Standalone [Project] reusable must only see [Project]-scoped sub-iterations")
+            .containsExactlyInAnyOrder("1", "2");
+    }
+
+    @Test
+    public void testGetIter_StandaloneSharedReusable_OnlySeesSharedScope() {
+        com.ing.engine.execution.run.TestCaseRunner context = mockStandaloneReusable(
+            ReusableRef.Scope.SHARED
+        );
+
+        Set<String> subIters = DataAccessInternal.getSubIter(context, sharedNameData);
+
+        assertThat(subIters)
+            .as("Standalone [Shared] reusable must only see [Shared]-scoped sub-iterations")
+            .containsExactly("1");
+    }
+
+    @Test
+    public void testGetIter_NestedProjectReusableInsideRegularTestCase_OnlySeesProjectScope() {
+        // Root: a normal Test Plan test case (empty scope) calling the [Project] "Login:Step1"
+        // reusable via a nested Execute step - root and nested context are DIFFERENT instances.
+        com.ing.engine.execution.run.TestCaseRunner rootContext = mock(
+            com.ing.engine.execution.run.TestCaseRunner.class
+        );
+        when(rootContext.scenario()).thenReturn("MainFlow");
+        when(rootContext.testcase()).thenReturn("RunLogin");
+        when(rootContext.getResolvedReusableScope()).thenReturn(null);
+        when(rootContext.getRoot()).thenReturn(rootContext);
+
+        com.ing.engine.execution.run.TestCaseRunner nestedContext = mock(
+            com.ing.engine.execution.run.TestCaseRunner.class
+        );
+        when(nestedContext.scenario()).thenReturn("Login");
+        when(nestedContext.testcase()).thenReturn("Step1");
+        when(nestedContext.iteration()).thenReturn("1");
+        when(nestedContext.getResolvedReusableScope()).thenReturn(ReusableRef.Scope.PROJECT);
+        when(nestedContext.getRoot()).thenReturn(rootContext);
+
+        Set<String> subIters = DataAccessInternal.getSubIter(nestedContext, sharedNameData);
+
+        assertThat(subIters)
+            .as(
+                "Nested [Project] reusable inside a regular test case must only see its own " +
+                "[Project]-scoped sub-iterations, not [Shared]'s"
+            )
+            .containsExactlyInAnyOrder("1", "2");
+    }
+
+    @Test
+    public void testGetDataFromModelWithScope_ResolvesCorrectRowPerScope() {
+        String projectVal = DataAccessInternal.getDataFromModelWithScope(
+            sharedNameData,
+            "Username",
+            "Login",
+            "Step1",
+            "1",
+            "1",
+            "[Project]"
+        );
+        String sharedVal = DataAccessInternal.getDataFromModelWithScope(
+            sharedNameData,
+            "Username",
+            "Login",
+            "Step1",
+            "1",
+            "1",
+            "[Shared]"
+        );
+
+        assertThat(projectVal).isEqualTo("proj-user-1");
+        assertThat(sharedVal).isEqualTo("shared-user-1");
+    }
+
+    /**
+     * Regression test: writing to the [Project] row for Login/Step1/1/1 must not also update
+     * (or instead update) the [Shared] row sharing the exact same scenario/testcase/iteration/
+     * sub-iteration - the two scopes' rows are otherwise indistinguishable by those keys alone.
+     */
+    @Test
+    public void testPutDataToModel_DoesNotCrossContaminateOtherScopeRow() {
+        boolean updated = DataAccessInternal.putDataToModel(
+            sharedNameData,
+            "Username",
+            "proj-user-1-UPDATED",
+            "Login",
+            "Step1",
+            "1",
+            "1",
+            "[Project]"
+        );
+        assertThat(updated).isTrue();
+
+        String projectVal = DataAccessInternal.getDataFromModelWithScope(
+            sharedNameData,
+            "Username",
+            "Login",
+            "Step1",
+            "1",
+            "1",
+            "[Project]"
+        );
+        String sharedVal = DataAccessInternal.getDataFromModelWithScope(
+            sharedNameData,
+            "Username",
+            "Login",
+            "Step1",
+            "1",
+            "1",
+            "[Shared]"
+        );
+
+        assertThat(projectVal)
+            .as("The [Project] row itself should reflect the update")
+            .isEqualTo("proj-user-1-UPDATED");
+        assertThat(sharedVal)
+            .as("The [Shared] row sharing the same scn/tc/iter/subIter must be untouched")
+            .isEqualTo("shared-user-1");
+    }
+}

--- a/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/scenario/ScenarioComponent.java
+++ b/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/scenario/ScenarioComponent.java
@@ -83,7 +83,9 @@ public class ScenarioComponent extends JPanel implements ActionListener {
 
     public void refreshTitle() {
         if (getCurrentScenario() != null) {
-            toolBar.setPlaceHolderText(getCurrentScenario().getName());
+            toolBar.setPlaceHolderText(
+                getCurrentScenario().getName() + " (" + getCurrentScenario().getScopeLabel() + ")"
+            );
         }
     }
 

--- a/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/testcase/TestCaseComponent.java
+++ b/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/testcase/TestCaseComponent.java
@@ -340,11 +340,12 @@ public class TestCaseComponent extends JPanel implements ActionListener {
         if (tcText.length() > 20) {
             tcText = tcText.substring(0, 20) + "...";
         }
+        String scopeLabel = getCurrentTestCase().getScenario().getScopeLabel();
         //        String toolTip
         //                = getCurrentTestCase().getScenario().getName()
         //                + " - "
         //                + getCurrentTestCase().getName();
-        toolBar.setPlaceHolderText(scText + " - " + tcText, null);
+        toolBar.setPlaceHolderText(scText + " - " + tcText + " (" + scopeLabel + ")", null);
     }
 
     public void load() {

--- a/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/tree/ProjectDnD.java
+++ b/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/tree/ProjectDnD.java
@@ -22,7 +22,9 @@ import java.awt.datatransfer.DataFlavor;
 import java.awt.datatransfer.Transferable;
 import java.awt.datatransfer.UnsupportedFlavorException;
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.swing.JComponent;
@@ -253,11 +255,11 @@ public class ProjectDnD extends TransferHandler {
             }
             TestCaseNode newTestCaseNode;
             if (isCut) {
-                // For move/cut, preserve original name by removing source first.
-                // This avoids transient cross-scope uniqueness conflicts while moving.
+                // Name collisions in the destination are resolved with a "_n" suffix (same as
+                // copy) rather than rejected - remove the source first so a move onto the same
+                // scenario it already lives in doesn't collide with itself.
                 scenario.removeTestCase(testCase);
-                newTestCaseNode =
-                    addTestCase(dropscenario.getScenario(), testCaseNode.toString(), false);
+                newTestCaseNode = addTestCase(dropscenario.getScenario(), testCaseNode.toString());
                 if (newTestCaseNode == null || newTestCaseNode.getTestCase() == null) {
                     scenario.getTestCases().add(testCase);
                     Logger
@@ -271,8 +273,7 @@ public class ProjectDnD extends TransferHandler {
                     continue;
                 }
             } else {
-                newTestCaseNode =
-                    addTestCase(dropscenario.getScenario(), testCaseNode.toString(), true);
+                newTestCaseNode = addTestCase(dropscenario.getScenario(), testCaseNode.toString());
                 if (newTestCaseNode == null || newTestCaseNode.getTestCase() == null) {
                     Logger
                         .getLogger(ProjectDnD.class.getName())
@@ -290,10 +291,19 @@ public class ProjectDnD extends TransferHandler {
             newTestCaseNode.getTestCase().setReusable(testCase.getReusable());
             if (isCut) {
                 sourceTreeModel.removeNodeFromParent(testCaseNode);
+                String oldTestCaseName = testCaseNode.toString();
+                String newTestCaseName = newTestCaseNode.getTestCase().getName();
+                if (!oldTestCaseName.equals(newTestCaseName)) {
+                    // The suffix-on-conflict rename means any Execute step reference pointing at
+                    // the old name must be repointed at the new one before the scenario move.
+                    pTree
+                        .getProject()
+                        .refactorTestCase(scenario.getName(), oldTestCaseName, newTestCaseName);
+                }
                 pTree
                     .getProject()
                     .refactorTestCaseScenario(
-                        testCaseNode.toString(),
+                        newTestCaseName,
                         scenario.getName(),
                         dropscenario.toString()
                     );
@@ -308,22 +318,23 @@ public class ProjectDnD extends TransferHandler {
         Boolean isCut
     ) {
         int skipped = 0;
+        // Test cases pasted together from the same source scenario in this batch must land in
+        // the same newly created destination scenario rather than each minting their own copy.
+        Map<Scenario, Scenario> destinationScenarios = new HashMap<>();
         for (TestCaseNode testCaseNode : testCaseNodes) {
             Scenario scenario = testCaseNode.getTestCase().getScenario();
             TestCase testCase = testCaseNode.getTestCase();
-            Scenario destinationScenario = getOrCreateDestinationScenarioForRootPaste(scenario);
+            Scenario destinationScenario = destinationScenarios.computeIfAbsent(
+                scenario,
+                this::createDestinationScenarioForRootPaste
+            );
             if (destinationScenario == null) {
                 skipped++;
                 continue;
             }
             ScenarioNode scNode = dropGroup.addScenarioIfNotPresent(destinationScenario);
 
-            TestCaseNode inserted;
-            if (isCut) {
-                inserted = addTestCase(destinationScenario, testCaseNode.toString(), false);
-            } else {
-                inserted = addTestCase(destinationScenario, testCaseNode.toString(), true);
-            }
+            TestCaseNode inserted = addTestCase(destinationScenario, testCaseNode.toString());
 
             if (inserted == null || inserted.getTestCase() == null) {
                 skipped++;
@@ -344,65 +355,23 @@ public class ProjectDnD extends TransferHandler {
         showSkippedPasteNotification(skipped);
     }
 
-    private Scenario getOrCreateDestinationScenarioForRootPaste(Scenario sourceScenario) {
-        String scenarioName = sourceScenario.getName();
-        if (pTree.getTreeModel().getRoot() instanceof TestPlanNode) {
-            Scenario existing = sourceScenario.getProject().getTestPlanScenarioByName(scenarioName);
-            if (existing != null) {
-                return existing;
-            }
-            Scenario created = new Scenario(
-                sourceScenario.getProject(),
-                scenarioName,
-                Scenario.Source.TEST_PLAN
-            );
-            sourceScenario.getProject().getScenarios().add(created);
-            return created;
-        }
-        if (pTree.getTreeModel().getRoot() instanceof ReusableNode) {
-            Scenario existing = sourceScenario.getProject().getReusableScenarioByName(scenarioName);
-            if (existing != null) {
-                return existing;
-            }
-            Scenario created = new Scenario(
-                sourceScenario.getProject(),
-                scenarioName,
-                Scenario.Source.REUSABLE_COMPONENTS
-            );
-            sourceScenario.getProject().getReusableScenarios().add(created);
-            return created;
-        }
-        if (pTree.getTreeModel().getRoot() instanceof SharedReusableNode) {
-            Scenario existing = sourceScenario
-                .getProject()
-                .getSharedReusableScenarioByName(scenarioName);
-            if (existing != null) {
-                return existing;
-            }
-            Scenario created = new Scenario(
-                sourceScenario.getProject(),
-                scenarioName,
-                Scenario.Source.SHARED_REUSABLE_COMPONENTS
-            );
-            sourceScenario.getProject().getSharedScenarios().add(created);
-            return created;
-        }
-        return null;
+    /**
+     * Root-level (Group/tree-root drop target) paste of standalone test cases never merges into
+     * a pre-existing same-named scenario in the destination scope - it always creates a new,
+     * independently-suffixed scenario, same as copying a whole Scenario does. (The Live Recorder
+     * has its own separate, intentionally different, merge-by-name scenario resolution and is
+     * unaffected by this.)
+     */
+    private Scenario createDestinationScenarioForRootPaste(Scenario sourceScenario) {
+        String uniqueScenarioName = buildCopiedScenarioName(sourceScenario);
+        return createScenarioInDestinationScope(sourceScenario, uniqueScenarioName);
     }
 
-    private TestCaseNode addTestCase(Scenario scenario, String name, boolean allowCopySuffix) {
-        String newName = name;
-        if (allowCopySuffix) {
-            newName =
-                NamingUtils.generateUniqueName(
-                    name,
-                    candidate -> scenario.getTestCaseByName(candidate) != null
-                );
-        } else {
-            if (scenario.getTestCaseByName(newName) != null) {
-                return null;
-            }
-        }
+    private TestCaseNode addTestCase(Scenario scenario, String name) {
+        String newName = NamingUtils.generateUniqueName(
+            name,
+            candidate -> scenario.getTestCaseByName(candidate) != null
+        );
         TestCase created = scenario.addTestCase(newName);
         if (created == null) {
             return null;

--- a/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/tree/ProjectTree.java
+++ b/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/tree/ProjectTree.java
@@ -46,7 +46,10 @@ import java.awt.event.MouseEvent;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -526,7 +529,7 @@ public class ProjectTree implements ActionListener {
             Notification.showWarning(
                 "Scenario '" +
                 scenarioName +
-                "' already exists in another scope (Test Plan, Reusable, or Shared Reusable)."
+                "' already exists in the Test Plan. Please choose a different Test Plan scenario name."
             );
             return;
         }
@@ -546,19 +549,46 @@ public class ProjectTree implements ActionListener {
      * @return unique scenario name
      */
     private String fetchNewScenarioName() {
-        String newScenarioName = "NewScenario";
-        for (int i = 0;; i++) {
-            // Check if scenario exists in any scope
+        String base = "NewScenario";
+        // prefer plain base name if available
+        if (
+            testDesign.getProject().getTestPlanScenarioByName(base) == null &&
+            !treeHasScenarioName(base)
+        ) {
+            return base;
+        }
+        int i = 0;
+        String newScenarioName;
+        for (;;) {
+            newScenarioName = base + i;
             if (
-                testDesign.getProject().getScenarioByName(newScenarioName) == null &&
-                testDesign.getProject().getReusableScenarioByName(newScenarioName) == null &&
-                testDesign.getProject().getSharedReusableScenarioByName(newScenarioName) == null
+                testDesign.getProject().getTestPlanScenarioByName(newScenarioName) == null &&
+                !treeHasScenarioName(newScenarioName)
             ) {
                 break;
             }
-            newScenarioName = "NewScenario" + i;
+            i++;
         }
         return newScenarioName;
+    }
+
+    private boolean treeHasScenarioName(String name) {
+        if (treeModel == null || treeModel.getRoot() == null) return false;
+        javax.swing.tree.TreeNode rootNode = (javax.swing.tree.TreeNode) treeModel.getRoot();
+        for (javax.swing.tree.TreeNode child : Collections.list(rootNode.children())) {
+            if (child instanceof GroupNode) {
+                for (ScenarioNode sc : ScenarioNode.toList(((GroupNode) child).children())) {
+                    if (sc.getScenario().getName().equalsIgnoreCase(name)) {
+                        return true;
+                    }
+                }
+            } else if (child instanceof ScenarioNode) {
+                if (((ScenarioNode) child).getScenario().getName().equalsIgnoreCase(name)) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 
     /**
@@ -573,14 +603,20 @@ public class ProjectTree implements ActionListener {
             }
         }
         if (scenarioNode != null) {
-            TestCase testcase;
             String testCaseName = fetchNewTestCaseName(scenarioNode.getScenario());
-            testcase = scenarioNode.getScenario().addTestCase(testCaseName);
+            TestCase testcase = scenarioNode.getScenario().addTestCase(testCaseName);
+            if (testcase == null) {
+                Notification.showWarning(
+                    "Failed to add test case: a test case with this name already exists."
+                );
+                return;
+            }
             testDesign.loadTableModelForSelection(testcase);
-            selectAndScrollTo(
-                new TreePath(treeModel.addTestCase(scenarioNode, testcase).getPath())
-            );
-            persistSortOrder(scenarioNode);
+            TestCaseNode tcNode = treeModel.addTestCase(scenarioNode, testcase);
+            if (tcNode != null && tcNode.getTestCase() != null) {
+                selectAndScrollTo(new TreePath(tcNode.getPath()));
+                persistSortOrder(scenarioNode);
+            }
         }
     }
 
@@ -592,7 +628,15 @@ public class ProjectTree implements ActionListener {
     private String fetchNewTestCaseName(Scenario scenario) {
         String newTestCaseName = "NewTestCase";
         for (int i = 0;; i++) {
-            if (scenario.getTestCaseByName(newTestCaseName) == null) {
+            if (
+                scenario.getTestCaseByName(newTestCaseName) == null &&
+                !getProject()
+                    .testCaseExistsForScenarioNameAcrossScopes(
+                        scenario.getName(),
+                        scenario,
+                        newTestCaseName
+                    )
+            ) {
                 break;
             }
             newTestCaseName = "NewTestCase" + i;
@@ -1429,6 +1473,9 @@ public class ProjectTree implements ActionListener {
             File scenarioDir = new File(scenarioNode.getScenario().getLocation());
             List<String> names = new ArrayList<>();
             for (TestCaseNode tcNode : TestCaseNode.toList(scenarioNode.children())) {
+                if (tcNode == null || tcNode.getTestCase() == null) {
+                    continue;
+                }
                 names.add(tcNode.getTestCase().getName());
             }
             SortOrderStore.save(scenarioDir, names);

--- a/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/tree/ProjectTree.java
+++ b/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/tree/ProjectTree.java
@@ -628,15 +628,7 @@ public class ProjectTree implements ActionListener {
     private String fetchNewTestCaseName(Scenario scenario) {
         String newTestCaseName = "NewTestCase";
         for (int i = 0;; i++) {
-            if (
-                scenario.getTestCaseByName(newTestCaseName) == null &&
-                !getProject()
-                    .testCaseExistsForScenarioNameAcrossScopes(
-                        scenario.getName(),
-                        scenario,
-                        newTestCaseName
-                    )
-            ) {
+            if (scenario.getTestCaseByName(newTestCaseName) == null) {
                 break;
             }
             newTestCaseName = "NewTestCase" + i;

--- a/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/tree/ReusableTree.java
+++ b/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/tree/ReusableTree.java
@@ -279,7 +279,7 @@ public class ReusableTree extends ProjectTree {
             Notification.showWarning(
                 "Scenario '" +
                 scenarioName +
-                "' already exists in another scope (Test Plan, Reusable, or Shared Reusable)."
+                "' already exists in Project Reusables. Please choose a different Project Reusable scenario name."
             );
             return;
         }
@@ -419,19 +419,36 @@ public class ReusableTree extends ProjectTree {
      * @return unique scenario name
      */
     private String fetchNewReusableScenarioName() {
-        String newScenarioName = "NewScenario";
-        for (int i = 0;; i++) {
-            // Check if scenario exists in Reusable scope
+        String base = "NewScenario";
+        // prefer plain base name if available (and not present in the tree)
+        if (getProject().getReusableScenarioByName(base) == null && !treeHasScenarioName(base)) {
+            return base;
+        }
+        int i = 0;
+        String newScenarioName;
+        for (;;) {
+            newScenarioName = base + i;
             if (
                 getProject().getReusableScenarioByName(newScenarioName) == null &&
-                getProject().getScenarioByName(newScenarioName) == null &&
-                getProject().getSharedReusableScenarioByName(newScenarioName) == null
+                !treeHasScenarioName(newScenarioName)
             ) {
                 break;
             }
-            newScenarioName = "NewScenario" + i;
+            i++;
         }
         return newScenarioName;
+    }
+
+    private boolean treeHasScenarioName(String name) {
+        if (getTreeModel() == null || getTreeModel().getRoot() == null) return false;
+        for (GroupNode group : GroupNode.toList(getTreeModel().getRoot().children())) {
+            for (ScenarioNode sc : ScenarioNode.toList(group.children())) {
+                if (sc.getScenario().getName().equalsIgnoreCase(name)) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 
     /**
@@ -442,7 +459,15 @@ public class ReusableTree extends ProjectTree {
     private String fetchNewReusableTestCaseName(Scenario scenario) {
         String newTestCaseName = "NewTestCase";
         for (int i = 0;; i++) {
-            if (scenario.getTestCaseByName(newTestCaseName) == null) {
+            if (
+                scenario.getTestCaseByName(newTestCaseName) == null &&
+                !getProject()
+                    .testCaseExistsForScenarioNameAcrossScopes(
+                        scenario.getName(),
+                        scenario,
+                        newTestCaseName
+                    )
+            ) {
                 break;
             }
             newTestCaseName = "NewTestCase" + i;

--- a/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/tree/ReusableTree.java
+++ b/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/tree/ReusableTree.java
@@ -459,15 +459,7 @@ public class ReusableTree extends ProjectTree {
     private String fetchNewReusableTestCaseName(Scenario scenario) {
         String newTestCaseName = "NewTestCase";
         for (int i = 0;; i++) {
-            if (
-                scenario.getTestCaseByName(newTestCaseName) == null &&
-                !getProject()
-                    .testCaseExistsForScenarioNameAcrossScopes(
-                        scenario.getName(),
-                        scenario,
-                        newTestCaseName
-                    )
-            ) {
+            if (scenario.getTestCaseByName(newTestCaseName) == null) {
                 break;
             }
             newTestCaseName = "NewTestCase" + i;

--- a/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/tree/SharedReusableTree.java
+++ b/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/tree/SharedReusableTree.java
@@ -1047,15 +1047,7 @@ public class SharedReusableTree extends ProjectTree {
     private String fetchNewSharedReusableTestCaseName(Scenario scenario) {
         String newTestCaseName = "NewSharedTestCase";
         for (int i = 0;; i++) {
-            if (
-                scenario.getTestCaseByName(newTestCaseName) == null &&
-                !getProject()
-                    .testCaseExistsForScenarioNameAcrossScopes(
-                        scenario.getName(),
-                        scenario,
-                        newTestCaseName
-                    )
-            ) {
+            if (scenario.getTestCaseByName(newTestCaseName) == null) {
                 break;
             }
             newTestCaseName = "NewSharedTestCase" + i;

--- a/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/tree/SharedReusableTree.java
+++ b/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/tree/SharedReusableTree.java
@@ -890,7 +890,7 @@ public class SharedReusableTree extends ProjectTree {
             Notification.showWarning(
                 "Scenario '" +
                 scenarioName +
-                "' already exists in another scope (Test Plan, Reusable, or Shared Reusable)."
+                "' already exists in Shared Reusables. Please choose a different Shared Reusable scenario name."
             );
             return;
         }
@@ -1005,19 +1005,38 @@ public class SharedReusableTree extends ProjectTree {
      * @return unique scenario name
      */
     private String fetchNewSharedReusableScenarioName() {
-        String newScenarioName = "NewSharedScenario";
-        for (int i = 0;; i++) {
-            // Check if scenario exists in any scope
+        String base = "NewSharedScenario";
+        // prefer plain base name if available (and not present in the tree)
+        if (
+            getProject().getSharedReusableScenarioByName(base) == null && !treeHasScenarioName(base)
+        ) {
+            return base;
+        }
+        int i = 0;
+        String newScenarioName;
+        for (;;) {
+            newScenarioName = base + i;
             if (
-                getProject().getScenarioByName(newScenarioName) == null &&
-                getProject().getReusableScenarioByName(newScenarioName) == null &&
-                getProject().getSharedReusableScenarioByName(newScenarioName) == null
+                getProject().getSharedReusableScenarioByName(newScenarioName) == null &&
+                !treeHasScenarioName(newScenarioName)
             ) {
                 break;
             }
-            newScenarioName = "NewSharedScenario" + i;
+            i++;
         }
         return newScenarioName;
+    }
+
+    private boolean treeHasScenarioName(String name) {
+        if (getTreeModel() == null || getTreeModel().getRoot() == null) return false;
+        for (GroupNode group : GroupNode.toList(getTreeModel().getRoot().children())) {
+            for (ScenarioNode sc : ScenarioNode.toList(group.children())) {
+                if (sc.getScenario().getName().equalsIgnoreCase(name)) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 
     /**
@@ -1028,7 +1047,15 @@ public class SharedReusableTree extends ProjectTree {
     private String fetchNewSharedReusableTestCaseName(Scenario scenario) {
         String newTestCaseName = "NewSharedTestCase";
         for (int i = 0;; i++) {
-            if (scenario.getTestCaseByName(newTestCaseName) == null) {
+            if (
+                scenario.getTestCaseByName(newTestCaseName) == null &&
+                !getProject()
+                    .testCaseExistsForScenarioNameAcrossScopes(
+                        scenario.getName(),
+                        scenario,
+                        newTestCaseName
+                    )
+            ) {
                 break;
             }
             newTestCaseName = "NewSharedTestCase" + i;

--- a/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/tree/model/GroupNode.java
+++ b/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/tree/model/GroupNode.java
@@ -60,7 +60,7 @@ public class GroupNode extends CommonNode {
         return false;
     }
 
-    public static List<GroupNode> toList(Enumeration<TreeNode> children) {
+    public static List<GroupNode> toList(Enumeration<? extends TreeNode> children) {
         return Collections
             .list(children)
             .stream()

--- a/IDE/src/main/java/com/ing/ide/main/utils/tree/CommonNode.java
+++ b/IDE/src/main/java/com/ing/ide/main/utils/tree/CommonNode.java
@@ -11,6 +11,11 @@ import javax.swing.tree.DefaultMutableTreeNode;
 public class CommonNode extends DefaultMutableTreeNode {
 
     public void sort() {
+        // Children is null if no children have been added yet
+        // (DefaultMutableTreeNode uses lazy initialization)
+        if (children == null) {
+            return;
+        }
         Collections.sort(
             children,
             new Comparator() {

--- a/TestData - Csv/src/main/java/com/ing/testdata/csv/CSVUtils.java
+++ b/TestData - Csv/src/main/java/com/ing/testdata/csv/CSVUtils.java
@@ -23,6 +23,14 @@ public class CSVUtils {
     public static void load(File location, AbstractDataModel sAbstractData) {
         CSVHParser parser = FileUtils.getCSVHParser(location);
         if (parser != null) {
+            // A file loaded under an older schema (e.g. test data predating the Scope
+            // column) still has its rows laid out in the old column order - splice in the
+            // missing value at the same index the column list was migrated at, or every
+            // value from that point on would silently be read as the wrong column.
+            boolean needsScopeSplice =
+                (sAbstractData instanceof TestDataModel) &&
+                ((TestDataModel) sAbstractData).isScopeColumnMigrated();
+
             for (CSVRecord crecord : parser.getRecords()) {
                 List<String> record = (List<String>) sAbstractData.getNewRecord();
                 for (int i = 0; i < crecord.size(); i++) {
@@ -33,6 +41,9 @@ public class CSVUtils {
                     } else {
                         record.add(val);
                     }
+                }
+                if (needsScopeSplice) {
+                    record.add(Math.min(2, record.size()), "");
                 }
                 sAbstractData.addRecord((List) record);
             }

--- a/TestData - Csv/src/main/java/com/ing/testdata/csv/CsvDataProvider.java
+++ b/TestData - Csv/src/main/java/com/ing/testdata/csv/CsvDataProvider.java
@@ -1,15 +1,18 @@
 package com.ing.testdata.csv;
 
 import com.ing.datalib.component.Project;
+import com.ing.datalib.component.Scenario;
 import com.ing.datalib.component.TestData;
 import com.ing.datalib.component.utils.FileUtils;
 import com.ing.datalib.testdata.DataProvider;
 import com.ing.datalib.testdata.model.Record;
 import java.io.File;
-import java.util.Objects;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 @DataProvider(type = "csv")
 public class CsvDataProvider extends TestData {
+    private static final Logger LOGGER = Logger.getLogger(CsvDataProvider.class.getName());
 
     public CsvDataProvider(Project sProject, String enviroment) {
         super(sProject, enviroment);
@@ -30,166 +33,144 @@ public class CsvDataProvider extends TestData {
                     CsvTestData csvData = new CsvTestData(tData.getAbsolutePath());
                     // ensure model is loaded so we can migrate records if the file lacks the Scope column
                     csvData.loadTableModel();
-                    // perform migration: ensure Scope column exists and populate based on prefixes or project reusables
-                    try {
-                        boolean modified = false;
-                        for (com.ing.datalib.testdata.model.Record record : csvData.getRecords()) {
-                            // If the CSV was using the older 4-column format (Scenario, Flow, Iteration, SubIteration),
-                            // the Scope column didn't exist. After loading, values will be at wrong indices:
-                            // Old: idx0=Scenario, idx1=Flow, idx2=Iteration, idx3=SubIteration, idx4+=DataColumns
-                            // New: idx0=Scenario, idx1=Flow, idx2=Scope, idx3=Iteration, idx4=SubIteration, idx5+=DataColumns
-                            // Detect old format by checking if index 2 is numeric (would be Iteration in old format)
-                            // AND index 3 is also numeric (would be SubIteration).
-                            // If index 2 has a Scope value like "[Project]" or "[Shared]", it's already new format.
-                            try {
-                                String idx2 = java.util.Objects.toString(record.get(2), "").trim();
-                                String idx3 = java.util.Objects.toString(record.get(3), "").trim();
-
-                                // Check if index 2 is numeric and index 3 is numeric - this indicates old 4-column format
-                                // Also verify idx2 is NOT a Scope marker like "[Project]" or "[Shared]"
-                                boolean idx2IsNumeric = idx2.matches("\\d+");
-                                boolean idx3IsNumeric = idx3.matches("\\d+");
-                                boolean idx2IsScopeMarker =
-                                    idx2.startsWith("[") && idx2.endsWith("]");
-
-                                if (idx2IsNumeric && idx3IsNumeric && !idx2IsScopeMarker) {
-                                    // Old format detected (Scenario, Flow, Iteration, SubIteration, Data...)
-                                    // Insert an empty Scope slot at index 2 which shifts Iteration/SubIteration/Data columns
-                                    // to their correct new positions: idx2=Scope, idx3=Iteration, idx4=SubIteration, idx5+=Data
-                                    try {
-                                        record.add(2, "");
-                                        modified = true;
-                                    } catch (Exception e) {
-                                        // if insertion fails for any reason, fall back to best-effort manual shift
-                                        try {
-                                            record.set(4, idx3);
-                                            record.set(3, idx2);
-                                            record.set(2, "");
-                                            modified = true;
-                                        } catch (Exception ex) {
-                                            // ignore - will be handled later
-                                        }
-                                    }
-                                }
-                            } catch (Exception ex) {
-                                // ignore index errors - record may not have enough elements
-                            }
-                            // ensure record has slots for all headers (Record constructor does this for new records)
-                            // get current scenario and testcase values
-                            String scenario = "";
-                            String testcase = "";
-                            try {
-                                scenario = java.util.Objects.toString(record.get(0), "").trim();
-                                testcase = java.util.Objects.toString(record.get(1), "").trim();
-                            } catch (Exception ex) {
-                                // ignore
-                            }
-                            String scope = "";
-                            String normalized = scenario;
-
-                            // First, check scenario for explicit scope markers
-                            if (normalized.startsWith("[Project] ")) {
-                                scope = "[Project]";
-                                normalized = normalized.substring("[Project] ".length());
-                            } else if (normalized.startsWith("[Shared] ")) {
-                                scope = "[Shared]";
-                                normalized = normalized.substring("[Shared] ".length());
-                            } else if (normalized.startsWith("[TestPlan] ")) {
-                                // Test plan scenario - scope should remain empty
-                                scope = "";
-                                normalized = normalized.substring("[TestPlan] ".length());
-                            } else {
-                                // try to match against project test plan or reusables if available
-                                try {
-                                    com.ing.datalib.component.Project proj = getsProject();
-                                    if (proj != null) {
-                                        // If it exists in the test plan scenarios, treat as TestPlan (scope empty)
-                                        if (proj.getScenarioByName(normalized) != null) {
-                                            scope = "";
-                                        } else if (
-                                            proj.getReusableScenarioByName(normalized) != null
-                                        ) {
-                                            scope = "[Project]";
-                                        } else if (
-                                            proj.getSharedReusableScenarioByName(normalized) != null
-                                        ) {
-                                            scope = "[Shared]";
-                                        }
-                                    }
-                                } catch (Exception ex) {
-                                    // project may not be fully initialized; ignore
-                                }
-                            }
-
-                            // If scope is still not determined, check the test case to infer scope
-                            if (scope == null || scope.isEmpty()) {
-                                try {
-                                    com.ing.datalib.component.Project proj = getsProject();
-                                    if (proj != null && !testcase.isEmpty()) {
-                                        // Check if the test case exists in project reusable scenarios
-                                        boolean foundInReusables = false;
-                                        for (com.ing.datalib.component.Scenario reusableScenario : proj.getReusableScenarios()) {
-                                            if (
-                                                reusableScenario.getTestCaseByName(testcase) != null
-                                            ) {
-                                                foundInReusables = true;
-                                                break;
-                                            }
-                                        }
-                                        if (foundInReusables) {
-                                            // Found in project reusables - set scope to [Project]
-                                            scope = "[Project]";
-                                        }
-                                        // If not found in project reusables, it's from test plan - scope remains empty
-                                    }
-                                } catch (Exception ex) {
-                                    // project may not be fully initialized; ignore
-                                }
-                            }
-
-                            // if scope determined or slot exists but empty, update record
-                            try {
-                                String existingScope = java.util.Objects.toString(
-                                    record.get(2),
-                                    ""
-                                );
-                                // If the scenario belongs to Test Plan, ensure Scope is empty and normalize
-                                if ((scope == null || scope.isEmpty())) {
-                                    // if existingScope is non-empty, clear it to reflect test plan ownership
-                                    if (existingScope != null && !existingScope.isEmpty()) {
-                                        record.set(2, "");
-                                        record.set(0, normalized);
-                                        modified = true;
-                                    } else if (
-                                        !Objects.toString(record.get(0), "").equals(normalized)
-                                    ) {
-                                        // normalization changed the scenario text
-                                        record.set(0, normalized);
-                                        modified = true;
-                                    }
-                                } else {
-                                    // For Project/Shared, set scope if different or missing
-                                    if (!scope.equals(existingScope)) {
-                                        record.set(2, scope);
-                                        record.set(0, normalized);
-                                        modified = true;
-                                    }
-                                }
-                            } catch (Exception ex) {
-                                // ignore out-of-bounds or other issues
-                            }
-                        }
-                        if (modified) {
-                            csvData.saveChanges();
-                        }
-                    } catch (Exception ex) {
-                        // ignore migration errors and continue loading
+                    // Scope is persisted, static data once written. Only a file whose Scope column was
+                    // just spliced in this load (legacy pre-Scope CSV) needs one-time population; a file
+                    // that already had the column keeps whatever values it already has, untouched.
+                    if (csvData.isScopeColumnMigrated()) {
+                        migrateLegacyRecords(csvData);
                     }
                     addTestData(csvData);
                 }
             }
         }
         loadGlobalData();
+    }
+
+    /**
+     * One-time, best-effort population of the Scope column for a file that predates it.
+     * Only runs for files where {@link CsvTestData#isScopeColumnMigrated()} is true this load.
+     */
+    private void migrateLegacyRecords(CsvTestData csvData) {
+        for (Record record : csvData.getRecords()) {
+            realignOldFourColumnRow(record);
+
+            String scenario = java.util.Objects.toString(record.get(0), "").trim();
+            String testcase = java.util.Objects.toString(record.get(1), "").trim();
+            String scope;
+            String normalized = scenario;
+
+            // First, check scenario for explicit scope markers carried over from legacy naming
+            if (normalized.startsWith("[Project] ")) {
+                scope = "[Project]";
+                normalized = normalized.substring("[Project] ".length());
+            } else if (normalized.startsWith("[Shared] ")) {
+                scope = "[Shared]";
+                normalized = normalized.substring("[Shared] ".length());
+            } else if (normalized.startsWith("[TestPlan] ")) {
+                scope = "";
+                normalized = normalized.substring("[TestPlan] ".length());
+            } else {
+                scope = resolveScopeByUniqueMatch(normalized, testcase);
+            }
+
+            if (scope == null) {
+                // Ambiguous: the same scenario+testcase combination exists in more than one scope
+                // (test plan / project reusable / shared reusable). Surface it instead of guessing;
+                // the structural column migration below is still persisted so this file isn't
+                // reprocessed as "legacy" forever - the user can set the correct scope explicitly
+                // by re-picking the scenario for this row.
+                LOGGER.log(
+                    Level.WARNING,
+                    "Cannot uniquely resolve Scope for Scenario=[{0}] TestCase=[{1}] in {2} - " +
+                    "found in multiple scopes. Leaving Scope unset; please set it explicitly.",
+                    new Object[] { normalized, testcase, csvData.getName() }
+                );
+                record.set(0, normalized);
+                continue;
+            }
+
+            record.set(2, scope);
+            record.set(0, normalized);
+        }
+        // The Scope column itself was just spliced into this file's structure (isScopeColumnMigrated()),
+        // so persist that structural change regardless of whether every row's value could be resolved.
+        csvData.saveChanges();
+    }
+
+    /**
+     * Detects and repairs the older 4-column layout (Scenario, Flow, Iteration, SubIteration) where the
+     * Scope column didn't exist, so Iteration/SubIteration/Data values are still at the pre-migration
+     * positions. Normally a no-op: {@code CSVUtils.load} already splices the Scope slot in for any
+     * file where {@code isScopeColumnMigrated()} is true, so this only matters as a defensive fallback.
+     */
+    private void realignOldFourColumnRow(Record record) {
+        try {
+            String idx2 = java.util.Objects.toString(record.get(2), "").trim();
+            String idx3 = java.util.Objects.toString(record.get(3), "").trim();
+
+            boolean idx2IsNumeric = idx2.matches("\\d+");
+            boolean idx3IsNumeric = idx3.matches("\\d+");
+            boolean idx2IsScopeMarker = idx2.startsWith("[") && idx2.endsWith("]");
+
+            if (idx2IsNumeric && idx3IsNumeric && !idx2IsScopeMarker) {
+                try {
+                    record.add(2, "");
+                    return;
+                } catch (Exception e) {
+                    try {
+                        record.set(4, idx3);
+                        record.set(3, idx2);
+                        record.set(2, "");
+                        return;
+                    } catch (Exception ex) {
+                        // ignore - will be handled later
+                    }
+                }
+            }
+        } catch (Exception ex) {
+            // ignore index errors - record may not have enough elements
+        }
+    }
+
+    /**
+     * Resolves scope by requiring an exact (scenario name + test case name) match in exactly one of
+     * Test Plan / Project Reusables / Shared Reusables. Returns "" for a unique Test Plan match,
+     * "[Project]"/"[Shared]" for a unique reusable match, or null if the match is ambiguous or absent.
+     */
+    private String resolveScopeByUniqueMatch(String scenarioName, String testCaseName) {
+        Project proj = getsProject();
+        if (proj == null || testCaseName.isEmpty()) {
+            return "";
+        }
+
+        boolean inTestPlan = hasTestCase(proj.getScenarioByName(scenarioName), testCaseName);
+        boolean inProjectReusable = hasTestCase(
+            proj.getReusableScenarioByName(scenarioName),
+            testCaseName
+        );
+        boolean inSharedReusable = hasTestCase(
+            proj.getSharedReusableScenarioByName(scenarioName),
+            testCaseName
+        );
+
+        int matchCount =
+            (inTestPlan ? 1 : 0) + (inProjectReusable ? 1 : 0) + (inSharedReusable ? 1 : 0);
+        if (matchCount != 1) {
+            // 0 matches: nothing found anywhere, default to Test Plan (its historical meaning).
+            // >1 match: same scenario+testcase name exists in multiple scopes - ambiguous.
+            return matchCount == 0 ? "" : null;
+        }
+        if (inProjectReusable) {
+            return "[Project]";
+        }
+        if (inSharedReusable) {
+            return "[Shared]";
+        }
+        return "";
+    }
+
+    private boolean hasTestCase(Scenario scenario, String testCaseName) {
+        return scenario != null && scenario.getTestCaseByName(testCaseName) != null;
     }
 
     private void loadGlobalData() {

--- a/TestData - Csv/src/test/java/com/ing/testdata/csv/CsvDataProviderTest.java
+++ b/TestData - Csv/src/test/java/com/ing/testdata/csv/CsvDataProviderTest.java
@@ -1,0 +1,157 @@
+package com.ing.testdata.csv;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+import com.ing.datalib.component.Project;
+import com.ing.datalib.component.Scenario;
+import com.ing.datalib.component.TestCase;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.List;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+/**
+ * Regression tests for Scope resolution on project (re)load, covering the reload bug where
+ * duplicate Scenario+TestCase names across Test Plan / Project Reusables / Shared Reusables
+ * caused the Scope column to be recomputed and overwritten on every load.
+ */
+public class CsvDataProviderTest {
+    private Path tempDir;
+    private Project project;
+
+    @BeforeMethod
+    public void setUp() throws IOException {
+        tempDir = Files.createTempDirectory("csv-data-provider-test");
+        project = mock(Project.class);
+        when(project.getLocation()).thenReturn(tempDir.toString());
+        when(project.getScenarioByName(anyString())).thenReturn(null);
+        when(project.getReusableScenarioByName(anyString())).thenReturn(null);
+        when(project.getSharedReusableScenarioByName(anyString())).thenReturn(null);
+    }
+
+    @AfterMethod
+    public void tearDown() throws IOException {
+        Files
+            .walk(tempDir)
+            .sorted(Comparator.reverseOrder())
+            .map(Path::toFile)
+            .forEach(File::delete);
+    }
+
+    private Scenario scenarioWithTestCase(String testCaseName) {
+        Scenario scenario = mock(Scenario.class);
+        TestCase testCase = mock(TestCase.class);
+        when(scenario.getTestCaseByName(testCaseName)).thenReturn(testCase);
+        return scenario;
+    }
+
+    private File testDataDir() {
+        File dir = new File(tempDir.toFile(), "TestData");
+        dir.mkdirs();
+        return dir;
+    }
+
+    private List<String> readLines(File csvFile) throws IOException {
+        return Files.readAllLines(csvFile.toPath());
+    }
+
+    @Test
+    public void reload_PreservesExistingScope_EvenWhenNameAlsoExistsInOtherScopes()
+        throws IOException {
+        // Same Scenario+TestCase name ("Login"/"Step1") exists in ALL THREE scopes - a genuine
+        // collision. Each row already has its own explicitly-set, distinct Scope value.
+        Scenario testPlanLogin = scenarioWithTestCase("Step1");
+        Scenario projectLogin = scenarioWithTestCase("Step1");
+        Scenario sharedLogin = scenarioWithTestCase("Step1");
+        when(project.getScenarioByName("Login")).thenReturn(testPlanLogin);
+        when(project.getReusableScenarioByName("Login")).thenReturn(projectLogin);
+        when(project.getSharedReusableScenarioByName("Login")).thenReturn(sharedLogin);
+
+        File csvFile = new File(testDataDir(), "LoginData.csv");
+        try (FileWriter fw = new FileWriter(csvFile)) {
+            fw.write("Scenario,Flow,Scope,Iteration,SubIteration,User\n");
+            fw.write("Login,Step1,,1,1,testplan-user\n");
+            fw.write("Login,Step1,[Project],1,1,project-user\n");
+            fw.write("Login,Step1,[Shared],1,1,shared-user\n");
+        }
+
+        CsvDataProvider provider = new CsvDataProvider(project, "Default");
+        provider.load();
+        provider.load(); // second reload - simulates closing and reopening the project again
+
+        List<String> lines = readLines(csvFile);
+        assertThat(lines.get(1)).startsWith("Login,Step1,,1,1,testplan-user");
+        assertThat(lines.get(2)).startsWith("Login,Step1,[Project],1,1,project-user");
+        assertThat(lines.get(3)).startsWith("Login,Step1,[Shared],1,1,shared-user");
+    }
+
+    @Test
+    public void reload_UniqueNames_AreUnaffected() throws IOException {
+        Scenario checkout = scenarioWithTestCase("Pay");
+        when(project.getScenarioByName("Checkout")).thenReturn(checkout);
+
+        File csvFile = new File(testDataDir(), "CheckoutData.csv");
+        try (FileWriter fw = new FileWriter(csvFile)) {
+            fw.write("Scenario,Flow,Scope,Iteration,SubIteration,Amount\n");
+            fw.write("Checkout,Pay,,1,1,100\n");
+        }
+
+        CsvDataProvider provider = new CsvDataProvider(project, "Default");
+        provider.load();
+
+        List<String> lines = readLines(csvFile);
+        assertThat(lines.get(1)).startsWith("Checkout,Pay,,1,1,100");
+    }
+
+    @Test
+    public void legacyFile_UniqueMatch_AutoPopulatesScopeOnFirstLoad() throws IOException {
+        // Old 4-column format (no Scope column at all) - genuinely unmigrated data.
+        // "Login"/"Step1" exists ONLY in Shared Reusables, so the match is unambiguous.
+        Scenario sharedLogin = scenarioWithTestCase("Step1");
+        when(project.getSharedReusableScenarioByName("Login")).thenReturn(sharedLogin);
+
+        File csvFile = new File(testDataDir(), "LegacyLoginData.csv");
+        try (FileWriter fw = new FileWriter(csvFile)) {
+            fw.write("Scenario,Flow,Iteration,SubIteration,User\n");
+            fw.write("Login,Step1,1,1,shared-user\n");
+        }
+
+        CsvDataProvider provider = new CsvDataProvider(project, "Default");
+        provider.load();
+
+        List<String> lines = readLines(csvFile);
+        assertThat(lines.get(0)).isEqualTo("Scenario,Flow,Scope,Iteration,SubIteration,User");
+        assertThat(lines.get(1)).isEqualTo("Login,Step1,[Shared],1,1,shared-user");
+    }
+
+    @Test
+    public void legacyFile_AmbiguousMatch_LeavesScopeUnsetInsteadOfDefaultingToProject()
+        throws IOException {
+        // Old 4-column format. "Login"/"Step1" collides across Project AND Shared Reusables -
+        // genuinely ambiguous, must NOT silently default to "[Project]".
+        Scenario projectLogin = scenarioWithTestCase("Step1");
+        Scenario sharedLogin = scenarioWithTestCase("Step1");
+        when(project.getReusableScenarioByName("Login")).thenReturn(projectLogin);
+        when(project.getSharedReusableScenarioByName("Login")).thenReturn(sharedLogin);
+
+        File csvFile = new File(testDataDir(), "AmbiguousLoginData.csv");
+        try (FileWriter fw = new FileWriter(csvFile)) {
+            fw.write("Scenario,Flow,Iteration,SubIteration,User\n");
+            fw.write("Login,Step1,1,1,some-user\n");
+        }
+
+        CsvDataProvider provider = new CsvDataProvider(project, "Default");
+        provider.load();
+
+        List<String> lines = readLines(csvFile);
+        assertThat(lines.get(0)).isEqualTo("Scenario,Flow,Scope,Iteration,SubIteration,User");
+        assertThat(lines.get(1)).isEqualTo("Login,Step1,,1,1,some-user");
+    }
+}

--- a/TestData - Csv/src/test/java/com/ing/testdata/csv/CsvTestDataTest.java
+++ b/TestData - Csv/src/test/java/com/ing/testdata/csv/CsvTestDataTest.java
@@ -136,6 +136,38 @@ public class CsvTestDataTest {
         assertThat(td.getNewRecord()).isNotNull().isEmpty();
     }
 
+    /**
+     * Regression test for scope-aware iteration lookups: the same Scenario/TestCase/Iteration
+     * combination can exist in two different reusable scopes with different sub-iteration
+     * data, and {@code withIterAndScope} must only return the sub-iterations for the
+     * requested scope rather than merging or matching whichever scope happens to come first.
+     */
+    @Test
+    public void testWithIterAndScopeDisambiguatesSameNameAcrossScopes() throws IOException {
+        File csvFile = tempDir.resolve("ScopedIter.csv").toFile();
+        try (FileWriter fw = new FileWriter(csvFile)) {
+            fw.write("Scenario,Flow,Scope,Iteration,SubIteration,CustomerID\n");
+            fw.write("Login,Step1,[Project],1,1,proj-cust-1\n");
+            fw.write("Login,Step1,[Project],1,2,proj-cust-2\n");
+            fw.write("Login,Step1,[Shared],1,1,shared-cust-1\n");
+        }
+
+        CsvTestData td = new CsvTestData(csvFile.getAbsolutePath());
+        td.loadRecords(csvFile);
+
+        Set<String> projectSubIters = td
+            .view()
+            .withIterAndScope("Login", "Step1", "1", "[Project]")
+            .getSubIterations();
+        assertThat(projectSubIters).containsExactlyInAnyOrder("1", "2");
+
+        Set<String> sharedSubIters = td
+            .view()
+            .withIterAndScope("Login", "Step1", "1", "[Shared]")
+            .getSubIterations();
+        assertThat(sharedSubIters).containsExactly("1");
+    }
+
     @Test
     public void testSaveChanges() throws IOException {
         File csvFile = tempDir.resolve("save.csv").toFile();

--- a/TestData - Csv/src/test/java/com/ing/testdata/csv/ProjectTestDataScopeConversionTest.java
+++ b/TestData - Csv/src/test/java/com/ing/testdata/csv/ProjectTestDataScopeConversionTest.java
@@ -1,0 +1,171 @@
+package com.ing.testdata.csv;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.ing.datalib.component.Project;
+import com.ing.datalib.component.Scenario;
+import com.ing.datalib.component.TestCase;
+import com.ing.datalib.testdata.TestDataFactory;
+import com.ing.datalib.testdata.model.Record;
+import com.ing.datalib.testdata.model.TestDataModel;
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Comparator;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+/**
+ * Regression tests for Part 2 of the Scope bug: converting a test case between Test Plan,
+ * Project Reusables, and Shared Reusables must explicitly update the Scope of the matching
+ * Test Data entry as part of the conversion itself, and must correctly disambiguate when the
+ * same scenario+testcase name collides across scopes.
+ */
+public class ProjectTestDataScopeConversionTest {
+    private Path tempDir;
+    private String originalUserDir;
+    private Project project;
+    private TestDataModel dataModel;
+
+    @BeforeMethod
+    public void setUp() throws Exception {
+        // Must run before the first Project is ever constructed in this JVM - Project's
+        // EnvTestData looks up the "csv" provider via TestDataFactory, which only registers it
+        // once this classpath scan has run (normally done once at app startup, e.g. IDE Main).
+        TestDataFactory.load();
+
+        tempDir = Files.createTempDirectory("project-scope-conversion-test");
+        // Shared Reusables live at an app-root "Shared" folder resolved from user.dir - isolate it
+        // under the temp dir for this test so we never touch the real repo checkout.
+        originalUserDir = System.getProperty("user.dir");
+        System.setProperty("user.dir", tempDir.toString());
+
+        project = new Project(tempDir.resolve("SampleProject").toString(), "csv").createProject();
+        dataModel = project.getTestData().defData().addTestData();
+    }
+
+    @AfterMethod
+    public void tearDown() throws Exception {
+        System.setProperty("user.dir", originalUserDir);
+        Files
+            .walk(tempDir)
+            .sorted(Comparator.reverseOrder())
+            .map(Path::toFile)
+            .forEach(File::delete);
+    }
+
+    private Record addDataRow(String scenario, String testcase, String scope) {
+        Record record = dataModel.addRecord();
+        record.setScenario(scenario);
+        record.setTestcase(testcase);
+        record.setScope(scope);
+        return record;
+    }
+
+    private String scopeOf(String scenario, String testcase) {
+        for (Record record : dataModel.getRecords()) {
+            if (record.getScenario().equals(scenario) && record.getTestcase().equals(testcase)) {
+                return record.getScope();
+            }
+        }
+        throw new AssertionError("No Test Data row found for " + scenario + "/" + testcase);
+    }
+
+    @Test
+    public void moveTestPlanToProjectReusable_UpdatesScope() throws Exception {
+        Scenario scenario = project.addScenario("Login");
+        TestCase testCase = scenario.addTestCase("Step1");
+        addDataRow("Login", "Step1", "");
+
+        project.moveTestCaseToReusable(testCase);
+
+        assertThat(scopeOf("Login", "Step1")).isEqualTo("[Project]");
+    }
+
+    @Test
+    public void moveProjectReusableToTestPlan_UpdatesScope() throws Exception {
+        Scenario scenario = project.addReusableScenario("Login");
+        TestCase testCase = scenario.addTestCase("Step1");
+        addDataRow("Login", "Step1", "[Project]");
+
+        project.moveTestCaseToTestPlan(testCase);
+
+        assertThat(scopeOf("Login", "Step1")).isEqualTo("");
+    }
+
+    @Test
+    public void moveProjectReusableToSharedReusable_UpdatesScope() throws Exception {
+        Scenario scenario = project.addReusableScenario("Login");
+        TestCase testCase = scenario.addTestCase("Step1");
+        addDataRow("Login", "Step1", "[Project]");
+
+        project.moveTestCaseToSharedReusable(testCase);
+
+        assertThat(scopeOf("Login", "Step1")).isEqualTo("[Shared]");
+    }
+
+    @Test
+    public void moveSharedReusableToProjectReusable_UpdatesScope() throws Exception {
+        Scenario scenario = project.addSharedReusableScenario("Login");
+        TestCase testCase = scenario.addTestCase("Step1");
+        addDataRow("Login", "Step1", "[Shared]");
+
+        project.moveSharedReusableToReusable(testCase);
+
+        assertThat(scopeOf("Login", "Step1")).isEqualTo("[Project]");
+    }
+
+    @Test
+    public void moveSharedReusableToTestPlan_UpdatesScope() throws Exception {
+        Scenario scenario = project.addSharedReusableScenario("Login");
+        TestCase testCase = scenario.addTestCase("Step1");
+        addDataRow("Login", "Step1", "[Shared]");
+
+        project.moveTestCaseToTestPlan(testCase);
+
+        assertThat(scopeOf("Login", "Step1")).isEqualTo("");
+    }
+
+    @Test
+    public void copyProjectReusableToSharedReusable_DoesNotTouchScope() throws Exception {
+        Scenario scenario = project.addReusableScenario("Login");
+        TestCase testCase = scenario.addTestCase("Step1");
+        addDataRow("Login", "Step1", "[Project]");
+
+        project.copyTestCaseToSharedReusable(testCase);
+
+        // Copy leaves the source test case (and its Test Data entry) exactly where it was.
+        assertThat(scopeOf("Login", "Step1")).isEqualTo("[Project]");
+    }
+
+    @Test
+    public void moveUpdatesOnlyTheCollidingEntryThatActuallyConverted() throws Exception {
+        // Same Scenario+TestCase name ("Login"/"Step1") exists in BOTH Test Plan and Shared
+        // Reusables already - a genuine name collision across scopes. Only the Test Plan
+        // entry should have its Scope updated when the Test Plan test case is converted;
+        // the colliding Shared entry, already correctly scoped, must be left untouched.
+        Scenario testPlanScenario = project.addScenario("Login");
+        TestCase testPlanTestCase = testPlanScenario.addTestCase("Step1");
+        project.addSharedReusableScenario("Login").addTestCase("Step1");
+
+        Record testPlanRow = dataModel.addRecord();
+        testPlanRow.setScenario("Login");
+        testPlanRow.setTestcase("Step1");
+        testPlanRow.setScope("");
+
+        Record sharedRow = dataModel.addRecord();
+        sharedRow.setScenario("Login");
+        sharedRow.setTestcase("Step1");
+        sharedRow.setScope("[Shared]");
+
+        project.moveTestCaseToReusable(testPlanTestCase);
+
+        assertThat(dataModel.getRecords().get(0).getScope())
+            .as("The converted Test Plan entry must now be scoped to Project")
+            .isEqualTo("[Project]");
+        assertThat(dataModel.getRecords().get(1).getScope())
+            .as("The colliding Shared entry must be left untouched")
+            .isEqualTo("[Shared]");
+    }
+}


### PR DESCRIPTION
- Fix Test Data reference when used in Reusable Components and Param Loop
- Allow reuse of deleted scenarios in Project Reusable Components when "Make As TestCase"