### PR TITLE
Maximize use of Web OR Properties Panel width

### DIFF
--- a/IDE/src/main/java/com/ing/ide/main/mainui/AppMainFrame.java
+++ b/IDE/src/main/java/com/ing/ide/main/mainui/AppMainFrame.java
@@ -99,6 +99,10 @@ public class AppMainFrame extends JFrame {
 
     private final StepMap stepMap;
 
+    private JPanel leftFiller;
+
+    private JPanel rightFiller;
+
     private Project sProject;
 
     private final LoaderScreen loader;
@@ -170,9 +174,12 @@ public class AppMainFrame extends JFrame {
         slideShow.addSlide("AICopilot", aiCopilot.getAICopilotUI());
         slideShow.addSlideChangeListener(aiCopilot);
         progressed(85);
+        leftFiller = simpleFiller();
+        rightFiller = simpleRightFiller();
         add(slideShow, BorderLayout.CENTER);
         add(toolBar, BorderLayout.NORTH);
-        add(simpleFiller(), BorderLayout.WEST);
+        add(leftFiller, BorderLayout.WEST);
+        add(rightFiller, BorderLayout.EAST);
         dashBoard.load();
         loader.setFrame(this);
         addWindowListener(
@@ -266,6 +273,30 @@ public class AppMainFrame extends JFrame {
             }
         );
         return filler;
+    }
+
+    private JPanel simpleRightFiller() {
+        JPanel filler = new JPanel();
+        filler.setPreferredSize(new java.awt.Dimension(4, 0));
+        filler.setOpaque(true);
+        if (com.ing.ide.main.Main.isDarkMode()) {
+            filler.setBackground(new java.awt.Color(50, 52, 55));
+        } else {
+            filler.setBackground(UIManager.getColor("Panel.background"));
+        }
+        return filler;
+    }
+
+    private void updateFillersTheme() {
+        java.awt.Color bg = com.ing.ide.main.Main.isDarkMode()
+            ? new java.awt.Color(50, 52, 55)
+            : UIManager.getColor("Panel.background");
+        if (leftFiller != null) {
+            leftFiller.setBackground(bg);
+        }
+        if (rightFiller != null) {
+            rightFiller.setBackground(bg);
+        }
     }
 
     /**
@@ -901,6 +932,7 @@ public class AppMainFrame extends JFrame {
     }
 
     public void adjustUI() {
+        updateFillersTheme();
         testDesign.getTestDesignUI().adjustUI();
         testExecution.getTestExecutionUI().adjustUI();
     }

--- a/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/TestDesignUI.java
+++ b/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/TestDesignUI.java
@@ -95,7 +95,7 @@ public class TestDesignUI extends JPanel {
 
         oneThree = new JSplitPane();
         oneThree.setOneTouchExpandable(true);
-        oneThree.setResizeWeight(0.8);
+        oneThree.setResizeWeight(0.70);
 
         oneThree.setLeftComponent(oneTwo);
         oneThree.setRightComponent(testDesign.getObjectRepo());
@@ -312,7 +312,7 @@ public class TestDesignUI extends JPanel {
 
     public void adjustUI() {
         oneTwo.setDividerLocation(0.25);
-        oneThree.setDividerLocation(0.8);
+        oneThree.setDividerLocation(0.70);
         oneTwo.setDividerLocation(0.25);
         projectNReusableTreeSplitPane.setDividerLocation(0.5);
         testCaseNTestDataSplitPane.setDividerLocation(0.5);

--- a/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/or/ObjectRepo.java
+++ b/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/or/ObjectRepo.java
@@ -267,6 +267,13 @@ public class ObjectRepo extends JPanel implements ItemListener {
 
             add(structuredDataButton = create("Structured Data", "or.StructuredData"));
             add(sapButton = create("SAP", "or.SAP"));
+            add(
+                new javax.swing.Box.Filler(
+                    new java.awt.Dimension(6, 0),
+                    new java.awt.Dimension(6, 0),
+                    new java.awt.Dimension(6, 32767)
+                )
+            );
         }
 
         private JToggleButton create(String text, String iconKey) {

--- a/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/or/mobile/MobileORTable.java
+++ b/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/or/mobile/MobileORTable.java
@@ -513,6 +513,13 @@ public class MobileORTable extends JPanel implements ActionListener {
             addSeparator();
             add(Utils.createButton("Move Rows Up", "up", "Ctrl+Up", MobileORTable.this));
             add(Utils.createButton("Move Rows Down", "down", "Ctrl+Down", MobileORTable.this));
+            add(
+                new javax.swing.Box.Filler(
+                    new java.awt.Dimension(6, 0),
+                    new java.awt.Dimension(6, 0),
+                    new java.awt.Dimension(6, 32767)
+                )
+            );
         }
 
         public void setTitleSuffix(String suffix) {

--- a/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/or/sap/SapORTable.java
+++ b/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/or/sap/SapORTable.java
@@ -419,6 +419,13 @@ public class SapORTable extends JPanel implements ActionListener {
             addSeparator();
             add(Utils.createButton("Move Rows Up", "up", "Ctrl+Up", SapORTable.this));
             add(Utils.createButton("Move Rows Down", "down", "Ctrl+Down", SapORTable.this));
+            add(
+                new javax.swing.Box.Filler(
+                    new java.awt.Dimension(6, 0),
+                    new java.awt.Dimension(6, 0),
+                    new java.awt.Dimension(6, 32767)
+                )
+            );
         }
     }
 

--- a/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/or/structureddata/StructuredDataORTable.java
+++ b/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/or/structureddata/StructuredDataORTable.java
@@ -495,6 +495,13 @@ public class StructuredDataORTable extends JPanel implements ActionListener {
                     StructuredDataORTable.this
                 )
             );
+            add(
+                new javax.swing.Box.Filler(
+                    new java.awt.Dimension(6, 0),
+                    new java.awt.Dimension(6, 0),
+                    new java.awt.Dimension(6, 32767)
+                )
+            );
         }
 
         public void setTitleSuffix(String suffix) {

--- a/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/or/web/WebORPanel.java
+++ b/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/or/web/WebORPanel.java
@@ -1,21 +1,17 @@
 package com.ing.ide.main.mainui.components.testdesign.or.web;
 
 import com.ing.datalib.component.Project;
-import com.ing.datalib.or.common.ORObjectInf;
 import com.ing.datalib.or.common.ObjectGroup;
 import com.ing.datalib.or.web.WebORObject;
 import com.ing.ide.main.mainui.components.testdesign.TestDesign;
 import com.ing.ide.main.mainui.components.testdesign.or.web.WebObjectTree.ORSource;
 import com.ing.ide.main.utils.tree.TreeSearch;
 import java.awt.BorderLayout;
-import java.awt.Toolkit;
-import java.awt.event.KeyEvent;
 import java.util.List;
 import javax.swing.JComponent;
 import javax.swing.JPanel;
 import javax.swing.JSplitPane;
 import javax.swing.JTabbedPane;
-import javax.swing.KeyStroke;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 import javax.swing.tree.TreePath;
@@ -186,6 +182,7 @@ public class WebORPanel extends JPanel {
         } else {
             splitPane.setDividerLocation(0.5);
         }
+        objectTable.adjustColumnsToViewport();
     }
 
     public Boolean navigateToObject(String objectName, String pageName) {

--- a/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/or/web/WebORTable.java
+++ b/IDE/src/main/java/com/ing/ide/main/mainui/components/testdesign/or/web/WebORTable.java
@@ -14,7 +14,10 @@ import com.ing.ide.main.utils.table.XTable;
 import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Component;
+import java.awt.Cursor;
 import java.awt.Font;
+import java.awt.Point;
+import java.awt.Rectangle;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.ComponentAdapter;
@@ -41,6 +44,7 @@ import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
 import javax.swing.table.DefaultTableCellRenderer;
 import javax.swing.table.DefaultTableModel;
+import javax.swing.table.JTableHeader;
 import javax.swing.table.TableCellEditor;
 import javax.swing.table.TableColumn;
 import javax.swing.table.TableColumnModel;
@@ -82,6 +86,7 @@ public class WebORTable extends JPanel implements ActionListener, ItemListener {
         roleCellEditor = new RoleCellEditor();
 
         // Create custom XTable that returns role editor for Role attribute
+        // and restricts header divider dragging to only between Attribute and Value columns
         table =
             new XTable() {
 
@@ -95,6 +100,45 @@ public class WebORTable extends JPanel implements ActionListener, ItemListener {
                         }
                     }
                     return super.getCellEditor(row, column);
+                }
+
+                @Override
+                protected JTableHeader createDefaultTableHeader() {
+                    return new JTableHeader(columnModel) {
+
+                        @Override
+                        public void setResizingColumn(TableColumn resizingColumn) {
+                            // Only column 0 (Attribute) can be resized by dragging header dividers
+                            if (
+                                resizingColumn != null &&
+                                (
+                                    getColumnModel().getColumnCount() < 1 ||
+                                    resizingColumn != getColumnModel().getColumn(0)
+                                )
+                            ) {
+                                return;
+                            }
+                            super.setResizingColumn(resizingColumn);
+                        }
+
+                        @Override
+                        public void setCursor(Cursor cursor) {
+                            if (cursor != null && cursor.getType() == Cursor.E_RESIZE_CURSOR) {
+                                if (getResizingColumn() == null) {
+                                    Point p = getMousePosition();
+                                    if (p != null && getColumnModel().getColumnCount() > 0) {
+                                        Rectangle r0 = getHeaderRect(0);
+                                        int boundary = r0.x + r0.width;
+                                        if (Math.abs(p.x - boundary) > 6) {
+                                            super.setCursor(Cursor.getDefaultCursor());
+                                            return;
+                                        }
+                                    }
+                                }
+                            }
+                            super.setCursor(cursor);
+                        }
+                    };
                 }
             };
         frameToolbar = new FrameToolBar();
@@ -112,6 +156,16 @@ public class WebORTable extends JPanel implements ActionListener, ItemListener {
         add(panel, BorderLayout.CENTER);
         add(toolBar, BorderLayout.NORTH);
         table.setComponentPopupMenu(popupMenu);
+
+        table.addComponentListener(
+            new ComponentAdapter() {
+
+                @Override
+                public void componentResized(ComponentEvent e) {
+                    adjustColumnsToViewport();
+                }
+            }
+        );
 
         ORTableInsertRowPrompt.install(
             table,
@@ -143,26 +197,27 @@ public class WebORTable extends JPanel implements ActionListener, ItemListener {
 
     private void configureColumns() {
         if (table.getColumnCount() >= 3) {
-            table.setAutoResizeMode(JTable.AUTO_RESIZE_LAST_COLUMN);
+            table.setAutoResizeMode(JTable.AUTO_RESIZE_SUBSEQUENT_COLUMNS);
 
-            // Column 0: Attribute - narrow width
-            TableColumn attrCol = table.getColumnModel().getColumn(0);
+            TableColumnModel columnModel = table.getColumnModel();
+
+            // Column 0: Attribute - resizable by user
+            TableColumn attrCol = columnModel.getColumn(0);
             attrCol.setCellRenderer(new PropertyAttributeRenderer());
-            attrCol.setPreferredWidth(100);
             attrCol.setMinWidth(60);
-            attrCol.setMaxWidth(150);
+            attrCol.setPreferredWidth(120);
 
             // Column 1: Value - takes remaining space (flexible)
-            TableColumn valueCol = table.getColumnModel().getColumn(1);
-            valueCol.setPreferredWidth(150);
+            TableColumn valueCol = columnModel.getColumn(1);
             valueCol.setMinWidth(50);
-            valueCol.setMaxWidth(350);
+            valueCol.setPreferredWidth(300);
 
-            // Column 2: Exact - fixed width, centered
-            TableColumn exactCol = table.getColumnModel().getColumn(2);
-            exactCol.setPreferredWidth(50);
+            // Column 2: Exact - fixed width, non-resizable, centered on the far right
+            TableColumn exactCol = columnModel.getColumn(2);
             exactCol.setMinWidth(50);
             exactCol.setMaxWidth(50);
+            exactCol.setPreferredWidth(50);
+            exactCol.setWidth(50);
             exactCol.setResizable(false);
 
             // Center-aligned header for Exact column
@@ -617,15 +672,6 @@ public class WebORTable extends JPanel implements ActionListener, ItemListener {
                     table.requestFocusInWindow();
                 }
             );
-            table.addComponentListener(
-                new ComponentAdapter() {
-
-                    @Override
-                    public void componentResized(ComponentEvent e) {
-                        adjustColumnsToViewport();
-                    }
-                }
-            );
         }
 
         @Override
@@ -647,7 +693,7 @@ public class WebORTable extends JPanel implements ActionListener, ItemListener {
         }
     }
 
-    private void adjustColumnsToViewport() {
+    public void adjustColumnsToViewport() {
         if (table.getColumnCount() < 3) return;
 
         TableColumnModel m = table.getColumnModel();
@@ -656,23 +702,37 @@ public class WebORTable extends JPanel implements ActionListener, ItemListener {
         TableColumn value = m.getColumn(1);
         TableColumn exact = m.getColumn(2);
 
-        int exactWidth = exact.getMinWidth();
-        int attrMin = attr.getMinWidth();
-        int valueMin = value.getMinWidth();
+        int exactWidth = 50;
+        exact.setMinWidth(exactWidth);
+        exact.setMaxWidth(exactWidth);
+        exact.setPreferredWidth(exactWidth);
+        exact.setWidth(exactWidth);
+        exact.setResizable(false);
 
-        int viewportWidth = table.getParent().getWidth();
+        int viewportWidth = table.getParent() != null
+            ? table.getParent().getWidth()
+            : table.getWidth();
+        if (viewportWidth <= 0) return;
+
         int available = viewportWidth - exactWidth;
+        if (available <= 0) return;
 
-        if (available > (attrMin + valueMin)) {
-            int attrWidth = Math.min(150, available / 3);
-            int valueWidth = available - attrWidth;
-
-            attr.setPreferredWidth(attrWidth);
-            value.setPreferredWidth(valueWidth);
+        int attrWidth = attr.getWidth();
+        if (attrWidth <= 0 || attrWidth < attr.getMinWidth()) {
+            attrWidth = Math.max(attr.getMinWidth(), Math.min(140, available / 3));
         } else {
-            attr.setPreferredWidth(attrMin);
-            value.setPreferredWidth(Math.max(0, available - attrMin));
+            attrWidth =
+                Math.max(attr.getMinWidth(), Math.min(available - value.getMinWidth(), attrWidth));
         }
+        int valueWidth = Math.max(value.getMinWidth(), available - attrWidth);
+
+        attr.setPreferredWidth(attrWidth);
+        attr.setWidth(attrWidth);
+
+        value.setPreferredWidth(valueWidth);
+        value.setWidth(valueWidth);
+
+        table.doLayout();
     }
 
     class ToolBar extends JToolBar {
@@ -724,6 +784,13 @@ public class WebORTable extends JPanel implements ActionListener, ItemListener {
             frameToggle.setToolTipText("Show/Hide Frame Property");
             frameToggle.setActionCommand("Toggle Frame");
             add(frameToggle);
+            add(
+                new javax.swing.Box.Filler(
+                    new java.awt.Dimension(6, 0),
+                    new java.awt.Dimension(6, 0),
+                    new java.awt.Dimension(6, 32767)
+                )
+            );
         }
 
         public void setTitleSuffix(String suffix) {


### PR DESCRIPTION
- Ensure Web OR Properties table columns fill panel width and set the Exact column at the rightmost
- Add empty space at the rightmost edge of the Test Design window